### PR TITLE
Get Windows installer in shape for a release

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -16,8 +16,6 @@ SetCompressor lzma
 !include MultiUser.nsh
 !include MUI.nsh
 !include Unix2DOS.nsh
-!include FontReg.nsh
-!include FontName.nsh
 
 ;
 ; The installer theme
@@ -128,28 +126,6 @@ Section "DoInstall"
     WriteRegStr HKCR "garglk" "" "URL:Gargoyle File Protocol"
     WriteRegStr HKCR "garglk" "URL Protocol" ""
     WriteRegStr HKCR "garglk\shell\open\command" "" "$INSTDIR\gargoyle.exe $\"%1$\""
-
-SectionEnd
-
-Section "Fonts"
-    StrCpy $FONT_DIR $FONTS
-    !insertmacro InstallFONFont "fonts\LuxiMono-Regular.ttf" "Luxi Mono Regular (TrueType)"
-    !insertmacro InstallFONFont "fonts\LuxiMono-Bold.ttf" "Luxi Mono Bold (TrueType)"
-    !insertmacro InstallFONFont "fonts\LuxiMono-Oblique.ttf" "Luxi Mono Oblique (TrueType)"
-    !insertmacro InstallFONFont "fonts\LuxiMono-BoldOblique.ttf" "Luxi Mono Bold Oblique (TrueType)"
-    !insertmacro InstallFONFont "fonts\CharterBT-Roman.ttf" "Bitstream Charter (TrueType)"
-    !insertmacro InstallFONFont "fonts\CharterBT-Bold.ttf" "Bitstream Charter Bold (TrueType)"
-    !insertmacro InstallFONFont "fonts\CharterBT-Italic.ttf" "Bitstream Charter Italic (TrueType)"
-    !insertmacro InstallFONFont "fonts\CharterBT-BoldItalic.ttf" "Bitstream Charter Bold Italic (TrueType)"
-    !insertmacro InstallFONFont "fonts\LiberationMono-Regular.ttf" "Liberation Mono (TrueType)"
-    !insertmacro InstallFONFont "fonts\LiberationMono-Bold.ttf" "Liberation Mono Bold (TrueType)"
-    !insertmacro InstallFONFont "fonts\LiberationMono-Italic.ttf" "Liberation Mono Italic (TrueType)"
-    !insertmacro InstallFONFont "fonts\LiberationMono-BoldItalic.ttf" "Liberation Mono Bold Italic (TrueType)"
-    !insertmacro InstallFONFont "fonts\LinLibertine_Re-4.7.5.otf" "LinLibertineO (TrueType)"
-    !insertmacro InstallFONFont "fonts\LinLibertine_Bd-4.1.5.otf" "LinLibertineOB (TrueType)"
-    !insertmacro InstallFONFont "fonts\LinLibertine_It-4.2.6.otf" "LinLibertineOI (TrueType)"
-    !insertmacro InstallFONFont "fonts\LinLibertine_BI-4.1.0.otf" "LinLibertineOBI (TrueType)"
-    SendMessage ${HWND_BROADCAST} ${WM_FONTCHANGE} 0 0 /TIMEOUT=5000
 
 SectionEnd
 

--- a/windows.sh
+++ b/windows.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# This script will cross compile Gargoyle for Windows using MinGW, and
+# build an installer for it using NSIS through Wine. This script makes
+# assumptions about the locations of MinGW and Wine, so may need to be
+# tweaked to get it to properly work.
+
+set -e
+
+[[ -e build/dist ]] && exit 1
+
+dlls="libstdc++-6.dll libgcc_s_sjlj-1.dll libwinpthread-1.dll"
+makensis="${HOME}/.wine/drive_c/Program Files (x86)/NSIS/makensis"
+
+jam -sC++=i686-w64-mingw32-g++ -sCC=i686-w64-mingw32-gcc -sOS=MINGW -sMINGWARCH=i686-w64-mingw32 -sCROSS=1 -dx
+jam -sC++=i686-w64-mingw32-g++ -sCC=i686-w64-mingw32-gcc -sOS=MINGW -sMINGWARCH=i686-w64-mingw32 -sCROSS=1 -dx install
+
+for dll in ${dlls}
+do
+  cp "/usr/i686-w64-mingw32/bin/${dll}" build/dist
+done
+
+wine "${makensis}" installer.nsi


### PR DESCRIPTION
I've created a couple of test versions of a new Windows installer, but the process was manual.  In order to ensure I don't forget how to do a Windows build, and to make sure that the Windows build process is consistent, I'm adding a small script to do the builds.  This is tailored to my MinGW/Wine environment.  Since nobody else is doing Windows builds, I have no problem not worrying about "portability" to other MinGW/Wine environments, although I'd have no problem with anybody making it more generic.  My only concern now, however, is having a working Windows installer for the next release.