### PR TITLE
Enable text-to-speech.

### DIFF
--- a/Jamrules
+++ b/Jamrules
@@ -7,6 +7,7 @@ USESDL ?= yes ;
 USEBABEL ?= yes ;
 MAC_USEHOMEBREW ?= no ;
 BUNDLEFONTS ?= yes ;
+USETTS ?= no ;
 
 # jam -sGUILIB=EFL
 GUILIB ?= gtk+ ;
@@ -78,6 +79,10 @@ switch $(OS)
             PKGCONFIG = "pkg-config freetype2 evas ecore ecore-evas elementary fontconfig" ;
         } else {
             PKGCONFIG = "pkg-config freetype2 gtk+-x11-2.0 gdk-x11-2.0 gobject-2.0 glib-2.0 fontconfig" ;
+        }
+
+        if $(USETTS) = yes {
+           PKGCONFIG = "$(PKGCONFIG) speech-dispatcher" ;
         }
 
         # Setting C++ standard version to use for current g++ compilers.

--- a/garglk/Jamfile
+++ b/garglk/Jamfile
@@ -46,6 +46,23 @@ GARGSRCS =
     fontdata.c babeldata.c
     ;
 
+if $(USETTS) = yes
+{
+    switch $(OS)
+    {
+        case MINGW :
+            GARGSRCS += ttswin.c ;
+        case *LINUX* :
+            GARGSRCS += ttsspeechd.c ;
+        case * :
+            Exit "TTS requested but no implementation is available on this platform ($(OS))." ;
+    }
+}
+else
+{
+    GARGSRCS += ttsnull.c ;
+}
+
 if $(OS) = IPLINUX { ObjectCcFlags draw.c : -DEFL_1BPP ; }
 else if $(GUILIB) = EFL { ObjectCcFlags draw.c : -DEFL_4BPP ; }
 

--- a/garglk/config.c
+++ b/garglk/config.c
@@ -171,6 +171,8 @@ int gli_conf_caps = 0;
 int gli_conf_graphics = 1;
 int gli_conf_sound = 1;
 int gli_conf_speak = 0;
+int gli_conf_speak_input = 0;
+const char *gli_conf_speak_language = NULL;
 
 int gli_conf_stylehint = 0;
 int gli_conf_safeclicks = 0;
@@ -428,8 +430,13 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
             gli_conf_graphics = atoi(arg);
         if (!strcmp(cmd, "sound"))
             gli_conf_sound = atoi(arg);
+
         if (!strcmp(cmd, "speak"))
             gli_conf_speak = atoi(arg);
+        if (!strcmp(cmd, "speak_input"))
+            gli_conf_speak_input = atoi(arg);
+        if (!strcmp(cmd, "speak_language"))
+            gli_conf_speak_language = strdup(arg);
 
         if (!strcmp(cmd, "stylehint"))
             gli_conf_stylehint = atoi(arg);
@@ -595,11 +602,9 @@ void gli_startup(int argc, char *argv[])
     if (!gli_baseline)
         gli_baseline = gli_conf_propsize + 0.5;
 
-#ifdef USETTS
     gli_initialize_tts();
     if (gli_conf_speak)
         gli_conf_quotes = 0;
-#endif
 
     gli_initialize_misc();
     gli_initialize_fonts();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -28,6 +28,8 @@
  * http://www.eblong.com/zarf/glk/index.html
  */
 
+#include <stddef.h>
+
 #include "gi_dispa.h"
 
 /* First, we define our own TRUE and FALSE and NULL, because ANSI
@@ -222,7 +224,10 @@ extern int gli_conf_lcd;
 
 extern int gli_conf_graphics;
 extern int gli_conf_sound;
+
 extern int gli_conf_speak;
+extern int gli_conf_speak_input;
+extern const char *gli_conf_speak_language;
 
 extern int gli_conf_stylehint;
 extern int gli_conf_safeclicks;
@@ -562,7 +567,9 @@ struct glk_schannel_struct
 
 extern void gli_initialize_sound(void);
 extern void gli_initialize_tts(void);
-extern void gli_speak_tts(char *buf, int len, int interrupt);
+extern void gli_tts_speak(const glui32 *buf, size_t len);
+extern void gli_tts_flush(void);
+extern void gli_tts_purge(void);
 
 /* ---------------------------------------------------------------------- */
 /*

--- a/garglk/ttsnull.c
+++ b/garglk/ttsnull.c
@@ -1,6 +1,5 @@
 /******************************************************************************
  *                                                                            *
- * Copyright (C) 2006-2009 by Tor Andersson.                                  *
  * Copyright (C) 2017 by Chris Spiegel.                                       *
  *                                                                            *
  * This file is part of Gargoyle.                                             *
@@ -21,86 +20,27 @@
  *                                                                            *
  *****************************************************************************/
 
-#define WIN32_LEAN_AND_MEAN
-
-#include <stdlib.h>
 #include <stdio.h>
-
-#include <sapi.h>
 
 #include "glk.h"
 #include "garglk.h"
 
