### PR TITLE
Support control-left and control-right for skipping words.

### DIFF
--- a/garglk/glk.h
+++ b/garglk/glk.h
@@ -482,5 +482,7 @@ extern void garglk_set_reversevideo_stream(strid_t str, glui32 reverse);
 #define keycode_Erase               (0xffffef7f)
 #define keycode_MouseWheelUp        (0xffffeffe)
 #define keycode_MouseWheelDown      (0xffffefff)
+#define keycode_SkipWordLeft        (0xfffff000)
+#define keycode_SkipWordRight       (0xfffff001)
 
 #endif /* GLK_H */

--- a/garglk/launchmac.m
+++ b/garglk/launchmac.m
@@ -147,6 +147,8 @@ char *winfilters[] =
 - (IBAction) cut: (id) sender;
 - (IBAction) copy: (id) sender;
 - (IBAction) paste: (id) sender;
+- (void) moveWordBackward: (id) sender;
+- (void) moveWordForward: (id) sender;
 - (IBAction) performZoom: (id) sender;
 - (void) performRefresh: (NSNotification *) notice;
 - (NSString *) openFileDialog: (NSString *) prompt
@@ -212,10 +214,8 @@ static BOOL isTextbufferEvent(NSEvent * evt)
     /* check for arrow keys */
     if ([evt modifierFlags] & NSFunctionKeyMask)
     {
-        /* modified keys for scrolling */
-        if ([evt modifierFlags] & NSCommandKeyMask ||
-            [evt modifierFlags] & NSAlternateKeyMask ||
-            [evt modifierFlags] & NSControlKeyMask)
+        /* alt/option modified key */
+        if ([evt modifierFlags] & NSAlternateKeyMask)
         {
             switch ([evt keyCode])
             {
@@ -227,8 +227,8 @@ static BOOL isTextbufferEvent(NSEvent * evt)
             }
         }
 
-        /* unmodified keys for line editing */
-        else
+        /* command modified key */
+        if ([evt modifierFlags] & NSCommandKeyMask)
         {
             switch ([evt keyCode])
             {
@@ -238,6 +238,16 @@ static BOOL isTextbufferEvent(NSEvent * evt)
                 case NSKEY_UP    : return NO;
                 default: break;
             }
+        }
+
+        /* unmodified key for line editing */
+        switch ([evt keyCode])
+        {
+            case NSKEY_LEFT  : return NO;
+            case NSKEY_RIGHT : return NO;
+            case NSKEY_DOWN  : return NO;
+            case NSKEY_UP    : return NO;
+            default: break;
         }
     }
 
@@ -416,6 +426,34 @@ static BOOL isTextbufferEvent(NSEvent * evt)
                    charactersIgnoringModifiers: @"V"
                                      isARepeat: NO
                                        keyCode: NSKEY_V]];
+}
+
+- (void) moveWordBackward: (id) sender
+{
+    [self sendEvent: [NSEvent keyEventWithType: NSKeyDown
+                                      location: NSZeroPoint
+                                 modifierFlags: NSAlternateKeyMask
+                                     timestamp: NSTimeIntervalSince1970
+                                  windowNumber: [self windowNumber]
+                                       context: [self graphicsContext]
+                                    characters: @""
+                   charactersIgnoringModifiers: @""
+                                     isARepeat: NO
+                                       keyCode: NSKEY_LEFT]];
+}
+
+- (void) moveWordForward: (id) sender
+{
+    [self sendEvent: [NSEvent keyEventWithType: NSKeyDown
+                                      location: NSZeroPoint
+                                 modifierFlags: NSAlternateKeyMask
+                                     timestamp: NSTimeIntervalSince1970
+                                  windowNumber: [self windowNumber]
+                                       context: [self graphicsContext]
+                                    characters: @""
+                   charactersIgnoringModifiers: @""
+                                     isARepeat: NO
+                                       keyCode: NSKEY_RIGHT]];
 }
 
 - (IBAction) performZoom: (id) sender

--- a/garglk/sysefl.c
+++ b/garglk/sysefl.c
@@ -449,6 +449,8 @@ static void onkeydown(void *data, Evas *e, Evas_Object *obj, void *event_info)
         else if ( !strcmp( eekd->keyname, "u" ) ) gli_input_handle_key(keycode_Escape);
         else if ( !strcmp( eekd->keyname, "v" ) ) winclipreceive(CLIPBOARD);
         else if ( !strcmp( eekd->keyname, "x" ) ) winclipsend(CLIPBOARD);
