### PR TITLE
Updated SDL Sound code

### DIFF
--- a/garglk/Jamfile
+++ b/garglk/Jamfile
@@ -20,6 +20,8 @@ if $(OS) = MINGW
 
 if $(USESDL) = yes
 {
+    SubDirCcFlags
+        -DGARGLK_USESDL ;
     SubDirHdrs $(TOP) support sdl ;
     SubDirHdrs $(TOP) support sdl_sound ;
 }

--- a/garglk/cggestal.c
+++ b/garglk/cggestal.c
@@ -110,7 +110,7 @@ glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr,
             return gli_conf_sound;
 
         case gestalt_Sound2:
-            return FALSE;
+            return gli_conf_sound;
 
         case gestalt_Unicode:
             return TRUE;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -30,6 +30,10 @@
 
 #include <stddef.h>
 
+#ifdef GARGLK_USESDL
+#include <SDL_timer.h>
+#endif
+
 #include "gi_dispa.h"
 
 /* First, we define our own TRUE and FALSE and NULL, because ANSI
@@ -564,6 +568,18 @@ struct glk_schannel_struct
     glui32 loop;
     int notify;
     int buffered;
+
+#ifdef GARGLK_USESDL
+    int paused;
+
+    /* for volume fades */
+    int volume_notify;
+    int volume_timeout;
+    int target_volume;
+    double float_volume;
+    double volume_delta;
+    SDL_TimerID timer;
+#endif
 
     gidispatch_rock_t disprock;
     channel_t *chain_next, *chain_prev;


### PR DESCRIPTION
This implements the extended GLK sound functions:

glk_schannel_create_ext()
glk_schannel_play_multi()
glk_schannel_set_volume_ext()
glk_schannel_pause()
glk_schannel_unpause()

What is still missing is working sound and volume notifications. They won't fire until some other event, such as the player pressing a key or moving the mouse, comes along, as reported in #204. This is implemented in #337, if only for Windows and macOS at present.

These changes only touch the SDL sound backend, and I have not been able to test whether FMOD sound still works.

I've made a test program [here](https://github.com/angstsmurf/soundtest/releases).