### PR TITLE
Small MinGW fixes.

### DIFF
--- a/Jamrules
+++ b/Jamrules
@@ -22,13 +22,15 @@ CXX ?= g++ ;
 
 if $(CROSS)
 {
+    MINGWARCH ?= i386-mingw32 ;
     CROSS   = "(cross-compiling)" ;
     OS      = MINGW ;
     SUFEXE  = .exe ;
-    CC      = i386-mingw32-gcc ;
-    CXX     = i386-mingw32-g++ ;
-    AR      = i386-mingw32-ar cru ;
-    RANLIB  = i386-mingw32-ranlib ;
+    CC      = $(MINGWARCH)-gcc ;
+    C++     = $(MINGWARCH)-g++ -std=c++11 ;
+    CXX     = $(C++) ;
+    AR      = $(MINGWARCH)-ar cru ;
+    RANLIB  = $(MINGWARCH)-ranlib ;
     LINK    = $(CC) ;
 }
 
@@ -207,7 +209,7 @@ rule WindRes
     Clean clean : $(<) ;
 }
 
-actions WindRes { windres -i $(>) -o $(<) --include-dir=$(>:D) }
+actions WindRes { $(MINGWARCH)-windres -i $(>) -o $(<) --include-dir=$(>:D) }
 
 #
 # You shouldn't need to touch anything from here on.

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -26,12 +26,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <math.h>
-#ifndef _WIN32
 #include <unistd.h>
-#else
-#define R_OK	4
-#define W_OK	2
-#endif
 
 #include "glk.h"
 #include "garglk.h"

--- a/tads/tads2/osnoui.c
+++ b/tads/tads2/osnoui.c
@@ -35,7 +35,7 @@ Modified
 #include <sys/stat.h>
 
 #ifdef T_WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <direct.h>
 #endif
 


### PR DESCRIPTION
These are a few small fixes I had to make in order to successfully build with a modern MinGW installation (MinGW 5.0.2 with gcc 6.3.1 and binutils 2.28).

Since I only have one MinGW environment I'd like to hear whether this succeeds or fails for anybody else.  If there are no negatives, then I'll merge it.