### PR TITLE
Enable `fullscreen` configuration option for macOS

### DIFF
--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -44,7 +44,7 @@ sound         1               # enable sound
 
 lcd           1               # 0=grayscale 1=subpixel
 
-fullscreen    0               # set to 1 for fullscreen (Windows only)
+fullscreen    0               # set to 1 for fullscreen (Windows and macOS only)
 
 
 #===============================================================================

--- a/garglk/launchmac.m
+++ b/garglk/launchmac.m
@@ -605,6 +605,7 @@ static BOOL isTextbufferEvent(NSEvent * evt)
 - (BOOL) initWindow: (pid_t) processID
               width: (unsigned int) width
              height: (unsigned int) height
+         fullscreen: (BOOL) fullscreen
 {
     if (!(processID > 0))
         return NO;
@@ -622,6 +623,8 @@ static BOOL isTextbufferEvent(NSEvent * evt)
     [window center];
     [window setReleasedWhenClosed: YES];
     [window setDelegate: self];
+    if (fullscreen)
+        [window toggleFullScreen: self];
 
     [windows setObject: window forKey: [NSNumber numberWithInt: processID]];
 

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -61,7 +61,8 @@
 
 - (BOOL) initWindow: (pid_t) processID
               width: (unsigned int) width
-             height: (unsigned int) height;
+             height: (unsigned int) height
+         fullscreen: (BOOL) fullscreen;
 
 - (NSEvent *) getWindowEvent: (pid_t) processID;
 

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -393,7 +393,8 @@ void winopen(void)
 
     [gargoyle initWindow: processID
                    width: defw
-                  height: defh];
+                  height: defh
+              fullscreen: gli_conf_fullscreen];
 
     wintitle();
     winresize();


### PR DESCRIPTION
Enable the following configuration option for macOS:

```
fullscreen    1               # set to 1 for fullscreen
```