+        else if ( !strcmp( eekd->key, "Left" ) ) gli_input_handle_key(keycode_SkipWordLeft);
+        else if ( !strcmp( eekd->key, "Right" ) ) gli_input_handle_key(keycode_SkipWordRight);
 
         return;
     }

--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -438,6 +438,8 @@ static void onkeydown(GtkWidget *widget, GdkEventKey *event, void *data)
             case GDK_u: case GDK_U: gli_input_handle_key(keycode_Escape); break;
             case GDK_v: case GDK_V: winclipreceive(CLIPBOARD); break;
             case GDK_x: case GDK_X: winclipsend(CLIPBOARD); break;
+            case GDK_Left: gli_input_handle_key(keycode_SkipWordLeft); break;
+            case GDK_Right: gli_input_handle_key(keycode_SkipWordRight); break;
         }
 
         return;

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -430,10 +430,21 @@ void winkey(NSEvent *evt)
     /* check for arrow keys */
     if ([evt modifierFlags] & NSFunctionKeyMask)
     {
-        /* modified keys for scrolling */
-        if ([evt modifierFlags] & NSCommandKeyMask
-            || [evt modifierFlags] & NSAlternateKeyMask
-            || [evt modifierFlags] & NSControlKeyMask)
+        /* alt/option modified key */
+        if ([evt modifierFlags] & NSAlternateKeyMask)
+        {
+            switch ([evt keyCode])
+            {
+                case NSKEY_LEFT  : gli_input_handle_key(keycode_SkipWordLeft);  return;
+                case NSKEY_RIGHT : gli_input_handle_key(keycode_SkipWordRight); return;
+                case NSKEY_DOWN  : gli_input_handle_key(keycode_PageDown);      return;
+                case NSKEY_UP    : gli_input_handle_key(keycode_PageUp);        return;
+                default: break;
+            }
+        }
+
+        /* command modified key */
+        if ([evt modifierFlags] & NSCommandKeyMask)
         {
             switch ([evt keyCode])
             {
@@ -445,17 +456,14 @@ void winkey(NSEvent *evt)
             }
         }
 
-        /* unmodified keys for line editing */
-        else
+        /* unmodified key for line editing */
+        switch ([evt keyCode])
         {
-            switch ([evt keyCode])
-            {
-                case NSKEY_LEFT  : gli_input_handle_key(keycode_Left);  return;
-                case NSKEY_RIGHT : gli_input_handle_key(keycode_Right); return;
-                case NSKEY_DOWN  : gli_input_handle_key(keycode_Down);  return;
-                case NSKEY_UP    : gli_input_handle_key(keycode_Up);    return;
-                default: break;
-            }
+            case NSKEY_LEFT  : gli_input_handle_key(keycode_Left);  return;
+            case NSKEY_RIGHT : gli_input_handle_key(keycode_Right); return;
+            case NSKEY_DOWN  : gli_input_handle_key(keycode_Down);  return;
+            case NSKEY_UP    : gli_input_handle_key(keycode_Up);    return;
+            default: break;
         }
     }
 

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -802,33 +802,45 @@ viewproc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
     }
 
     case WM_KEYDOWN:
