### PR TITLE
Clipboard bugfixes - newlines added even to single word selections; NUL char included in text

### DIFF
--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -229,7 +229,7 @@ void winclipstore(glui32 *text, int len)
 
     /* null-terminated string */
     cliptext[k] = '\0';
-    cliplen = k + 1;
+    cliplen = k;
 }
 
 void winclipsend(int source)

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -539,9 +539,12 @@ void win_textbuffer_redraw(window_t *win)
                     dwin->copypos++;
                 }
             }
-            /* add newline to copy buffer */
-            dwin->copybuf[dwin->copypos] = '\n';
-            dwin->copypos++;
+            /* add newline if we reach the end of the line */
+            if(0==ln->len || (rsc+1)==ln->len)
+            {
+                dwin->copybuf[dwin->copypos] = '\n';
+                dwin->copypos++;
+            }
         }
 
         /* clear any stored hyperlink coordinates */

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -540,7 +540,7 @@ void win_textbuffer_redraw(window_t *win)
                 }
             }
             /* add newline if we reach the end of the line */
-            if(0==ln->len || (rsc+1)==ln->len)
+            if (ln->len == 0 || ln->len == (rsc+1))
             {
                 dwin->copybuf[dwin->copypos] = '\n';
                 dwin->copypos++;


### PR DESCRIPTION
There are 2 clipboard problems solved here:

1. **NUL inclusion** In sysgtk.c: ``cliplen=k+1`` includes the NUL byte at the end of the text. The standard string interface behavior is to give the length of the text, not including the NUL byte at the end. I fixed this in this file but the same problem is in ``syswin.c`` etc.
2. **newline** There is code to add a newline to every "line" of text selected. However, it always adds even when the selection is _only a partial line_ e.g. a single word. I've made the _newline adding_ conditional on our selection touching the end of a line (better would be conditioning on continuing past the line end but that would require deep search of the code and its capabilities).
I've tested with the gtk build of bocfel. I didn't fix the other sysXXX.c cos I cannot test those, but they all have problem 1 above. Solution 2 is in ``wintext.c`` and affects all platforms equally.