### PR TITLE
Enable DPI awareness on Windows, to support HiDPI displays 

### DIFF
--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -275,6 +275,7 @@ void winclipreceive(void)
 void wininit(int *argc, char **argv)
 {
     WNDCLASS wc;
+    int pixX = 0;
 
     argv0 = argv[0];
 
@@ -288,11 +289,11 @@ void wininit(int *argc, char **argv)
     }
 
     // Scale settings, assuming they are chosen to match a 96 DPI display
-    int pixX;
     HDC screen = GetDC(0);
     pixX = GetDeviceCaps(screen, LOGPIXELSX);
     ReleaseDC(0, screen);
-    gli_zoom = (float) pixX / 96.0;
+    if (pixX >= 72)
+        gli_zoom = (float) pixX / 96.0;
 
     /* Create and register frame window class */
     wc.style = 0;

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -70,6 +70,15 @@ static char *winfilters[] =
     "All files (*.*)\0*.*\0\0",
 };
 
+// MingW does not include SetProcessDpiAwareness, so declare it here
+typedef enum PROCESS_DPI_AWARENESS
+{
+    PROCESS_DPI_UNAWARE = 0,
+    PROCESS_SYSTEM_DPI_AWARE = 1,
+    PROCESS_PER_MONITOR_DPI_AWARE = 2
+} PROCESS_DPI_AWARENESS;
+typedef HRESULT (WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);
+
 void glk_request_timer_events(glui32 millisecs)
 {
     if (timerid != -1)
@@ -268,6 +277,22 @@ void wininit(int *argc, char **argv)
     WNDCLASS wc;
 
     argv0 = argv[0];
+
+    /* enable DPI awareness for better looking fonts */
+    HMODULE shcore = LoadLibraryA("Shcore.dll");
+    if (shcore)
+    {
+        SETPROCESSDPIAWARENESS_T SetProcessDpiAwareness = (SETPROCESSDPIAWARENESS_T) GetProcAddress(shcore, "SetProcessDpiAwareness");
+        if (SetProcessDpiAwareness)
+            SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+    }
+
+    // Scale settings, assuming they are chosen to match a 96 DPI display
+    int pixX;
+    HDC screen = GetDC(0);
+    pixX = GetDeviceCaps(screen, LOGPIXELSX);
+    ReleaseDC(0, screen);
+    gli_zoom = (float) pixX / 96.0;
 
     /* Create and register frame window class */
     wc.style = 0;


### PR DESCRIPTION
Enables DPI awareness to avoid ugly pixel-based scaling. Based on the recent changes made to support Retina displays on Macs.