### PR TITLE
Don't free scaled images if they are in the scrollback. Fixes #213.

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -700,6 +700,8 @@ picture_t *gli_picture_load(unsigned long id);
 void gli_picture_store(picture_t *pic);
 picture_t *gli_picture_retrieve(unsigned long id, int scaled);
 picture_t *gli_picture_scale(picture_t *src, int destwidth, int destheight);
+void gli_picture_increment(picture_t *pic);
+void gli_picture_decrement(picture_t *pic);
 void gli_piclist_increment(void);
 void gli_piclist_decrement(void);
 

--- a/garglk/imgload.c
+++ b/garglk/imgload.c
@@ -74,8 +74,8 @@ void gli_piclist_clear(void)
         tmpptr = picptr;
         picptr = picptr->next;
 
-        gli_picture_discard(tmpptr->picture);
-        gli_picture_discard(tmpptr->scaled);
+        gli_picture_decrement(tmpptr->picture);
+        gli_picture_decrement(tmpptr->scaled);
 
         free(tmpptr);
     }
@@ -92,6 +92,19 @@ void gli_piclist_decrement(void)
 {
     if (gli_piclist_refcount > 0 && --gli_piclist_refcount == 0)
         gli_piclist_clear();
+}
+
+void gli_picture_increment(picture_t *pic)
+{
+    pic->refcount++;
+}
+
+void gli_picture_decrement(picture_t *pic)
+{
+    piclist_t *picptr;
+
+    if (pic->refcount > 0 && --pic->refcount == 0)
+        gli_picture_discard(pic);
 }
 
 void gli_picture_store_original(picture_t *pic)
@@ -127,7 +140,7 @@ void gli_picture_store_scaled(picture_t *pic)
         return;
 
     if (picptr->scaled)
-        gli_picture_discard(picptr->scaled);
+        gli_picture_decrement(picptr->scaled);
 
     picptr->scaled = pic;
 }


### PR DESCRIPTION
When an image is rescaled, the previous scaled image was freed, even if it was still in the scrollback.
Instead of freeing it, we decrease a refcount.

Haven't tested it yet, to see if images are refcounted and freed correctly.