-
-    switch (wParam)
     {
-    case VK_PRIOR: gli_input_handle_key(keycode_PageUp); break;
-    case VK_NEXT: gli_input_handle_key(keycode_PageDown); break;
-    case VK_HOME: gli_input_handle_key(keycode_Home); break;
-    case VK_END: gli_input_handle_key(keycode_End); break;
-    case VK_LEFT: gli_input_handle_key(keycode_Left); break;
-    case VK_RIGHT: gli_input_handle_key(keycode_Right); break;
-    case VK_UP: gli_input_handle_key(keycode_Up); break;
-    case VK_DOWN: gli_input_handle_key(keycode_Down); break;
-    case VK_ESCAPE: gli_input_handle_key(keycode_Escape); break;
-    case VK_DELETE: gli_input_handle_key(keycode_Erase); break;
-    case VK_F1: gli_input_handle_key(keycode_Func1); break;
-    case VK_F2: gli_input_handle_key(keycode_Func2); break;
-    case VK_F3: gli_input_handle_key(keycode_Func3); break;
-    case VK_F4: gli_input_handle_key(keycode_Func4); break;
-    case VK_F5: gli_input_handle_key(keycode_Func5); break;
-    case VK_F6: gli_input_handle_key(keycode_Func6); break;
-    case VK_F7: gli_input_handle_key(keycode_Func7); break;
-    case VK_F8: gli_input_handle_key(keycode_Func8); break;
-    case VK_F9: gli_input_handle_key(keycode_Func9); break;
-    case VK_F10: gli_input_handle_key(keycode_Func10); break;
-    case VK_F11: gli_input_handle_key(keycode_Func11); break;
-    case VK_F12: gli_input_handle_key(keycode_Func12); break;
+        if (GetKeyState(VK_CONTROL) < 0)
+        {
+            switch (wParam)
+            {
+            case VK_LEFT: gli_input_handle_key(keycode_SkipWordLeft); break;
+            case VK_RIGHT: gli_input_handle_key(keycode_SkipWordRight); break;
+            }
+        }
+        else
+        {
+            switch (wParam)
+            {
+            case VK_PRIOR: gli_input_handle_key(keycode_PageUp); break;
+            case VK_NEXT: gli_input_handle_key(keycode_PageDown); break;
+            case VK_HOME: gli_input_handle_key(keycode_Home); break;
+            case VK_END: gli_input_handle_key(keycode_End); break;
+            case VK_LEFT: gli_input_handle_key(keycode_Left); break;
+            case VK_RIGHT: gli_input_handle_key(keycode_Right); break;
+            case VK_UP: gli_input_handle_key(keycode_Up); break;
+            case VK_DOWN: gli_input_handle_key(keycode_Down); break;
+            case VK_ESCAPE: gli_input_handle_key(keycode_Escape); break;
+            case VK_DELETE: gli_input_handle_key(keycode_Erase); break;
+            case VK_F1: gli_input_handle_key(keycode_Func1); break;
+            case VK_F2: gli_input_handle_key(keycode_Func2); break;
+            case VK_F3: gli_input_handle_key(keycode_Func3); break;
+            case VK_F4: gli_input_handle_key(keycode_Func4); break;
+            case VK_F5: gli_input_handle_key(keycode_Func5); break;
+            case VK_F6: gli_input_handle_key(keycode_Func6); break;
+            case VK_F7: gli_input_handle_key(keycode_Func7); break;
+            case VK_F8: gli_input_handle_key(keycode_Func8); break;
+            case VK_F9: gli_input_handle_key(keycode_Func9); break;
+            case VK_F10: gli_input_handle_key(keycode_Func10); break;
+            case VK_F11: gli_input_handle_key(keycode_Func11); break;
+            case VK_F12: gli_input_handle_key(keycode_Func12); break;
+            }
+        }
+        return 0;
     }
-    return 0;
 
     /* unicode encoded chars, including escape, backspace etc... */
     case WM_UNICHAR:

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -1676,6 +1676,20 @@ void gcmd_buffer_accept_readline(window_t *win, glui32 arg)
             dwin->incurs = dwin->numchars;
             break;
 
+        case keycode_SkipWordLeft:
+            while (dwin->incurs > dwin->infence && dwin->chars[dwin->incurs - 1] == ' ')
+                dwin->incurs--;
+            while (dwin->incurs > dwin->infence && dwin->chars[dwin->incurs - 1] != ' ')
+                dwin->incurs--;
+            break;
+
+        case keycode_SkipWordRight:
+            while (dwin->incurs < dwin->numchars && dwin->chars[dwin->incurs] != ' ')
+                dwin->incurs++;
+            while (dwin->incurs < dwin->numchars && dwin->chars[dwin->incurs] == ' ')
+                dwin->incurs++;
+            break;
+
             /* Delete keys, during line input. */
 
         case keycode_Delete:


### PR DESCRIPTION
This addresses issue #272, which requests control-left and control-right to skip words.  There are a couple things:

* Pseudo keycodes are used to represent control left and control right. A more “proper” approach would probably be to fully support modifiers, but that would cause a somewhat large change in the input system that I'm not ready to do.
* EFL, Windows, and gtk all have support here, but OS X does not. I don't have access to an OS X machine, nor do I know how it's supposed to behave, whether this ticket applies to it at all.  If anybody wants to contribue OS X support that would be great but I will also merge without it if not.
* Only spaces count as word separators.  I don't think this is really a problem.