### PR TITLE
Added os_file_stat implementation for MinGW.

### DIFF
--- a/tads/osextra.c
+++ b/tads/osextra.c
@@ -24,7 +24,12 @@
 #include <stddef.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include "os.h"
+#include "osextra.h"
 
 /*
  * This file contains extra OS-specific functionality which is required
@@ -183,4 +188,4 @@ unsigned long oss_get_file_attrs(const char *fname)
     /* return the attributes */
     return attrs;
 }
-#endif _WIN32
+#endif /* _WIN32 */

--- a/tads/osextra.c
+++ b/tads/osextra.c
@@ -61,3 +61,126 @@ int os_is_file_absolute(const char *fname)
     /* The path is relative. */
     return FALSE;
 }
+
+#ifdef _WIN32
+/*
+ *   Copied and adapted from tads2/osnoui.c.
+ *   Get the DOS attributes for a file
+ *
+ *   We don't use either of the versions provided in tads2/osnoui.c directly,
+ *   even though the version provided for the MICROSOFT compiler is pretty
+ *   much what we need, because defining the MICROSOFT precompiler symbol
+ *   would include a bunch of other stuff that we don't necessarily want.
+ */
+unsigned long oss_get_file_attrs(const char *fname)
+{
+    unsigned long attrs = 0;
+    
+    /* get the DOS attribute flags */
+    DWORD dos_attrib = GetFileAttributes(fname);
+
+    /* translate the HIDDEN and SYSTEM bits */
+    if ((dos_attrib & _A_HIDDEN) != 0)
+        attrs |= OSFATTR_HIDDEN;
+    if ((dos_attrib & _A_SYSTEM) != 0)
+        attrs |= OSFATTR_SYSTEM;
+
+    /* if the RDONLY bit is set, it's readable, otherwise read/write */
+    attrs |= OSFATTR_READ;
+    if ((dos_attrib & _A_RDONLY) == 0)
+        attrs |= OSFATTR_WRITE;
+
+    /*
+     *   On Windows, attempt to do a full security manager check to determine
+     *   our actual access rights to the file.  If we fail to get the
+     *   security info, we'll give up and return the simple RDONLY
+     *   determination we just made above.  In most cases, failure to check
+     *   the security information will simply be because the file has no ACL,
+     *   which means that anyone can access it, hence our tentative result
+     *   from the RDONLY attribute is correct after all.
+     */
+    {
+        /* 
+         *   get the file's DACL and owner/group security info; first, ask
+         *   how much space we need to allocate for the returned information 
+         */
+        DWORD len = 0;
+        SECURITY_INFORMATION info = (SECURITY_INFORMATION)(
+            OWNER_SECURITY_INFORMATION
+            | GROUP_SECURITY_INFORMATION
+            | DACL_SECURITY_INFORMATION);
+        GetFileSecurity(fname, info, 0, 0, &len);
+        if (len != 0)
+        {
+            /* allocate a buffer for the security info */
+            SECURITY_DESCRIPTOR *sd = (SECURITY_DESCRIPTOR *)malloc(len);
+            if (sd != 0)
+            {
+                /* now actually retrieve the security info into our buffer */
+                if (GetFileSecurity(fname, info, sd, len, &len))
+                {
+                    HANDLE ttok;
+
+                    /* impersonate myself for security purposes */
+                    ImpersonateSelf(SecurityImpersonation);
+
+                    /* 
+                     *   get the security token for the current thread, which
+                     *   is the context in which the caller will presumably
+                     *   eventually attempt to access the file 
+                     */
+                    if (OpenThreadToken(
+                        GetCurrentThread(), TOKEN_ALL_ACCESS, TRUE, &ttok))
+                    {
+                        GENERIC_MAPPING genmap = {
+                            FILE_GENERIC_READ,
+                            FILE_GENERIC_WRITE,
+                            FILE_GENERIC_EXECUTE,
+                            FILE_ALL_ACCESS
+                        };
+                        PRIVILEGE_SET privs;
+                        DWORD privlen = sizeof(privs);
+                        BOOL granted = FALSE;
+                        DWORD desired;
+                        DWORD allowed;
+
+                        /* test read access */
+                        desired = GENERIC_READ;
+                        MapGenericMask(&desired, &genmap);
+                        if (AccessCheck(sd, ttok, desired, &genmap,
+                                        &privs, &privlen, &allowed, &granted))
+                        {
+                            /* clear the read bit if reading isn't allowed */
+                            if (allowed == 0)
+                                attrs &= ~OSFATTR_READ;
+                        }
+
+                        /* test write access */
+                        desired = GENERIC_WRITE;
+                        MapGenericMask(&desired, &genmap);
+                        if (AccessCheck(sd, ttok, desired, &genmap,
+                                        &privs, &privlen, &allowed, &granted))
+                        {
+                            /* clear the read bit if reading isn't allowed */
+                            if (allowed == 0)
+                                attrs &= ~OSFATTR_WRITE;
+                        }
+
+                        /* done with the thread token */
+                        CloseHandle(ttok);
+                    }
+
+                    /* terminate our security self-impersonation */
+                    RevertToSelf();
+                }
+
+                /* free the allocated security info buffer */
+                free(sd);
+            }
+        }
+    }
+
+    /* return the attributes */
+    return attrs;
+}
+#endif _WIN32

