### PR TITLE
Fix issue 315: Mouse Input Events broken by retina/zoom change

### DIFF
--- a/garglk/config.c
+++ b/garglk/config.c
@@ -623,21 +623,21 @@ void gli_startup(int argc, char *argv[])
 
     if (gli_hires)
         gli_zoom *= gli_backingscalefactor;
-    gli_baseline = gli_baseline * gli_zoom + 0.5;
+    gli_baseline = gli_zoom_int(gli_baseline);
     gli_conf_monosize = gli_conf_monosize * gli_zoom;
     gli_conf_propsize = gli_conf_propsize * gli_zoom;
-    gli_leading = gli_leading * gli_zoom + 0.5;
-    gli_scroll_width_save = gli_scroll_width_save * gli_zoom + 0.5;
-    gli_tmarginx = gli_tmarginx * gli_zoom + 0.5;
-    gli_tmarginy = gli_tmarginy * gli_zoom + 0.5;
-    gli_wborderx = gli_wborderx * gli_zoom + 0.5;
-    gli_wbordery = gli_wbordery * gli_zoom + 0.5;
-    gli_wmarginx = gli_wmarginx * gli_zoom + 0.5;
-    gli_wmarginx_save = gli_wmarginx_save * gli_zoom + 0.5;
-    gli_wmarginy = gli_wmarginy * gli_zoom + 0.5;
-    gli_wmarginy_save = gli_wmarginy_save * gli_zoom + 0.5;
-    gli_wpaddingx = gli_wpaddingx * gli_zoom + 0.5;
-    gli_wpaddingy = gli_wpaddingy * gli_zoom + 0.5;
+    gli_leading = gli_zoom_int(gli_leading);
+    gli_scroll_width_save = gli_zoom_int(gli_scroll_width_save);
+    gli_tmarginx = gli_zoom_int(gli_tmarginx);
+    gli_tmarginy = gli_zoom_int(gli_tmarginy);
+    gli_wborderx = gli_zoom_int(gli_wborderx);
+    gli_wbordery = gli_zoom_int(gli_wbordery);
+    gli_wmarginx = gli_zoom_int(gli_wmarginx);
+    gli_wmarginx_save = gli_zoom_int(gli_wmarginx_save);
+    gli_wmarginy = gli_zoom_int(gli_wmarginy);
+    gli_wmarginy_save = gli_zoom_int(gli_wmarginy_save);
+    gli_wpaddingx = gli_zoom_int(gli_wpaddingx);
+    gli_wpaddingy = gli_zoom_int(gli_wpaddingy);
 
     gli_initialize_tts();
     if (gli_conf_speak)

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -89,8 +89,8 @@ typedef struct window_graphics_s window_graphics_t;
 #define HISTORYLEN 100
 
 #define GLI_SUBPIX 8
-#define GLI_ZOOM(x) ((x) * gli_zoom + 0.5)
-#define GLI_UNZOOM(x) ((x) / gli_zoom + 0.5)
+#define gli_zoom_int(x) ((x) * gli_zoom + 0.5)
+#define gli_unzoom_int(x) ((x) / gli_zoom + 0.5)
 
 extern char gli_program_name[256];
 extern char gli_program_info[256];

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -89,6 +89,8 @@ typedef struct window_graphics_s window_graphics_t;
 #define HISTORYLEN 100
 
 #define GLI_SUBPIX 8
