### PR TITLE
WIP, RFC: Updated SDL sound code (Do not merge)

### DIFF
--- a/garglk/cggestal.c
+++ b/garglk/cggestal.c
@@ -110,7 +110,7 @@ glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr,
             return gli_conf_sound;
 
         case gestalt_Sound2:
-            return FALSE;
+            return gli_conf_sound;
 
         case gestalt_Unicode:
             return TRUE;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -562,6 +562,15 @@ struct glk_schannel_struct
     glui32 loop;
     int notify;
     int buffered;
+	int paused;
+
+	/* for volume fades */
+	int volume_notify;
+	int volume_timeout;
+	int target_volume;
+	double float_volume;
+	double volume_delta;
+	void *timer;
 
     gidispatch_rock_t disprock;
     channel_t *chain_next, *chain_prev;
@@ -778,6 +787,10 @@ void gli_clipboard_copy(glui32 *buf, int len);
 void gli_start_selection(int x, int y);
 void gli_resize_mask(unsigned int x, unsigned int y);
 void gli_move_selection(int x, int y);
+
+void gli_invalidate_volume_timer(void *volume_timer);
+void *gli_create_volume_timer(schanid_t chan, double duration);
+void gli_fade(schanid_t chan);
 
 void attrset(attr_t *attr, glui32 style);
 void attrclear(attr_t *attr);

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -562,15 +562,15 @@ struct glk_schannel_struct
     glui32 loop;
     int notify;
     int buffered;
-	int paused;
+    int paused;
 
-	/* for volume fades */
-	int volume_notify;
-	int volume_timeout;
-	int target_volume;
-	double float_volume;
-	double volume_delta;
-	void *timer;
+    /* for volume fades */
+    int volume_notify;
+    int volume_timeout;
+    int target_volume;
+    double float_volume;
+    double volume_delta;
+    void *timer;
 
     gidispatch_rock_t disprock;
     channel_t *chain_next, *chain_prev;

--- a/garglk/sndsdl.c
+++ b/garglk/sndsdl.c
@@ -48,6 +48,9 @@
 #define giblorb_ID_WAVE (giblorb_make_id('W', 'A', 'V', 'E'))
 
 #define SDL_CHANNELS 64
+#define GLK_MAXVOLUME 0x10000
+#define FADE_GRANULARITY 100
+
 
 static channel_t *gli_channellist = NULL;
 static channel_t *sound_channels[SDL_CHANNELS];
@@ -90,52 +93,60 @@ void gli_initialize_sound(void)
         }
         int channels = Mix_AllocateChannels(SDL_CHANNELS);
         Mix_GroupChannels(0, channels - 1 , FREE);
