### PR TITLE
Restrict number of text columns / rows

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -88,6 +88,10 @@ typedef struct window_graphics_s window_graphics_t;
 #define SCROLLBACK 512
 #define HISTORYLEN 100
 
+/* restrict the number of columns/rows */
+#define MAXCOLS 255
+#define MAXROWS 127
+
 #define GLI_SUBPIX 8
 #define gli_zoom_int(x) ((x) * gli_zoom + 0.5)
 #define gli_unzoom_int(x) ((x) / gli_zoom + 0.5)

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -88,12 +88,6 @@ int isvisible(int x, int y)
     return x >= 0 && x < gli_image_w && y >= 0 && y < gli_image_h;
 }
 
-void clippoint(int x, int y, int *cx, int *cy)
-{
-    *cx = x < 0 ? 0 : (x >= gli_image_w ? gli_image_w : x);
-    *cy = y < 0 ? 0 : (y >= gli_image_h ? gli_image_h : y);
-}
-
 void glk_request_timer_events(glui32 millisecs)
 {
     if (timerid != -1)


### PR DESCRIPTION
Running Gargoyle with either a high resolution or a small font reveals buffer overflows due to buffers that are defined as `char[256]`. 

This set of patches works around this problem by limiting the number of text columns and rows to 255 / 127 on Windows and Gtk. The text is displayed centered when the window is larger than that.

The Gtk version previously limited the maximum window size to 255 columns and 250 rows, which interfered with the fullscreen mode.