### PR TITLE
Fix a pointer comparison.

### DIFF
--- a/tads/tads3/tct3stm.cpp
+++ b/tads/tads3/tct3stm.cpp
@@ -315,7 +315,11 @@ void CTPNVarIn::gen_iter_init(CTcPrsNode *coll_expr, int iter_local_id,
     CTcPrsNode *create_iter = G_cg->get_metaclass_prop("collection", 0);
 
     /* if we didn't find the property, it's an error */
+#if 0 /* Gargoyle: Modified from upstream. */
     if (create_iter != VM_INVALID_PROP)
+#else
+    if (create_iter != 0)
+#endif
     {
         /* 
          *   generate a call to the createIterator() property on the


### PR DESCRIPTION
VM_INVALID_PROP is a uint16_t, but create_iter is a pointer, so the
comparison is invalid. Instead, create_iter should be compared against a
null pointer constant. 0 is used instead of nullptr for consistency with
the rest of the TADS codebase.