+
     }
 }
 
 schanid_t glk_schannel_create(glui32 rock)
 {
-    channel_t *chan;
-
-    if (!gli_conf_sound)
-        return NULL;
-    chan = malloc(sizeof(channel_t));
-
-    if (!chan)
-        return NULL;
-
-    chan->rock = rock;
-    chan->status = CHANNEL_IDLE;
-    chan->volume = MIX_MAX_VOLUME;
-    chan->resid = 0;
-    chan->loop = 0;
-    chan->notify = 0;
-    chan->sdl_memory = 0;
-    chan->sdl_rwops = 0;
-    chan->sample = 0;
-    chan->decode = 0;
-    chan->buffered = 0;
-    chan->sdl_channel = -1;
-    chan->music = 0;
-
-    chan->chain_prev = NULL;
-    chan->chain_next = gli_channellist;
-    gli_channellist = chan;
-    if (chan->chain_next)
-        chan->chain_next->chain_prev = chan;
-
-    if (gli_register_obj)
-        chan->disprock = (*gli_register_obj)(chan, gidisp_Class_Schannel);
-    else
-        chan->disprock.ptr = NULL;
-
-    return chan;
+	return  glk_schannel_create_ext(rock, 0x10000);
 }
 
 schanid_t glk_schannel_create_ext(glui32 rock, glui32 volume)
 {
-    /* not implemented */
-    return NULL;
+	channel_t *chan;
+
+	if (!gli_conf_sound)
+		return NULL;
+	chan = malloc(sizeof(channel_t));
+
+	if (!chan)
+		return NULL;
+
+	chan->rock = rock;
+	chan->status = CHANNEL_IDLE;
+	chan->volume = volume >= GLK_MAXVOLUME ? MIX_MAX_VOLUME : round(pow(((double) volume) / GLK_MAXVOLUME, log(4)) * MIX_MAX_VOLUME);
+	chan->resid = 0;
+	chan->loop = 0;
+	chan->notify = 0;
+	chan->sdl_memory = 0;
+	chan->sdl_rwops = 0;
+	chan->sample = 0;
+	chan->decode = 0;
+	chan->buffered = 0;
+	chan->paused = 0;
+	chan->sdl_channel = -1;
+	chan->music = 0;
+
+	chan->volume_notify = 0;
+	chan->volume_timeout = 0;
+	chan->target_volume = 0;
+	chan->float_volume = 0;
+	chan->volume_delta = 0;
+	chan->timer = NULL;
+
+	chan->chain_prev = NULL;
+	chan->chain_next = gli_channellist;
+	gli_channellist = chan;
+	if (chan->chain_next)
+		chan->chain_next->chain_prev = chan;
+
+	if (gli_register_obj)
+		chan->disprock = (*gli_register_obj)(chan, gidisp_Class_Schannel);
+	else
+		chan->disprock.ptr = NULL;
+
+	return chan;
 }
 
 static void cleanup_channel(schanid_t chan)
@@ -247,8 +258,15 @@ glui32 glk_schannel_play(schanid_t chan, glui32 snd)
 glui32 glk_schannel_play_multi(schanid_t *chanarray, glui32 chancount,
         glui32 *sndarray, glui32 soundcount, glui32 notify)
 {
-    /* not implemented */
-    return 0;
+	int i, successes;
+
+	successes = 0;
+
+	for (i = 0; i < chancount; i++)
+	{
+		successes += glk_schannel_play_ext(chanarray[i], sndarray[i], 1, notify);
+	}
+    return successes;
 }
 
 void glk_sound_load_hint(glui32 snd, glui32 flag)
@@ -256,31 +274,107 @@ void glk_sound_load_hint(glui32 snd, glui32 flag)
     /* nop */
 }
 