--- a/tads/osextra.h
+++ b/tads/osextra.h
@@ -21,6 +21,9 @@
  *                                                                            *
  *****************************************************************************/
 
- #ifdef _WIN32
+#ifdef _WIN32
+#ifdef __cplusplus
+extern "C"
+#endif
 unsigned long oss_get_file_attrs(const char *fname);
 #endif

--- a/tads/osextra.h
+++ b/tads/osextra.h
@@ -28,7 +28,9 @@
 extern "C" {
 #endif
 
+#ifdef _WIN32
 unsigned long oss_get_file_attrs(const char *fname);
+#endif
 
 /*
  *   Done with C linkage section

--- a/tads/osextra.h
+++ b/tads/osextra.h
@@ -1,0 +1,26 @@
+/******************************************************************************
+ *                                                                            *
+ * Copyright (C) 2006-2009 by Tor Andersson.                                  *
+ * Copyright (C) 2010 by Ben Cressey.                                         *
+ *                                                                            *
+ * This file is part of Gargoyle.                                             *
+ *                                                                            *
+ * Gargoyle is free software; you can redistribute it and/or modify           *
+ * it under the terms of the GNU General Public License as published by       *
+ * the Free Software Foundation; either version 2 of the License, or          *
+ * (at your option) any later version.                                        *
+ *                                                                            *
+ * Gargoyle is distributed in the hope that it will be useful,                *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with Gargoyle; if not, write to the Free Software                    *
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA *
+ *                                                                            *
+ *****************************************************************************/
+
+ #ifdef _WIN32
+unsigned long oss_get_file_attrs(const char *fname);
+#endif

--- a/tads/osextra.h
+++ b/tads/osextra.h
@@ -21,9 +21,18 @@
  *                                                                            *
  *****************************************************************************/
 
-#ifdef _WIN32
+/*
+ *   For C++ files, define externals with C linkage 
+ */
 #ifdef __cplusplus
-extern "C"
+extern "C" {
 #endif
+
 unsigned long oss_get_file_attrs(const char *fname);
+
+/*
+ *   Done with C linkage section
+ */
+#ifdef __cplusplus
+}
 #endif

--- a/tads/osportable.cc
+++ b/tads/osportable.cc
@@ -577,9 +577,125 @@ osfmode( const char *fname, int follow_links, unsigned long *mode,
     return ok;
 }
 
+#ifdef _WIN32
+/*
+ *   Copied and adapted from tads2/osnoui.c
+ *   Get the DOS attributes for a file
+ */
+unsigned long oss_get_file_attrs(const char *fname)
+{
+    unsigned long attrs = 0;
+    
+    /* get the DOS attribute flags */
+    DWORD dos_attrib = GetFileAttributes(fname);
+
+    /* translate the HIDDEN and SYSTEM bits */
+    if ((dos_attrib & _A_HIDDEN) != 0)
+        attrs |= OSFATTR_HIDDEN;
+    if ((dos_attrib & _A_SYSTEM) != 0)
+        attrs |= OSFATTR_SYSTEM;
+
+    /* if the RDONLY bit is set, it's readable, otherwise read/write */
+    attrs |= OSFATTR_READ;
+    if ((dos_attrib & _A_RDONLY) == 0)
+        attrs |= OSFATTR_WRITE;
+
+    /*
+     *   On Windows, attempt to do a full security manager check to determine
+     *   our actual access rights to the file.  If we fail to get the
+     *   security info, we'll give up and return the simple RDONLY
+     *   determination we just made above.  In most cases, failure to check
+     *   the security information will simply be because the file has no ACL,
+     *   which means that anyone can access it, hence our tentative result
+     *   from the RDONLY attribute is correct after all.
+     */
+    {
+        /* 
+         *   get the file's DACL and owner/group security info; first, ask
+         *   how much space we need to allocate for the returned information 
+         */
+        DWORD len = 0;
+        SECURITY_INFORMATION info = (SECURITY_INFORMATION)(
+            OWNER_SECURITY_INFORMATION
+            | GROUP_SECURITY_INFORMATION
+            | DACL_SECURITY_INFORMATION);
+        GetFileSecurity(fname, info, 0, 0, &len);
+        if (len != 0)
+        {
+            /* allocate a buffer for the security info */
+            SECURITY_DESCRIPTOR *sd = (SECURITY_DESCRIPTOR *)malloc(len);
+            if (sd != 0)
+            {
+                /* now actually retrieve the security info into our buffer */
+                if (GetFileSecurity(fname, info, sd, len, &len))
+                {
+                    HANDLE ttok;
+
+                    /* impersonate myself for security purposes */
+                    ImpersonateSelf(SecurityImpersonation);
+
+                    /* 
+                     *   get the security token for the current thread, which
+                     *   is the context in which the caller will presumably
+                     *   eventually attempt to access the file 
+                     */
+                    if (OpenThreadToken(
+                        GetCurrentThread(), TOKEN_ALL_ACCESS, TRUE, &ttok))
+                    {
+                        GENERIC_MAPPING genmap = {
+                            FILE_GENERIC_READ,
+                            FILE_GENERIC_WRITE,
+                            FILE_GENERIC_EXECUTE,
+                            FILE_ALL_ACCESS
+                        };
+                        PRIVILEGE_SET privs;
+                        DWORD privlen = sizeof(privs);
+                        BOOL granted = FALSE;
+                        DWORD desired;
+                        DWORD allowed;
+
+                        /* test read access */
+                        desired = GENERIC_READ;
+                        MapGenericMask(&desired, &genmap);
+                        if (AccessCheck(sd, ttok, desired, &genmap,
+                                        &privs, &privlen, &allowed, &granted))
+                        {
+                            /* clear the read bit if reading isn't allowed */
+                            if (allowed == 0)
+                                attrs &= ~OSFATTR_READ;
+                        }
+
+                        /* test write access */
+                        desired = GENERIC_WRITE;
+                        MapGenericMask(&desired, &genmap);
+                        if (AccessCheck(sd, ttok, desired, &genmap,
+                                        &privs, &privlen, &allowed, &granted))
+                        {
+                            /* clear the read bit if reading isn't allowed */
+                            if (allowed == 0)
+                                attrs &= ~OSFATTR_WRITE;
+                        }
+
+                        /* done with the thread token */
+                        CloseHandle(ttok);
+                    }
+
+                    /* terminate our security self-impersonation */
+                    RevertToSelf();
+                }
+
+                /* free the allocated security info buffer */
+                free(sd);
+            }
+        }
+    }
+
+    /* return the attributes */
+    return attrs;
+}
+#endif _WIN32
+
 /* Get full stat() information on a file.
- *
- * TODO: Windows implementation for mingw.
  */
 int
 os_file_stat( const char *fname, int follow_links, os_file_stat_t *s )
@@ -598,14 +714,13 @@ os_file_stat( const char *fname, int follow_links, os_file_stat_t *s )
     s->mode = buf.st_mode;
     s->attrs = 0;
 
+#ifdef _WIN32
+    s->attrs = oss_get_file_attrs(fname);
+#else ifndef _WIN32
     if (os_get_root_name(fname)[0] == '.') {
         s->attrs |= OSFATTR_HIDDEN;
     }
 
-    /* XXX
-     * This needs to be implemented for MinGW.
-     */
-#ifndef _WIN32
     // If we're the owner, check if we have read/write access.
     if (geteuid() == buf.st_uid) {
         if (buf.st_mode & S_IRUSR)


### PR DESCRIPTION
Hoping to make myself useful here, as I seemed to understand that this was one of the blocking points for the TADS port.... I'm no C or MinGW expert at all, but I simply copied and adapted the Windows version of oss_get_file_attrs defined in tads2/osnoui.c.

With this change I successfully built gargoyle.exe and tadsr.exe on MinGW, and I tested that the correct hidden/readable/writeable file attributes are now accessible from a T3 program running in Gargoyle.

Here are the steps I followed to carry out the test (from a fresh checkout of this branch, and with the Windows version of Jam installed):

1.  I commented out the line "USESDL ?= yes ;" in the JamRules file in the base directory, so as to remove the dependency on SDL_mixer.

2.  I ran gargoyle_build.cmd. Everything built successfully except Git (I believe), which fortunately wasn't needed for this test.

3.  I ran gargoyle_win32.cmd. This copied a bunch of executables in build\dist.  The makensis.exe command in the script failed, but again whatever it's supposed to do wasn't a blocker for this test.

4.  In build\dist I copied a TADS program named "fileinfo.t3", which I created (it's attached to this message).  This program repeatedly prompts the user for file names and displays the corresponding file stats as they appear from within the TADS program.

6.  In the same folder, I ran tadsr.exe *outside* of gargoyle.exe, using the following command: "tadsr.exe -s00 fileinfo.t3".  The -s00 option was necessary to lower the file safety level so that the interpreter would allow access to the file infos I requested. Without this option, or from within Gargoyle.exe, the interpreter denied access to the stats for all files. (This was also true before my change, and may be a separate problem to look into. I don't know if it impacts only MinGW builds or all systems.)

7. From within the .T3 program, I typed various file names and checked that hidden, read-only, and read-write files are now correctly identified as such.

[fileinfo.t3.zip](https://github.com/garglk/garglk/files/945665/fileinfo.t3.zip)
