### PR TITLE
Fix grid window unicode input and Glk input array (un)registration.

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -459,8 +459,9 @@ struct window_textgrid_s
 
     /* for line input */
     void *inbuf;	/* unsigned char* for latin1, glui32* for unicode */
+    int inunicode;
     int inorgx, inorgy;
-    int inmax;
+    int inoriglen, inmax;
     int incurs, inlen;
     attr_t origattr;
     gidispatch_rock_t inarrayrock;
@@ -513,6 +514,7 @@ struct window_textbuffer_s
 
     /* for line input */
     void *inbuf;	/* unsigned char* for latin1, glui32* for unicode */
+    int inunicode;
     int inmax;
     long infence;
     long incurs;


### PR DESCRIPTION
This PR fixes a bug in Gargoyle's Unicode input handling that was discovered by running `inputeventest.ulx` unit test (linked below) while trying to reproduce #330. The bug affects Unicode input handling in grid windows and has been reproduced using the latest macOS and Windows builds (Linux was not tested but should have the same problem).

To trigger the bug run the `inputeventest.ulx` game with either `git` or `glulxe` interpreters. Issue the command:

```> PUSH STATUS```

to make the status (grid) window the target of future input commands. Make the interpreter window less than 80 characters wide and then type:

```> GET UNICODE LINE```

As soon as Enter/Return is pressed, the interpreter will exit with a fatal error. `Git` will just exit; `glulxe` will exit printing `Glulxe fatal error: Mismatched array argument in Glk call.` The bug is *not* triggered if the window is wider than 80 characters (the size of the input buffer passed by the game).

The bug is caused when initializing the status/grid window for line input and the Glk window is narrower than the number of characters in the input array passed by the game. Per Glk spec, line input in a grid window is not allowed to wrap so the maximum input count is set to however many characters will fit up to the right edge/margin. Gargoyle then registers the input array with the Glk dispatch mechanism using the truncated length instead of the array's actual length. This length mismatch triggers `git`/`glulxe` error/consistency checks.

As this bug has different behavior than the one described in #330 it's uncertain if this fix will correct that problem. I have not been able to duplicate issue #330 exactly as described.

* [https://eblong.com/zarf/glulx/inputeventtest.ulx](https://eblong.com/zarf/glulx/inputeventtest.ulx)