### PR TITLE
automated testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /*.exe
 bldgarglk
 runzork
+runtrinity

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /build
 /*.zip
 /*.exe
+bldgarglk
+runzork

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 bldgarglk
 runzork
 runtrinity
+test.cmd
+test.out
+test.exp

--- a/garglk/garglktst.c
+++ b/garglk/garglktst.c
@@ -1,0 +1,63 @@
+// gargoyle automated testing code
+// (only in debug build)
+#include "garglktst.h"
+struct garglktstctx garglktstctx={0};
+static FILE* garglktst_checked_fopen(char const *fname, const char *mode){
+	FILE *f;
+	if(fname){
+		f=fopen(fname, mode);
+		if(NULL==f){
+			fprintf(stderr, "cannot open file (mode=%s): %s\n", mode, fname);
+			exit(1);
+			}
+		return f;
+		}
+	return NULL;
+	}
+static int garglktst_init_and_stripargv(int ac, char ***pav){
+	int n,i;
+	char ch;
+	char **av=*pav;
+	for(n=1; 0==strncmp("-grg", av[n], sizeof("-grg")-1); n++){
+		switch((ch=av[n][4])){
+			default:
+				fprintf(stderr, "unknown -grg option -grg[%c]\n", ch);
+				exit(1);
+			case 'i':
+				garglktstctx.inpfname=av[++n];
+				break;
+			case 'o':
+				garglktstctx.outfname=av[++n];
+				break;
+			case 's':
+				garglktstctx.sleep=strtoul(av[++n], NULL, 10);
+				break;
+			case 'x':
+				garglktstctx.eofexit=1;
+				break;
+			}
+		}
+	if(n>1){
+		fprintf(stderr, "gargoyle testing context settings (skip to arg[%d] '%s'):\n", n, av[n]);
+		garglktstctx.active=1;
+		if(garglktstctx.inpfname){
+			garglktstctx.inpf=garglktst_checked_fopen(garglktstctx.inpfname, "r");
+			fprintf(stderr, "\tinput file: %s\n", garglktstctx.inpfname);
+			fprintf(stderr, "\t\ton command eof: %s\n", garglktstctx.eofexit?"exit":"keep playing");
+			}
+		if(garglktstctx.outfname){
+			garglktstctx.outf=garglktst_checked_fopen(garglktstctx.outfname, "w");
+			fprintf(stderr, "\toutput file: %s\n", garglktstctx.outfname);
+			}
+		if(garglktstctx.sleep>0) fprintf(stderr, "\tpause between commands: %us\n", garglktstctx.sleep);
+		n--;
+		av[n]=av[0];
+		*pav=&av[n];
+		ac-=n;
+		fprintf(stderr, "\tremaining command line args being passed on: (argc=%d)\n", ac);
+		for(i=0;i<ac;i++){
+			fprintf(stderr, "\t\targv[%3d]='%s'\n", i, (*pav)[i]);
+			}
+		}
+	return ac;
+	}

--- a/garglk/garglktst.h
+++ b/garglk/garglktst.h
@@ -1,0 +1,9 @@
+// header for gargoyle automated testing code
+// (only in debug build)
+#include <unistd.h> // TODO better x-platform way to get sleep function
+struct garglktstctx{
+	int active, sleep, eofexit;
+	char const *inpfname, *outfname;
+	FILE *inpf, *outf;
+	};
+extern struct garglktstctx garglktstctx;

--- a/garglk/garglktst_events.c
+++ b/garglk/garglktst_events.c
@@ -1,0 +1,31 @@
+// to be included in window.c for testing
+static void garglktst_send_cmd(int character){
+	static char cmd[256];
+	if(0==fgets(cmd, sizeof(cmd), garglktstctx.inpf)){
+		if(garglktstctx.eofexit){
+			if(garglktstctx.outf){
+				fprintf(garglktstctx.outf, "\n");
+				fflush(garglktstctx.outf);
+				}
+			exit(0);
+			}
+		return;
+		}
+	if(character){
+		if('\n'==cmd[0]){
+			gli_input_handle_key(keycode_Return);
+			}
+		else{
+			gli_input_handle_key(cmd[0]);
+			}
+		return;
+		}
+	int len=strlen(cmd);
+	if(len>0 && '\n'==cmd[len-1]) cmd[len-1]='\0';
+	char *s=cmd;
+	for(;*s;s++){
+		gli_input_handle_key(*s);
+		}
+	gli_input_handle_key(keycode_Return);
+	sleep(garglktstctx.sleep);
+	}

--- a/garglk/main.c
+++ b/garglk/main.c
@@ -29,8 +29,11 @@
 #include "glkstart.h"
 #include "garglk.h"
 
+// TODO only if DEBUG build
+#include "garglktst.c"
 int main(int argc, char *argv[])
 {
+    argc=garglktst_init_and_stripargv(argc, &argv); // TODO only if DEBUG build
     glkunix_startup_t startdata;
     startdata.argc = argc;
     startdata.argv = malloc(argc * sizeof(char*));

--- a/garglk/show-devenv
+++ b/garglk/show-devenv
@@ -1,0 +1,4 @@
+#!/bin/sh
+\date -u "+%F %T [%Z]"
+gcc --version | head -n1
+uname -smov

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -947,6 +947,8 @@ void glk_request_char_event(window_t *win)
 
 }
 
+// TODO debug build only
+#include "garglktst_events.c"
 void glk_request_char_event_uni(window_t *win)
 {
     if (!win)
@@ -966,6 +968,7 @@ void glk_request_char_event_uni(window_t *win)
         case wintype_TextBuffer:
         case wintype_TextGrid:
             win->char_request_uni = TRUE;
+            if(garglktstctx.inpf) garglktst_send_cmd(1);
             break;
         default:
             gli_strict_warning("request_char_event_uni: window does not support keyboard input");
@@ -1005,29 +1008,6 @@ void glk_request_line_event(window_t *win, char *buf, glui32 maxlen,
     }
 
 }
-// TODO debug build only
-static void garglktst_send_line(void){
-	static char cmd[256];
-	if(0==fgets(cmd, sizeof(cmd), garglktstctx.inpf)){
-		if(garglktstctx.eofexit){
-			if(garglktstctx.outf){
-				fprintf(garglktstctx.outf, "\n");
-				fflush(garglktstctx.outf);
-				}
-			exit(0);
-			}
-		return;
-		}
-	int len=strlen(cmd);
-	if(len>0 && '\n'==cmd[len-1]) cmd[len-1]='\0';
-
-	char *s=cmd;
-	for(;*s;s++){
-		gli_input_handle_key(*s);
-		}
-	gli_input_handle_key(keycode_Return);
-	sleep(garglktstctx.sleep);
-	}
 void glk_request_line_event_uni(window_t *win, glui32 *buf, glui32 maxlen,
     glui32 initlen)
 {
@@ -1048,7 +1028,7 @@ void glk_request_line_event_uni(window_t *win, glui32 *buf, glui32 maxlen,
         case wintype_TextBuffer:
             win->line_request_uni = TRUE;
             win_textbuffer_init_line_uni(win, buf, maxlen, initlen);
-            if(garglktstctx.inpf) garglktst_send_line();
+            if(garglktstctx.inpf) garglktst_send_cmd(0);
             break;
         case wintype_TextGrid:
             win->line_request_uni = TRUE;


### PR DESCRIPTION
**Automated Testing**

My assumption is that we do testing manually now? e.g. when testing _Counterfeit Monkey_'s undo bug we must play the game manually to reach the bug state.

The goal of these changes is to allow us to automate testing of bugfix patches (since that seems to be the main purpose of the next release). The ideal would be to run
```
make test
```
to check all bug fixes for regression, automatically.

To this end I've added the following command line options to the game engines.
```
-grgi - input file from which to read user commands (default none)
-grgo - output file to which to write game output/transcript (default none)
-grgs - sleep between each command issue (default none)
-grgx - exit game at end of input file (default, keep game running for interactive use)
```
(The change is small and localized in the garglk library.)

The idea is

- put the user commands in a file
- run this file against the game
- compare the output with an expected version (`diff`)

For example
```
$ cat test.cmd
look
inventory
open box
take it
open door
ne
e
open window
w
take all
quit
$ LD_LIBRARY_PATH=build/dist build/dist/bocfel \
        -grgi test.cmd -grgo test.out -grgs 1 -grgx \
        zork.z3
$ diff test.out test.exp
```
I have done this development on Linux (some version info below)
```
$ garglk/show-devenv
2017-03-27 10:20:51 [UTC]
gcc (GCC) 6.2.1 20160830
Linux #1 SMP PREEMPT Fri Dec 9 07:43:17 CET 2016 i686 GNU/Linux
```