+/** Start a fade timer */
+void init_fade(schanid_t chan, int volume, int duration, int notify)
+{
+	chan->volume_notify = notify;
+
+	/* Convert requested Glk Volume to SDL Volume */
+	chan->target_volume = volume >= GLK_MAXVOLUME ? MIX_MAX_VOLUME : round(pow(((double) volume) / GLK_MAXVOLUME, log(4)) * MIX_MAX_VOLUME);
+
+	chan->float_volume = (double)chan->volume;
+	chan->volume_delta = (double)(chan->target_volume - chan->volume) / FADE_GRANULARITY;
+
+	chan->volume_timeout = FADE_GRANULARITY;
+
+	chan->timer = gli_create_volume_timer(chan, duration / FADE_GRANULARITY);
+}
+
+/** Make an incremental volume change when the fade timer fires */
+void gli_fade(schanid_t chan)
+{
+	chan->float_volume += chan->volume_delta;
+
+	if (chan->float_volume < 0)
+		chan->float_volume = 0;
+
+	if ((int)chan->float_volume != chan->volume)
+	{
+		chan->volume = (int)chan->float_volume;
+
+		if (chan->status == CHANNEL_SOUND)
+			Mix_Volume(chan->sdl_channel, chan->volume);
+		else if (chan->status == CHANNEL_MUSIC)
+			Mix_VolumeMusic(chan->volume);
+	}
+
+	chan->volume_timeout--;
+
+	/* If the timer has fired FADE_GRANULARITY times, kill it */
+	if (chan->volume_timeout == 0)
+	{
+		if (chan->volume_notify)
+		{
+			gli_event_store(evtype_VolumeNotify, 0,
+                         0, chan->volume_notify);
+        }
+
+		gli_invalidate_volume_timer(chan->timer);
+		chan->timer = NULL;
+
+
+		if (chan->volume != chan->target_volume)
+		{
+			chan->volume = chan->target_volume;
+			if (chan->status == CHANNEL_SOUND)
+				Mix_Volume(chan->sdl_channel, chan->volume);
+			else if (chan->status == CHANNEL_MUSIC)
+				Mix_VolumeMusic(chan->volume);
+		}
+	}
+}
+
+
+
 void glk_schannel_set_volume(schanid_t chan, glui32 vol)
 {
-    if (!chan)
-    {
-        gli_strict_warning("schannel_set_volume: invalid id.");
-        return;
-    }
-    chan->volume = vol > 0x10000 ? MIX_MAX_VOLUME : round(pow(((double) vol) / 0x10000, log(4)) * MIX_MAX_VOLUME);
-    switch (chan->status)
-    {
-        case CHANNEL_IDLE:
-            break;
-        case CHANNEL_SOUND:
-            Mix_Volume(chan->sdl_channel, chan->volume);
-            break;
-        case CHANNEL_MUSIC:
-            Mix_VolumeMusic(chan->volume);
-            break;
-    }
+	glk_schannel_set_volume_ext(chan, vol, 0, 0);
 }
 
 void glk_schannel_set_volume_ext(schanid_t chan, glui32 vol,
         glui32 duration, glui32 notify)
 {
-    /* not implemented */
+	if (!chan)
+	{
+		gli_strict_warning("schannel_set_volume: invalid id.");
+		return;
+	}
+
+	if (!duration)
+	{
+		chan->volume = vol >= GLK_MAXVOLUME ? MIX_MAX_VOLUME : round(pow(((double) vol) / GLK_MAXVOLUME, log(4)) * MIX_MAX_VOLUME);
+
+		switch (chan->status)
+		{
+			case CHANNEL_IDLE:
+				break;
+			case CHANNEL_SOUND:
+				Mix_Volume(chan->sdl_channel, chan->volume);
+				break;
+			case CHANNEL_MUSIC:
+//				if (chan->volume == 0)
+//					Mix_HaltMusic();
+//				else
+					Mix_VolumeMusic(chan->volume);
+				break;
+		}
+	}
+	else
+	{
+		chan->notify = notify;
+
+		init_fade(chan, vol, duration, notify);
+	}
 }
 
 /* Notify the music channel completion */
@@ -291,10 +385,10 @@ static void music_completion_callback()
         gli_strict_warning("music callback failed");
         return;
     }
-    if (music_channel->notify)
+    if (music_channel->notify && music_channel->resid)
     {
-        gli_event_store(evtype_SoundNotify, 0,
-                        music_channel->resid, music_channel->notify);
+		gli_event_store(evtype_SoundNotify, 0,
+                         music_channel->resid, music_channel->notify);
     }
     cleanup_channel(music_channel);
 }
