### PR TITLE
React to sound and volume notifications immediately

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -796,6 +796,7 @@ void gli_clipboard_copy(glui32 *buf, int len);
 void gli_start_selection(int x, int y);
 void gli_resize_mask(unsigned int x, unsigned int y);
 void gli_move_selection(int x, int y);
+void gli_notification_waiting(void);
 
 void attrset(attr_t *attr, glui32 style);
 void attrclear(attr_t *attr);

--- a/garglk/sndsdl.c
+++ b/garglk/sndsdl.c
@@ -314,6 +314,7 @@ Uint32 volume_timer_callback(Uint32 interval, void *param)
         {
             gli_event_store(evtype_VolumeNotify, 0,
                 0, chan->volume_notify);
+            gli_notification_waiting();
         }
 
         if (!chan->timer)
@@ -420,6 +421,7 @@ static void music_completion_callback()
     {
         gli_event_store(evtype_SoundNotify, 0, music_channel->resid,
             music_channel->notify);
+        gli_notification_waiting();
     }
     cleanup_channel(music_channel);
 }
@@ -441,6 +443,7 @@ static void sound_completion_callback(int chan)
         {
             gli_event_store(evtype_SoundNotify, 0,
                 sound_channel->resid, sound_channel->notify);
+            gli_notification_waiting();
         }
         cleanup_channel(sound_channel);
         sound_channels[chan] = 0;
@@ -456,6 +459,7 @@ static void sound_completion_callback(int chan)
             {
                 gli_event_store(evtype_SoundNotify, 0,
                     sound_channel->resid, sound_channel->notify);
+                gli_notification_waiting();
             }
             cleanup_channel(sound_channel);
             sound_channels[chan] = 0;

--- a/garglk/sysefl.c
+++ b/garglk/sysefl.c
@@ -98,6 +98,11 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
+void gli_notification_waiting(void)
+{
+    /* stub */
+}
+
 void winabort(const char *fmt, ...)
 {
     va_list ap;

--- a/garglk/sysefl.c
+++ b/garglk/sysefl.c
@@ -113,7 +113,7 @@ void gli_notification_waiting(void)
         notifyid = NULL;
     }
 
-    notifyid = ecore_timer_add( 1, do_nothing, NULL );
+    notifyid = ecore_timer_add( 0.001, do_nothing, NULL );
     notify = 1;
 }
 

--- a/garglk/sysefl.c
+++ b/garglk/sysefl.c
@@ -107,14 +107,14 @@ static Eina_Bool do_nothing(void *data)
 
 void gli_notification_waiting(void)
 {
-    if (notifyid != NULL)
+    /* if (notifyid != NULL)
     {
         ecore_timer_del( notifyid );
         notifyid = NULL;
     }
 
     notifyid = ecore_timer_add( 0.001, do_nothing, NULL );
-    notify = 1;
+    notify = 1; */
 }
 
 void winabort(const char *fmt, ...)

--- a/garglk/sysefl.c
+++ b/garglk/sysefl.c
@@ -57,6 +57,8 @@ static char filepath[MaxBuffer];
 
 static Ecore_Timer *timerid = NULL;
 static volatile int timeouts = 0;
+static Ecore_Timer *notifyid = NULL;
+static volatile int notify = 0;
 
 /* buffer for clipboard text */
 static char *cliptext = NULL;
@@ -98,9 +100,21 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
+static Eina_Bool do_nothing(void *data)
+{
+    return ECORE_CALLBACK_CANCEL;
+}
+
 void gli_notification_waiting(void)
 {
-    /* stub */
+    if (notifyid != NULL)
+    {
+        ecore_timer_del( notifyid );
+        notifyid = NULL;
+    }
+
+    notifyid = ecore_timer_add( 1, do_nothing, NULL );
+    notify = 1;
 }
 
 void winabort(const char *fmt, ...)
@@ -631,18 +645,24 @@ void gli_select(event_t *event, int polled)
     if (!polled)
     {
         poll_event_queue = EINA_FALSE;
-        while (gli_curevent->type == evtype_None && !timeouts)
+        while (gli_curevent->type == evtype_None && !timeouts && !notify)
         {
             ecore_main_loop_begin();
             gli_dispatch_event(gli_curevent, polled);
         }
     }
 
-    if (gli_curevent->type == evtype_None && timeouts)
+    if (gli_curevent->type == evtype_None)
     {
-        gli_event_store(evtype_Timer, NULL, 0, 0);
-        gli_dispatch_event(gli_curevent, polled);
-        timeouts = 0;
+        if (notify)
+            notify = 0;
+
+        if (timeouts)
+        {
+            gli_event_store(evtype_Timer, NULL, 0, 0);
+            gli_dispatch_event(gli_curevent, polled);
+            timeouts = 0;
+        }
     }
 
     gli_curevent = NULL;

--- a/garglk/syseoi.c
+++ b/garglk/syseoi.c
@@ -144,6 +144,11 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
+void gli_notification_waiting(void)
+{
+    /* stub */
+}
+
 void winabort(const char *fmt, ...)
 {
     va_list ap;

--- a/garglk/syseoi.c
+++ b/garglk/syseoi.c
@@ -153,14 +153,14 @@ static Eina_Bool do_nothing(void *data)
 
 void gli_notification_waiting(void)
 {
-    if (notifyid != NULL)
+    /* if (notifyid != NULL)
     {
         ecore_timer_del( notifyid );
         notifyid = NULL;
     }
 
     notifyid = ecore_timer_add( 0.001, do_nothing, NULL );
-    notify = 1;
+    notify = 1; */
 }
 
 void winabort(const char *fmt, ...)

--- a/garglk/syseoi.c
+++ b/garglk/syseoi.c
@@ -159,7 +159,7 @@ void gli_notification_waiting(void)
         notifyid = NULL;
     }
 
