### PR TITLE
[MinGW][TADS] Fixed file safety checks + minor IO issues.

### DIFF
--- a/tads/Jamfile
+++ b/tads/Jamfile
@@ -19,7 +19,6 @@ SubDirCcFlags
     -DGLK_TIMERS
     -DTC_TARGET_T3
     -DRUNTIME
-    -DOSNOUI_OMIT_IS_FILE_ABSOLUTE
     ;
 
 # HTMLMODE ?= yes ;
@@ -37,6 +36,11 @@ if $(OS) = MACOSX
 {
     SubDirCcFlags -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
     LINKFLAGS = -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
+}
+
+if $(OS) = MINGW
+{
+    SubDirCcFlags -DMSDOS -DT_WIN32 ;
 }
 
 SEARCH_SOURCE =

--- a/tads/osextra.c
+++ b/tads/osextra.c
@@ -36,37 +36,6 @@
  * but is not part of osportable.cc.
  */
 
-/*
- *   Determine if a path is absolute or relative.  If the path starts with
- *   a path separator character, we consider it absolute, otherwise we
- *   consider it relative.
- *   
- *   Note that, on Windows, an absolute path can also follow a drive letter.
- *   So, if the path contains a letter followed by a colon, we'll consider
- *   the path to be absolute. 
- *
- *   This is provided because the noui version only knows about DOS, not
- *   Windows, so will not handle drive letters properly, assuming
- *   something like C:/foo is not absoolute. The macro
- *   OSNOUI_OMIT_IS_FILE_ABSOLUTE must be defined so that the noui version
- *   is not built.
- */
-int os_is_file_absolute(const char *fname)
-{
-    /* If the name starts with a path separator, it's absolute. */
-    if (fname[0] == OSPATHCHAR || strchr(OSPATHALT, fname[0]) != NULL)
-        return TRUE;
-
-#ifdef _WIN32
-    /* On Windows, a file is absolute if it starts with a drive letter. */
-    if (isalpha((unsigned char)fname[0]) && fname[1] == ':')
-        return TRUE;
-#endif /* _WIN32 */
-
-    /* The path is relative. */
-    return FALSE;
-}
-
 #ifdef _WIN32
 /*
  *   Copied and adapted from tads2/osnoui.c.

--- a/tads/osportable.cc
+++ b/tads/osportable.cc
@@ -1035,8 +1035,8 @@ static char *realpath(const char *file_name, char *resolved_name)
         return NULL;
 
     DWORD len = GetFullPathName(file_name, PATH_MAX + 1, resolved_name, NULL);
-	if (!len || len > PATH_MAX)
-		return NULL;
+    if (!len || len > PATH_MAX)
+        return NULL;
 
     return resolved_name;
 }

--- a/tads/osportable.cc
+++ b/tads/osportable.cc
@@ -449,12 +449,12 @@ os_gen_temp_filename( char* buf, size_t buflen )
 }
 #endif
 
-/* Get the temporary file path.
- *
- * tads2/osnoui.c defines a DOS version of this routine when MSDOS is
- * defined.
+/* tads2/osnoui.c defines DOS versions of those routine when MSDOS is defined.
  */
 #ifndef MSDOS
+
+/* Get the temporary file path.
+ */
 void
 os_get_tmp_path( char* buf )
 {
@@ -497,8 +497,6 @@ os_get_tmp_path( char* buf )
     }
 #endif
 }
-#endif // not MSDOS
-
 
 /* Create a directory.
  */
@@ -558,6 +556,8 @@ os_rmdir( const char *dir )
 {
     return rmdir(dir) == 0;
 }
