### PR TITLE
[macOS] Updates for Xcode 10 and macOS 10.14

### DIFF
--- a/Jamrules
+++ b/Jamrules
@@ -6,6 +6,7 @@ BUILD ?= RELEASE ;
 USESDL ?= yes ;
 USEBABEL ?= yes ;
 MAC_USEHOMEBREW ?= no ;
+MACOS_MIN_VER ?= 10.7 ;
 BUNDLEFONTS ?= yes ;
 USETTS ?= no ;
 
@@ -176,7 +177,7 @@ switch $(PLATFORM)
     case MACOSX :
         Echo "OS is MACOSX (cocoa)" ;
         SUFDLL = .dylib ;
-        MAINARCH = -arch x86_64 -mmacosx-version-min=10.7 ;
+        MAINARCH = -arch x86_64 -mmacosx-version-min=$(MACOS_MIN_VER) ;
         AR = "libtool -static -o" ;
         RM = "touch -c" ;
         CCFLAGS = -Wno-pointer-sign $(MAINARCH) ;

--- a/tads/Jamfile
+++ b/tads/Jamfile
@@ -34,7 +34,7 @@ if $(OS) = LINUX || $(OS) = SOLARIS
 
 if $(OS) = MACOSX
 {
-    SubDirCcFlags -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
+    SubDirCcFlags $(MAINARCH) $(ALTARCH) ;
     LINKFLAGS = -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
 }
 

--- a/terps/Jamfile
+++ b/terps/Jamfile
@@ -185,7 +185,7 @@ if $(MAKE_GEAS) = yes
 
     if $(OS) = MACOSX
     {
-        SubDirCcFlags -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
+        SubDirCcFlags $(MAINARCH) $(ALTARCH) ;
         LINKFLAGS = -headerpad_max_install_names $(MAINARCH) $(ALTARCH) ;
     }
 


### PR DESCRIPTION
Xcode 10 removed support for `libstdc++` so the minimum target SDK needs to be 10.9 (Mavericks) for C++ compilation to work (using `libc++`).

I've updated the `gargoyle_osx.sh` build script to detect which Xcode/SDK version is being used and set the minimum target SDK version accordingly.

I also updated the build script to enable Text-to-Speech support by default and make sure to install the newly added replacements fonts to the application bundle.