-static ISpVoice *voice = NULL;
-#define TXTSIZE 4096
-static WCHAR txtbuf[TXTSIZE + 1];
-static size_t txtlen;
-
 void gli_initialize_tts(void)
 {
-    if (gli_conf_speak)
-    {
-        if (CoInitialize(NULL) == S_OK)
-        {
-            CoCreateInstance(
-                    &CLSID_SpVoice,		/* rclsid */
-                    NULL,			/* aggregate */
-                    CLSCTX_ALL,			/* dwClsContext */
-                    &IID_ISpVoice,		/* riid */
-                    (void**)&voice);
-        }
-    }
-    else
-    {
-        voice = NULL;
-    }
-
-    txtlen = 0;
 }
 
 void gli_tts_flush(void)
 {
-    if (voice != NULL)
-    {
-        txtbuf[txtlen] = 0;
-        voice->lpVtbl->Speak(voice, txtbuf, SPF_ASYNC, NULL);
-    }
-
-    txtlen = 0;
 }
 
 void gli_tts_purge(void)
 {
-    if (voice != NULL)
-        voice->lpVtbl->Speak(voice, NULL, SPF_PURGEBEFORESPEAK, NULL);
 }
 
 void gli_tts_speak(const glui32 *buf, size_t len)
 {
-    if (voice == NULL)
-        return;
-
-    for (size_t i = 0; i < len; i++)
-    {
-        if (txtlen >= TXTSIZE)
-            gli_tts_flush();
-
-        if (buf[i] == '>' || buf[i] == '*')
-            continue;
-
-        if (buf[i] < 0x10000)
-            txtbuf[txtlen++] = buf[i];
-
-        if (buf[i] == '.' || buf[i] == '!' || buf[i] == '?' || buf[i] == '\n')
-            gli_tts_flush();
-    }
 }
 
 void gli_free_tts(void)
 {
-    if (voice != NULL)
-    {
-        voice->lpVtbl->Release(voice);
-        CoUninitialize();
-    }
 }

--- a/garglk/ttsspeechd.c
+++ b/garglk/ttsspeechd.c
@@ -21,49 +21,81 @@
  *                                                                            *
  *****************************************************************************/
 
-#define WIN32_LEAN_AND_MEAN
-
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <sapi.h>
+#include <libspeechd.h>
 
 #include "glk.h"
 #include "garglk.h"
 
-static ISpVoice *voice = NULL;
 #define TXTSIZE 4096
-static WCHAR txtbuf[TXTSIZE + 1];
+static glui32 txtbuf[TXTSIZE + 1];
 static size_t txtlen;
+
+static SPDConnection *spd;
 
 void gli_initialize_tts(void)
 {
     if (gli_conf_speak)
     {
-        if (CoInitialize(NULL) == S_OK)
-        {
-            CoCreateInstance(
-                    &CLSID_SpVoice,		/* rclsid */
-                    NULL,			/* aggregate */
-                    CLSCTX_ALL,			/* dwClsContext */
-                    &IID_ISpVoice,		/* riid */
-                    (void**)&voice);
-        }
-    }
-    else
-    {
-        voice = NULL;
+        spd = spd_open("gargoyle", "main", NULL, SPD_MODE_SINGLE);
+
+        if (spd != NULL && gli_conf_speak_language != NULL)
+            spd_set_language(spd, gli_conf_speak_language);
     }
 
     txtlen = 0;
 }
 