-    notifyid = ecore_timer_add( 1, do_nothing, NULL );
+    notifyid = ecore_timer_add( 0.001, do_nothing, NULL );
     notify = 1;
 }
 

--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -87,6 +87,11 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
+void gli_notification_waiting(void)
+{
+    /* stub */
+}
+
 void winabort(const char *fmt, ...)
 {
     va_list ap;

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -41,6 +41,8 @@ static volatile int gli_window_alive = TRUE;
 #define kPointingHandCursor 3
 
 void wintick(CFRunLoopTimerRef timer, void *info);
+void winhandler(int signal);
+
 
 @interface GargoyleMonitor : NSObject
 {
@@ -142,6 +144,11 @@ void glk_request_timer_events(glui32 millisecs)
 void wintick(CFRunLoopTimerRef timer, void *info)
 {
     [monitor tick];
+}
+
+void gli_notification_waiting()
+{
+    winhandler(SIGUSR1);
 }
 
 void winabort(const char *fmt, ...)

--- a/garglk/syswin.c
+++ b/garglk/syswin.c
@@ -87,6 +87,11 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
+void gli_notification_waiting(void)
+{
+    PostMessage(hwndframe, WM_NOTIFY, 0, 0);
+}
+
 void onabout(void)
 {
     char txt[512];


### PR DESCRIPTION
This is an attempt to fix #204.

I have not been able to make much progress on this since it was opened (15 months ago at the time of writing) so I am just going to write down my findings so far, in the hope that a real programmer will read it and be able to tell me where I went wrong.

The TL;DR summary is that currently this works on all supported Gargoyle platforms except EFL.

Basically, what is happening is this: modern graphical user interfaces such as those used by Gargoyle (Windows, macOS, Gtk, EFL) are event driven. This means that they have a loop in the UI thread that waits for user events, such as the user moving the mouse or typing a letter on the keyboard. Meanwhile, any actual games and interpreters are running on a different thread (and process), but the UI thread will ignore them and will not print any text on the screen until it is made aware of a user event.

This becomes a problem when a game wants things to happen and messages to be printed in real time, while the player is just sitting around doing nothing, such as when a Glk timer fires or a sound notification occurs. Currently, the UI in Gargoyle will not react to sound or volume notifications until after the player does something. Fortunately, all our supported GUIs already have this problem solved when it comes to timers, so we have working implementations to study when trying to fix this.

This pull request consists of two parts. One is in [the common multi-platform code](https://github.com/garglk/garglk/pull/337/commits/b22f0f4f44ace72857f9f07e48d309aa05b539e3): whenever a Glk sound or volume notification is created, we immediately call a function called gli_notification_waiting() which is implemented in the platform-specific code and makes the main UI loop take notice. This is different from how the existing timer code works: there the Glk timer event is *created* in the platform specific gli_select() implementation every time a timer fires.

On [Windows, things are easy](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/syswin.c#L90-L93). It basically has a function for this, PostMessage(), which will make the main UI loop react just as readily as if the user moved the mouse.

The Apple Core Foundation has the concept of "run loops" and "loop sources" (or input sources), where a loop source is pretty much what we are looking for, something that makes the UI loop react immediately. [Our Mac timer implementation](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysmac.m#L87-L105) uses a loop source called CFRunLoopTimer, and I guess the corresponding way to implement sound notifications would be to call CFRunLoopSourceCreate to make the UI run loop listen for our custom signal, and then call CFRunLoopSourceSignal when we want to generate it. However, I noticed that the Mac code [already implements a Mach message handler](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysmac.m#L341-L392) (windhandler()) to handle the game process, which could be used for this purpose as well. [Simply calling the winhandler() function](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysmac.m#L149-L152) was enough to make the UI run loop take notice of any waiting notifications.

Gtk has its own "Gtk signals", and [in the winopen function in sysgtk.c](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysgtk.c#L556-L576) we can see how the UI loop is told explicitly which signals to listen for, with calls to gtk_signal_connect(). However, creating our own custom signals turned out to be anything but straightforward. [The timer code](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysgtk.c#L79-L91) uses the Gtk function g_timeout_add() to create a timer event source, and there is a similar function called g_idle_add() which is supposed to create an event that the main event loop will process "as soon as there are no higher priority events pending," which sounds like what we are looking for, but when I tried to use it, it would freeze the UI after the first notification. So I resorted to [a hack](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysgtk.c#L98-L108) that simply duplicates the timer code and creates another timer of 1 millisecond, which seems to work just fine.

I then tried to [repeat this trick with EFL](https://github.com/garglk/garglk/blob/786f2dc6bed1b3b68b0c39ed8dbeeaffe9ef438d/garglk/sysefl.c#L108-L118): duplicate the timer code to create a new one-millisecond timer. EFL would have none of that. While the existing timer code works just fine, trying to create another timer in the same way would invariably give the error `lib/eo/eo.c:920 _efl_add_internal_end() Eo ID (nil) is not a valid object. Current thread: 0x7f62866a8700. This ID has probably been deleted or this was never a valid object ID.` Even now that I've commented out most of the code, I still get this error. And notifications do not work, of course.

The only guess I have is that it has something to do with SDL: that the new timer is somehow created on a SDL thread that EFL does not like. But it is probably something else entirely.