### PR TITLE
Support HiDPI displays on Windows

### DIFF
--- a/garglk/config.c
+++ b/garglk/config.c
@@ -608,12 +608,12 @@ void gli_startup(int argc, char *argv[])
 {
     gli_baseline = 0;
 
-    wininit(&argc, argv);
-
     if (argc > 1)
         glkunix_set_base_file(argv[argc-1]);
 
     gli_read_config(argc, argv);
+
+    wininit(&argc, argv);
 
     memcpy(gli_tstyles_def, gli_tstyles, sizeof(gli_tstyles_def));
     memcpy(gli_gstyles_def, gli_gstyles, sizeof(gli_gstyles_def));

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -46,7 +46,7 @@ lcd           1               # 0=grayscale 1=subpixel
 
 fullscreen    0               # set to 1 for fullscreen (Windows/Unix only)
 
-hires         1               # set to 1 to enable Retina display on macOS
+hires         1               # set to 1 to enable Retina display (macOS) / HiDPI (Windows)
 zoom          1.0             # set display zoom
 
 

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -275,6 +275,7 @@ void winclipreceive(void)
 void wininit(int *argc, char **argv)
 {
     WNDCLASS wc;
+    int pixX = 0;
 
     argv0 = argv[0];
 
@@ -288,11 +289,11 @@ void wininit(int *argc, char **argv)
     }
 
     // Scale settings, assuming they are chosen to match a 96 DPI display
-    int pixX;
     HDC screen = GetDC(0);
     pixX = GetDeviceCaps(screen, LOGPIXELSX);
     ReleaseDC(0, screen);
-    gli_zoom = (float) pixX / 96.0;
+    if (pixX >= 72)
+        gli_zoom = (float) pixX / 96.0;
 
     /* Create and register frame window class */
     wc.style = 0;

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -70,6 +70,15 @@ static char *winfilters[] =
     "All files (*.*)\0*.*\0\0",
 };
 
+// MingW does not include SetProcessDpiAwareness, so declare it here
+typedef enum PROCESS_DPI_AWARENESS
+{
+    PROCESS_DPI_UNAWARE = 0,
+    PROCESS_SYSTEM_DPI_AWARE = 1,
+    PROCESS_PER_MONITOR_DPI_AWARE = 2
+} PROCESS_DPI_AWARENESS;
+typedef HRESULT (WINAPI * SETPROCESSDPIAWARENESS_T)(PROCESS_DPI_AWARENESS);
+
 void glk_request_timer_events(glui32 millisecs)
 {
     if (timerid != -1)
@@ -268,6 +277,22 @@ void wininit(int *argc, char **argv)
     WNDCLASS wc;
 
     argv0 = argv[0];
+
+    /* enable DPI awareness for better looking fonts */
+    HMODULE shcore = LoadLibraryA("Shcore.dll");
+    if (shcore)
+    {
+        SETPROCESSDPIAWARENESS_T SetProcessDpiAwareness = (SETPROCESSDPIAWARENESS_T) GetProcAddress(shcore, "SetProcessDpiAwareness");
+        if (SetProcessDpiAwareness)
+            SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+    }
+
+    // Scale settings, assuming they are chosen to match a 96 DPI display
+    int pixX;
+    HDC screen = GetDC(0);
+    pixX = GetDeviceCaps(screen, LOGPIXELSX);
+    ReleaseDC(0, screen);
+    gli_zoom = (float) pixX / 96.0;
 
     /* Create and register frame window class */
     wc.style = 0;

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -280,20 +280,25 @@ void wininit(int *argc, char **argv)
     argv0 = argv[0];
 
     /* enable DPI awareness for better looking fonts */
-    HMODULE shcore = LoadLibraryA("Shcore.dll");
-    if (shcore)
+    if (gli_hires)
     {
-        SETPROCESSDPIAWARENESS_T SetProcessDpiAwareness = (SETPROCESSDPIAWARENESS_T) GetProcAddress(shcore, "SetProcessDpiAwareness");
-        if (SetProcessDpiAwareness)
-            SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+        HMODULE shcore = LoadLibraryA("Shcore.dll");
+        if (shcore)
+        {
+            SETPROCESSDPIAWARENESS_T SetProcessDpiAwareness =
+                (SETPROCESSDPIAWARENESS_T) GetProcAddress(shcore, "SetProcessDpiAwareness");
+            if (SetProcessDpiAwareness)
+                SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
+        }
+
+        /* Scale settings, assuming they are chosen to match a 96 DPI display */
+        HDC screen = GetDC(0);
+        pixX = GetDeviceCaps(screen, LOGPIXELSX);
+        ReleaseDC(0, screen);
+        if (pixX >= 72)
+            gli_backingscalefactor = (float) pixX / 96.0;
     }
 
-    // Scale settings, assuming they are chosen to match a 96 DPI display
-    HDC screen = GetDC(0);
-    pixX = GetDeviceCaps(screen, LOGPIXELSX);
-    ReleaseDC(0, screen);
-    if (pixX >= 72)
-        gli_zoom = (float) pixX / 96.0;
 
     /* Create and register frame window class */
     wc.style = 0;


### PR DESCRIPTION
Enables DPI awareness to avoid ugly pixel-based scaling. Based on the recent changes made to support Retina displays on Macs.

Required a change in the initialization order: reading the configuration (gli_read_config) must be done before initializing the system windows (wininit). Otherwise, the configuration option "hires" could not be supported on Windows.