@@ -303,11 +397,19 @@ static void music_completion_callback()
 static void sound_completion_callback(int chan)
 {
     channel_t *sound_channel = sound_channels[chan];
+//	fprintf(stderr, "channel %d finished playback.\n",chan);
     if (!sound_channel || Mix_Playing(chan))
     {
         gli_strict_warning("sound callback failed");
+        if (!sound_channel)
+            fprintf(stderr, "sound_channel %d is NULL\n", chan);
+        if (Mix_Playing(chan))
+		{
+            fprintf(stderr, "Mix_Playing(%d) is TRUE\n", chan);
+		}
         return;
     }
+
     if (!sound_channel->buffered || !sound_channel->decode)
     {
         if (sound_channel->notify)
@@ -514,25 +616,48 @@ static glui32 play_compressed(schanid_t chan, char *ext)
 static glui32 play_mod(schanid_t chan, long len)
 {
     FILE *file;
-    char *tn;
+    char tn[256];
     char *tempdir;
     int music_busy;
 
+    if (chan == NULL)
+        gli_strict_warning("MOD player called with an invalid channel!");
+
+	music_busy = Mix_PlayingMusic();
+
+	if (music_busy)
+	{
+		/* We already checked for music playing on *this* channel in glk_schannel_play_ext */
+		gli_strict_warning("MOD player already in use on another channel!");
+		return 0;
+	}
+
     chan->status = CHANNEL_MUSIC;
     /* The fscking mikmod lib want to read the mod only from disk! */
-    tempdir = getenv("TEMP");
+    tempdir = getenv("TMPDIR");
     if (tempdir == NULL) tempdir = ".";
-    tn = tempnam(tempdir, "gargtmp");
+	//fprintf(stderr, "tempdir = %s\n", tempdir);
+
+    sprintf(tn, "%sXXXXXX", tempdir);
+    mkstemp(tn);
+	sprintf(tn, "%s.mod", tn);
+
+    //fprintf(stderr, "tn = %s\n", tn);
+
     file = fopen(tn, "wb");
     fwrite(chan->sdl_memory, 1, len, file);
-    fclose(file);
+
+    Mix_SetMusicCMD(NULL);
     chan->music = Mix_LoadMUS(tn);
+
+    if(!chan->music)
+        fprintf(stderr, "Mix_LoadMUS(\"%s\"): %s\n", tn, Mix_GetError());
+    // this might be a critical error...
+
+    fclose(file);
     remove(tn);
-    free(tn);
-    music_busy = Mix_PlayingMusic();
-    if (music_busy)
-        gli_strict_warning("MOD player already in use");
-    if (!music_busy && chan->music)
+
+    if (chan->music)
     {
         SDL_LockAudio();
         music_channel = chan;
@@ -552,8 +677,10 @@ static glui32 play_mod(schanid_t chan, long len)
 
 glui32 glk_schannel_play_ext(schanid_t chan, glui32 snd, glui32 repeats, glui32 notify)
 {
-    long len;
+    long len = 0;
     glui32 type;
+	glui32 result = 0;
+	glui32 paused = 0;
     char *buf = 0;
 
     if (!chan)
@@ -561,6 +688,9 @@ glui32 glk_schannel_play_ext(schanid_t chan, glui32 snd, glui32 repeats, glui32 
         gli_strict_warning("schannel_play_ext: invalid id.");
         return 0;
     }
+
+	/* store paused state of channel */
+	paused = chan->paused;
 
     /* stop previous noise */
     glk_schannel_stop(chan);
@@ -572,7 +702,7 @@ glui32 glk_schannel_play_ext(schanid_t chan, glui32 snd, glui32 repeats, glui32 
     type = load_sound_resource(snd, &len, &buf);
 
     chan->sdl_memory = (unsigned char*)buf;
-    chan->sdl_rwops = SDL_RWFromConstMem(buf, len);
+    chan->sdl_rwops = SDL_RWFromConstMem(buf, (int)len);
     chan->notify = notify;
     chan->resid = snd;
     chan->loop = repeats;
@@ -582,36 +712,75 @@ glui32 glk_schannel_play_ext(schanid_t chan, glui32 snd, glui32 repeats, glui32 
         case giblorb_ID_FORM:
         case giblorb_ID_AIFF:
         case giblorb_ID_WAVE:
-            return play_sound(chan);
+            result = play_sound(chan);
             break;
 
         case giblorb_ID_OGG:
-            return play_compressed(chan, "OGG");
+            result = play_compressed(chan, "OGG");
             break;
 
         case giblorb_ID_MP3:
-            return play_compressed(chan, "MP3");
+            result = play_compressed(chan, "MP3");
             break;
 
         case giblorb_ID_MOD:
-            return play_mod(chan, len);
+            result = play_mod(chan, len);
             break;
 
         default:
             gli_strict_warning("schannel_play_ext: unknown resource type.");
     }
 
-    return 0;
+	/* if channel was paused it should be paused again */
+	if (result && paused)
+	{
+		if (paused)
+			fprintf(stderr, "glk_schannel_play_ext: pausing channel again\n");
+		glk_schannel_pause(chan);
+	}
+
+    return result;
 }
 
 void glk_schannel_pause(schanid_t chan)
 {
-    /* not implemented */
+	if (!chan)
+	{
+		gli_strict_warning("schannel_pause: invalid id.");
+		return;
+	}
+
+	switch (chan->status)
+	{
+		case CHANNEL_SOUND:
+			Mix_Pause(chan->sdl_channel);
+			break;
+		case CHANNEL_MUSIC:
+			Mix_PauseMusic();
+			break;
+	}
+
+	chan->paused = 1;
 }
 
 void glk_schannel_unpause(schanid_t chan)
 {
-    /* not implemented */
+	if (!chan)
+	{
+		gli_strict_warning("schannel_unpause: invalid id.");
+		return;
+	}
+	switch (chan->status)
+	{
+		case CHANNEL_SOUND:
+			Mix_Resume(chan->sdl_channel);
+			break;
+		case CHANNEL_MUSIC:
+			Mix_ResumeMusic();
+			break;
+	}
+
+	chan->paused = 0;
 }
 
 void glk_schannel_stop(schanid_t chan)
@@ -623,13 +792,20 @@ void glk_schannel_stop(schanid_t chan)
     }
     SDL_LockAudio();
     chan->buffered = 0;
+	chan->paused = 0;
+	glk_schannel_unpause(chan);
     SDL_UnlockAudio();
     switch (chan->status)
     {
         case CHANNEL_SOUND:
+			Mix_ChannelFinished(NULL);
             Mix_HaltChannel(chan->sdl_channel);
             break;
         case CHANNEL_MUSIC:
+			if (music_channel == chan)
+			{
+				Mix_HookMusicFinished(NULL);
+			}
             Mix_HaltMusic();
             break;
     }

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -139,6 +139,41 @@ void glk_request_timer_events(glui32 millisecs)
     [monitor track: ((double) millisecs) / 1000];
 }
 
+void volume_timer_callback(CFRunLoopTimerRef timer, void *info)
+{
+	gli_fade((schanid_t)info);
+}
+
+void *gli_create_volume_timer(schanid_t chan, double millisecs)
+{
+	CFRunLoopTimerRef timer_ref = NULL;
+
+	CFRunLoopTimerContext context = {0, chan, NULL, NULL, 0};
+
+    if (millisecs)
+    {
+        timer_ref = CFRunLoopTimerCreate(NULL, CFAbsoluteTimeGetCurrent(), millisecs / 1000, 0, 0, &volume_timer_callback, &context);
+        if (timer_ref)
+            CFRunLoopAddTimer([[NSRunLoop currentRunLoop] getCFRunLoop], timer_ref, kCFRunLoopDefaultMode);
+    }
+
+	return (void *)timer_ref;
+}
+
+
+void gli_invalidate_volume_timer(void *volume_timer)
+{
+	CFRunLoopTimerRef timer_ref = (CFRunLoopTimerRef)volume_timer;
+
+	if (timer_ref)
+    {
+        if (CFRunLoopTimerIsValid(timer_ref))
+            CFRunLoopTimerInvalidate(timer_ref);
+        CFRelease(timer_ref);
+    }
+
+}
+
 void wintick(CFRunLoopTimerRef timer, void *info)
 {
     [monitor tick];


### PR DESCRIPTION
At the moment, this is macOS only, but it kind of works. There are basically just two functions that need to be implemented on every platform.

The idea is to implement the full gestalt_Sound2 sound functionality: pause, unpause, play multi, sound faders and so on. The only thing really missing, apart from non-Mac support, is sound and volume notifications. They won't fire until some other event, such as line input, comes along, as reported in #204. It seems like we need to implement a loop that constantly polls for them.

I made a test program [here](https://github.com/angstsmurf/soundtest), but unfortunately it has a bug or triggers a bug in Gargoyle that makes it hang after running the volume fade test (TEST FADE).