+static char *unicode_to_utf8(const glui32 *src, size_t n)
+{
+    char *dst, *dstp;
+
+    dst = dstp = malloc((4 * n) + 1);
+
+    for (size_t i = 0; i < n; i++)
+    {
+        uint8_t hi  = (src[i] >> 16) & 0xff,
+                mid = (src[i] >>  8) & 0xff,
+                lo  = (src[i]      ) & 0xff;
+
+        if (src[i] < 0x80)
+        {
+            *dstp++ = src[i];
+        }
+        else if (src[i] < 0x800)
+        {
+            *dstp++ = 0xc0 | (mid << 2) | (lo >> 6);
+            *dstp++ = 0x80 | (lo & 0x3f);
+        }
+        else if (src[i] < 0x10000)
+        {
+            *dstp++ = 0xe0 | (mid >> 4);
+            *dstp++ = 0x80 | ((mid << 2) & 0x3f) | (lo >> 6);
+            *dstp++ = 0x80 | (lo & 0x3f);
+        }
+        else if (src[i] < 0x200000)
+        {
+            *dstp++ = 0xf0 | (hi >> 2);
+            *dstp++ = 0x80 | ((hi << 4) & 0x30) | (mid >> 4);
+            *dstp++ = 0x80 | ((mid << 2) & 0x3c) | (lo >> 6);
+            *dstp++ = 0x80 | (lo & 0x3f);
+        }
+    }
+
+    *dstp = 0;
+
+    return dst;
+}
+
 void gli_tts_flush(void)
 {
-    if (voice != NULL)
+    if (spd != NULL && txtlen > 0)
     {
-        txtbuf[txtlen] = 0;
-        voice->lpVtbl->Speak(voice, txtbuf, SPF_ASYNC, NULL);
+        char *utf8 = unicode_to_utf8(txtbuf, txtlen);
+        spd_say(spd, SPD_MESSAGE, utf8);
+        free(utf8);
     }
 
     txtlen = 0;
@@ -71,13 +103,13 @@ void gli_tts_flush(void)
 
 void gli_tts_purge(void)
 {
-    if (voice != NULL)
-        voice->lpVtbl->Speak(voice, NULL, SPF_PURGEBEFORESPEAK, NULL);
+    if (spd != NULL)
+        spd_cancel(spd);
 }
 
 void gli_tts_speak(const glui32 *buf, size_t len)
 {
-    if (voice == NULL)
+    if (spd == NULL)
         return;
 
     for (size_t i = 0; i < len; i++)
@@ -88,8 +120,7 @@ void gli_tts_speak(const glui32 *buf, size_t len)
         if (buf[i] == '>' || buf[i] == '*')
             continue;
 
-        if (buf[i] < 0x10000)
-            txtbuf[txtlen++] = buf[i];
+        txtbuf[txtlen++] = buf[i];
 
         if (buf[i] == '.' || buf[i] == '!' || buf[i] == '?' || buf[i] == '\n')
             gli_tts_flush();
@@ -98,9 +129,6 @@ void gli_tts_speak(const glui32 *buf, size_t len)
 
 void gli_free_tts(void)
 {
-    if (voice != NULL)
-    {
-        voice->lpVtbl->Release(voice);
-        CoUninitialize();
-    }
+    if (spd != NULL)
+        spd_close(spd);
 }

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -971,9 +971,7 @@ void win_textbuffer_putchar_uni(window_t *win, glui32 ch)
     int linelen;
     unsigned char *color;
 
-#ifdef USETTS
-    { char b[1]; b[0] = ch; gli_speak_tts(b, 1, 0); }
-#endif
+    gli_tts_speak(&ch, 1);
 
     pw = (win->bbox.x1 - win->bbox.x0 - gli_tmarginx * 2 - gli_scroll_width) * GLI_SUBPIX;
     pw = pw - 2 * SLOP - dwin->radjw - dwin->ladjw;
@@ -1185,9 +1183,7 @@ void win_textbuffer_init_line(window_t *win, char *buf, int maxlen, int initlen)
     window_textbuffer_t *dwin = win->data;
     int pw;
 
-#ifdef USETTS
-    gli_speak_tts("\n", 1, 0);
-#endif
+    gli_tts_flush();
 
     /* because '>' prompt is ugly without extra space */
     if (dwin->numchars && dwin->chars[dwin->numchars-1] == '>')
@@ -1240,9 +1236,7 @@ void win_textbuffer_init_line_uni(window_t *win, glui32 *buf, int maxlen, int in
     window_textbuffer_t *dwin = win->data;
     int pw;
 
-#ifdef USETTS
-    gli_speak_tts("\n", 1, 0);
-#endif
+    gli_tts_flush();
 
     /* because '>' prompt is ugly without extra space */
     if (dwin->numchars && dwin->chars[dwin->numchars-1] == '>')
@@ -1442,9 +1436,7 @@ void gcmd_buffer_accept_readchar(window_t *win, glui32 arg)
             key = arg;
     }
 
-#ifdef USETTS
-    gli_speak_tts("", 0, 1);
-#endif
+    gli_tts_purge();
 
     if (key > 0xff && key < (0xffffffff - keycode_MAXVAL + 1))
     {
@@ -1480,9 +1472,12 @@ static void acceptline(window_t *win, glui32 keycode)
     if (win->echostr) 
         gli_stream_echo_line_uni(win->echostr, dwin->chars+dwin->infence, len);
 
-#ifdef USETTS
-    gli_speak_tts(dwin->chars+dwin->infence, len, 1);
-#endif
+    gli_tts_purge();
+    if (gli_conf_speak_input)
+    {
+        gli_tts_speak(dwin->chars + dwin->infence, len);
+        gli_tts_speak((glui32[]){'\n'}, 1);
+    }
 
     /*
      * Store in history.


### PR DESCRIPTION
This adds conditional (at compile time) support for text-to-speech.  Currently supported platforms are Windows (via its [Speech API](https://msdn.microsoft.com/en-us/library/ee125663(v=vs.85).aspx)) and Linux (via [speech-dispatcher](https://devel.freebsoft.org/speechd)).

TTS support nominally existed already, but it was impossible to build without tweaking the build system, and was Windows only; and in addition, it appears to have predated Unicode support, so it didn't properly build anyway.

One config option, the boolean ``speak``, existed already, which enables TTS.  I added ``speak_input`` which, if true, will speak what the user typed.  At least Z-machine games already typically echo back the input, so if this is enabled, the input is spoken twice.  In addition, I've added ``speak_language``, which sets the speech language as described in ISO 639 / IETF 1766.  Language selection is currently only supported by the speech-dispatcher backend.

This is considered experimental, but will not be built unless explicitly asked for, so should not be disruptive in the general case.

To add TTS support, pass ``-sUSETTS=yes`` to the jam command line.

This addresses #257.
