### PR TITLE
Fix copy & paste crash on macOS build.

### DIFF
--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -21,6 +21,12 @@
  *                                                                            *
  *****************************************************************************/
 
+#ifdef __ppc__
+#define UTF32StringEncoding NSUTF32BigEndianStringEncoding
+#else
+#define UTF32StringEncoding NSUTF32LittleEndianStringEncoding
+#endif
+
 #define NSKEY_LEFT      0x7b
 #define NSKEY_RIGHT     0x7c
 #define NSKEY_DOWN      0x7d

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -212,9 +212,9 @@ void winclipstore(glui32 *text, int len)
         cliptext = nil;
     }
 
-    cliptext = [[NSString string] initWithBytes: text
-                                         length: (len * sizeof(glui32))
-                                       encoding: NSUTF32StringEncoding];
+    cliptext = [[NSString alloc] initWithBytes: text
+                                        length: (len * sizeof(glui32))
+                                      encoding: NSUTF32StringEncoding];
 }
 
 void winclipsend(void)

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -214,7 +214,7 @@ void winclipstore(glui32 *text, int len)
 
     cliptext = [[NSString alloc] initWithBytes: text
                                         length: (len * sizeof(glui32))
-                                      encoding: NSUTF32StringEncoding];
+                                      encoding: UTF32StringEncoding];
 }
 
 void winclipsend(void)
@@ -243,7 +243,7 @@ void winclipreceive(void)
             for (i=0; i < len; i++)
             {
                 if ([input getBytes: &ch maxLength: sizeof ch usedLength: NULL
-                           encoding: NSUTF32StringEncoding
+                           encoding: UTF32StringEncoding
                             options: 0
                               range: NSMakeRange(i, 1)
                      remainingRange: NULL])
@@ -515,7 +515,7 @@ void winkey(NSEvent *evt)
     /* convert character to UTF-32 value */
     glui32 ch;
     if ([evt_char getBytes: &ch maxLength: sizeof ch usedLength: NULL
-                  encoding: NSUTF32StringEncoding
+                  encoding: UTF32StringEncoding
                    options: 0
                      range: NSMakeRange(0, [evt_char length])
             remainingRange: NULL])


### PR DESCRIPTION
Correctly allocate the NSString object to post to the clipboard to prevent interpreter exit from an unhandled exception.

Further testing appears to show that something has changed in macOS SDK or Xcode or both. It is now necessary to explicity specify UTF-32 endianness or the `initWithBytes` method cannot create an `NSString` object from the Glk input buffer (ran into this while attempting to add TTS support to macOS build).

To summarize: the first commit fixes the crash (unhandled exception), the second commit allows copy and paste to work again.