+
+#endif // not MSDOS
 
 /* Get a file's mode/type.  This returns the same information as
  * the 'mode' member of os_file_stat_t from os_file_stat(), so we
@@ -1034,7 +1034,9 @@ static char *realpath(const char *file_name, char *resolved_name)
     if (resolved_name == NULL)
         return NULL;
 
-    GetFullPathName(file_name, PATH_MAX + 1, resolved_name, NULL);
+    DWORD len = GetFullPathName(file_name, PATH_MAX + 1, resolved_name, NULL);
+	if (!len || len > PATH_MAX)
+		return NULL;
 
     return resolved_name;
 }
@@ -1168,7 +1170,7 @@ os_is_file_in_dir( const char* filename, const char* path,
     plen = strlen(path);
 
     // If the path ends in a separator character, ignore that.
-    if (plen > 0 and path[plen-1] == '/')
+    if (plen > 0 and path[plen-1] == OSPATHCHAR)
         --plen;
 
     // if the names match, return true if and only if we're matching the
@@ -1190,7 +1192,7 @@ os_is_file_in_dir( const char* filename, const char* path,
     // as matching "c:\abc\d.txt" - if we only matched the "c:\a" prefix,
     // we'd miss the fact that the file is actually in directory "c:\abc",
     // not "c:\a".)
-    if (filename[plen] != '/')
+    if (filename[plen] != OSPATHCHAR)
         return false;
 
     // We're good on the path prefix - we definitely have a file that's
@@ -1214,7 +1216,7 @@ os_is_file_in_dir( const char* filename, const char* path,
     // itself, so it's not a match.  If we don't find any separators,
     // we have a file directly in 'path', so it's a match.
     const char* p;
-    for (p = filename; *p != '\0' and *p != '/' ; ++p)
+    for (p = filename; *p != '\0' and *p != OSPATHCHAR ; ++p)
         ;
 
     // If we reached the end of the string without finding a path

--- a/tads/tads2/osnoui.c
+++ b/tads/tads2/osnoui.c
@@ -1033,7 +1033,7 @@ int os_locate(const char *fname, int flen, const char *arg0,
 # define fname_memcmp memcmp
 #endif
 
-#ifdef GARGOYLE
+#if defined(GARGOYLE) && !defined(fname_memcmp)
 #  define fname_memcmp memcmp
 #endif
 


### PR DESCRIPTION
This fixes the file safety issue under MinGW, which we discussed a few days ago as part of the file stats pull request, and fixes a few other minor issues under MinGW

The issue was a combination of three bugs:

1/  The MinGW implementation of realpath() (in osportable.cc) returned wrong results for empty paths.

This was because the call to the Windows function GetFullPathName() inside this function returns 0 (an error code) for empty paths, and this error wasn't handled, so realpath() returned garbage in that case.  I fixed it by having realpath() detect it (and check that the input buffer has sufficient length while I was at it), and return NULL in case of such errors.  (The NULL is correctly handled by caller code.)

2/  os_is_file_in_dir (in osportable.cc) assumed that the path separator was '/'.

I fixed this by using OSPATHCHAR instead.

3/ os_is_file_absolute (in osextra.c) incorrectly classified empty paths as absolute.

This was because of how strchr was used in this function.  strchr considers the null terminator as part of the string, so that strchr(OSPATHALT, fname[0]) does not return NULL when fname[0] == 0.

The most immediately fix would have been to guard for this case with an explicit check for fname[0] != 0. 

However, I pointed out earlier (in the file stat thread) that, under MinGW, defining the precompiler symbols MSDOS (and T_WIN32) would improve many things in osnoui.c, and os_is_file_absolute is one of the things that actually gets fixed for free when compiled with MSDOS.  Specifically, the following comment for the version of os_is_file_absolute defined in osextra.c:

```
 *   This is provided because the noui version only knows about DOS, not
 *   Windows, so will not handle drive letters properly, assuming
 *   something like C:/foo is not absoolute. The macro
 *   OSNOUI_OMIT_IS_FILE_ABSOLUTE must be defined so that the noui version
 *   is not built.
```

does not apply anymore when osnoui.c is compiled with MSDOS, and on the other hand the osnoui.c version of os_is_file_absolute essentially falls back to the same implementation as the osextra.c version when not.

Therefore, rather than correcting the oextra.c version, I deleted it (I hope you don't mind) and re-enabled the osnoui.c version (by removing the -DOSNOUI_OMIT_IS_FILE_ABSOLUTE option from the TADS Jam file), which now has the correct behavior with or without MinGW, provided the appropriate compiler symbols are defined.

This brings me to the other minor corrections:

4/ The TADS Jam file now defines the precompiler symbols MSDOS and T_WIN32 when OS = MINGW (as appropriate), enabling a number of small improvements in osnoui.c under MinGW.

For this to work, though, I had to fix a few rough edges, namely:

-  With MSDOS defined, osnoui.c now defines its own versions of os_mkdir and os_rmdir, so I had to guard the osportable.cc versions of os_mkdir and os_rmdir with "#ifndef MSDOS" checks, to avoid a duplicate definition.  osportable.cc already had some "#ifndef MSDOS" checks for other functions, for the same reason, so this is just being consistent with what's already done elsewhere in the same file.

-  In osnoui.c, I replaced an "#ifdef GARGOYLE" check with "#if defined(GARGOYLE) && !defined(fname_memcmp)", again to avoid a duplicate definition when MSDOS and/or T_WIN32 are defined.  I understand the desire to avoid modifying the original TADS 2 sources if possible, but considering that the "#ifdef GARGOYLE" was already an addition, I figured that one's okay.