+#define GLI_ZOOM(x) ((x) * gli_zoom + 0.5)
+#define GLI_UNZOOM(x) ((x) / gli_zoom + 0.5)
 
 extern char gli_program_name[256];
 extern char gli_program_info[256];

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -245,7 +245,7 @@ winid_t glk_window_open(winid_t splitwin,
         case wintype_Graphics:
             newwin->data = win_graphics_create(newwin);
             if (method & winmethod_Fixed)
-                size = size * gli_zoom + 0.5;
+                size = gli_zoom_int(size);
             break;
         case wintype_Pair:
             gli_strict_warning("window_open: cannot open pair window directly");
@@ -479,7 +479,7 @@ void glk_window_get_arrangement(window_t *win, glui32 *method, glui32 *size,
     {
         *size = dwin->size;
         if (dwin->key && (dwin->key->type == wintype_Graphics) && (dwin->dir == winmethod_Fixed))
-            *size = *size / gli_zoom + 0.5;
+            *size = gli_unzoom_int(*size);
     }
     if (keywin)
     {
@@ -570,7 +570,7 @@ void glk_window_set_arrangement(window_t *win, glui32 method, glui32 size, winid
     dwin->key = key;
     dwin->size = size;
     if (key && (key->type == wintype_Graphics) && (newdir == winmethod_Fixed))
-        dwin->size = dwin->size * gli_zoom + 0.5;
+        dwin->size = gli_zoom_int(dwin->size);
     dwin->wborder = ((method & winmethod_BorderMask) == winmethod_Border);
 
     dwin->vertical = (dwin->dir == winmethod_Left || dwin->dir == winmethod_Right);
@@ -609,8 +609,8 @@ void glk_window_get_size(window_t *win, glui32 *width, glui32 *height)
             hgt = hgt / gli_cellh;
             break;
         case wintype_Graphics:
-            wid = (win->bbox.x1 - win->bbox.x0) / gli_zoom + 0.5;
-            hgt = (win->bbox.y1 - win->bbox.y0) / gli_zoom + 0.5;
+            wid = gli_unzoom_int((win->bbox.x1 - win->bbox.x0));
+            hgt = gli_unzoom_int(win->bbox.y1 - win->bbox.y0);
             break;
     }
 

--- a/garglk/wingfx.c
+++ b/garglk/wingfx.c
@@ -176,7 +176,7 @@ void win_graphics_click(window_graphics_t *dwin, int sx, int sy)
 
     if (win->mouse_request)
     {
-        gli_event_store(evtype_MouseInput, win, x, y);
+        gli_event_store(evtype_MouseInput, win, GLI_UNZOOM(x), GLI_UNZOOM(y));
         win->mouse_request = FALSE;
         if (gli_conf_safeclicks)
             gli_forceclick = 1;
@@ -184,7 +184,7 @@ void win_graphics_click(window_graphics_t *dwin, int sx, int sy)
 
     if (win->hyper_request)
     {
-        glui32 linkval = gli_get_hyperlink(sx, sy);
+        glui32 linkval = gli_get_hyperlink(GLI_UNZOOM(sx), GLI_UNZOOM(sy));
         if (linkval)
         {
             gli_event_store(evtype_Hyperlink, win, linkval, 0);

--- a/garglk/wingfx.c
+++ b/garglk/wingfx.c
@@ -176,7 +176,7 @@ void win_graphics_click(window_graphics_t *dwin, int sx, int sy)
 
     if (win->mouse_request)
     {
-        gli_event_store(evtype_MouseInput, win, GLI_UNZOOM(x), GLI_UNZOOM(y));
+        gli_event_store(evtype_MouseInput, win, gli_unzoom_int(x), gli_unzoom_int(y));
         win->mouse_request = FALSE;
         if (gli_conf_safeclicks)
             gli_forceclick = 1;
@@ -184,7 +184,7 @@ void win_graphics_click(window_graphics_t *dwin, int sx, int sy)
 
     if (win->hyper_request)
     {
-        glui32 linkval = gli_get_hyperlink(GLI_UNZOOM(sx), GLI_UNZOOM(sy));
+        glui32 linkval = gli_get_hyperlink(gli_unzoom_int(sx), gli_unzoom_int(sy));
         if (linkval)
         {
             gli_event_store(evtype_Hyperlink, win, linkval, 0);
@@ -202,8 +202,8 @@ glui32 win_graphics_draw_picture(window_graphics_t *dwin,
 {
     picture_t *pic = gli_picture_load(image);
     glui32 hyperlink = dwin->owner->attr.hyper;
-    xpos = xpos * gli_zoom + 0.5;
-    ypos = ypos * gli_zoom + 0.5;
+    xpos = gli_zoom_int(xpos);
+    ypos = gli_zoom_int(ypos);
 
     if (!pic)
         return FALSE;
@@ -219,8 +219,8 @@ glui32 win_graphics_draw_picture(window_graphics_t *dwin,
         imagewidth = pic->w;
         imageheight = pic->h;
     }
-    imagewidth = imagewidth * gli_zoom + 0.5;
-    imageheight = imageheight * gli_zoom + 0.5;
+    imagewidth = gli_zoom_int(imagewidth);
+    imageheight = gli_zoom_int(imageheight);
 
     drawpicture(pic, dwin, xpos, ypos, imagewidth, imageheight, hyperlink);
 
@@ -236,10 +236,10 @@ void win_graphics_erase_rect(window_graphics_t *dwin, int whole,
     int y1 = y0 + height;
     int x, y;
     int hx0, hx1, hy0, hy1;
-    x0 = x0 * gli_zoom + 0.5;
-    y0 = y0 * gli_zoom + 0.5;
-    x1 = x1 * gli_zoom + 0.5;
-    y1 = y1 * gli_zoom + 0.5;
+    x0 = gli_zoom_int(x0);
+    y0 = gli_zoom_int(y0);
+    x1 = gli_zoom_int(x1);
+    y1 = gli_zoom_int(y1);
 
     if (whole)
     {
@@ -286,10 +286,10 @@ void win_graphics_fill_rect(window_graphics_t *dwin, glui32 color,
     unsigned char col[3];
     int x1 = x0 + width;
     int y1 = y0 + height;
-    x0 = x0 * gli_zoom + 0.5;
-    y0 = y0 * gli_zoom + 0.5;
-    x1 = x1 * gli_zoom + 0.5;
-    y1 = y1 * gli_zoom + 0.5;
+    x0 = gli_zoom_int(x0);
+    y0 = gli_zoom_int(y0);
+    x1 = gli_zoom_int(x1);
+    y1 = gli_zoom_int(y1);
     int x, y;
     int hx0, hx1, hy0, hy1;
 

--- a/garglk/winpair.c
+++ b/garglk/winpair.c
@@ -114,7 +114,7 @@ void win_pair_rearrange(window_t *win, rect_t *box)
                             split = dwin->size * gli_cellh;
                         break;
                     case wintype_Graphics:
-                        split = dwin->size;
+                        split = gli_zoom_int(dwin->size);
                         break;
                     default:
                         split = 0;

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -1814,7 +1814,7 @@ glui32 win_textbuffer_draw_picture(window_textbuffer_t *dwin,
     else
     {
         picture_t *tmp;
-        tmp = gli_picture_scale(pic, pic->w * gli_zoom, pic->h * gli_zoom);
+        tmp = gli_picture_scale(pic, gli_zoom_int(pic->w), gli_zoom_int(pic->h));
         pic = tmp;
     }
 


### PR DESCRIPTION
This fixes issue 315 (Mouse Input Events broken by retina/zoom change) and a related issue (graphics were not correctly resized when using a zoom factor > 1)

I also replaced all occurrences of
  ` someExpression * gli_zoom + 0.5`
and 
 ` someExpression / gli_zoom + 0.5 `
with two macros: 
  `gli_zoom_int(someExpression)`
  `gli_unzoom_int(someExpression)`
