### PR TITLE
Fix compilation on OS X 10.7 Lion

### DIFF
--- a/garglk/fontmac.m
+++ b/garglk/fontmac.m
@@ -167,7 +167,7 @@ static void propfont(char *file, int style)
     }
 }
 
-static NSMutableArray<NSURL *> * gli_registered_fonts = nil;
+static NSMutableArray * gli_registered_fonts = nil;
 static NSDistributedLock * gli_font_lock = nil;
 
 void fontreplace(char *font, int type)
@@ -181,7 +181,7 @@ void fontreplace(char *font, int type)
     NSFontDescriptor * fontFamilyDescriptor =
         [[NSFontDescriptor fontDescriptorWithFontAttributes: nil] fontDescriptorWithFamily: fontFamily];
 
-    NSArray<NSFontDescriptor *> * fontMatches =
+    NSArray * fontMatches =
         [fontFamilyDescriptor matchingFontDescriptorsWithMandatoryKeys: nil];
 
     for (NSFontDescriptor * sysfont in fontMatches)
@@ -259,7 +259,7 @@ void fontload(void)
 
     // obtain a list of all files in the Fonts directory
     NSString * fontFolder = [[NSString stringWithUTF8String: env] stringByAppendingPathComponent: @"Fonts"];
-    NSArray<NSString *> * fontFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath: fontFolder error: nil];
+    NSArray * fontFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtPath: fontFolder error: nil];
 
     // create a collection to hold the registered font URLs
     gli_registered_fonts = [NSMutableArray new];

--- a/garglk/launchmac.m
+++ b/garglk/launchmac.m
@@ -556,7 +556,7 @@ static BOOL isTextbufferEvent(NSEvent * evt)
                          <GargoyleApp, NSApplicationDelegate, NSWindowDelegate>
 {
     BOOL openedFirstGame;
-    NSMutableDictionary<NSNumber *, GargoyleWindow *> * windows;
+    NSMutableDictionary * windows;
     NSConnection * link;
 }
 - (BOOL) launchFile: (NSString *) file;
@@ -885,7 +885,7 @@ static BOOL isTextbufferEvent(NSEvent * evt)
     if (urlParts && [urlParts count] == 2)
     {
         openedFirstGame = YES;
-        NSString * game = [[urlParts objectAtIndex: 1] stringByRemovingPercentEncoding];
+        NSString * game = [[urlParts objectAtIndex: 1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 
         if ([[NSFileManager defaultManager] fileExistsAtPath: game] == YES)
             [self launchFile: game];

--- a/garglk/ttsmac.m
+++ b/garglk/ttsmac.m
@@ -30,7 +30,7 @@
 #import "sysmac.h"
 
 // a queue of phrases to feed to the speech synthesizer
-static NSMutableArray<NSString *> * phraseQueue = nil;
+static NSMutableArray * phraseQueue = nil;
 static NSRange purgeRange;
 
 @interface SpeechDelegate : NSObject <NSSpeechSynthesizerDelegate>
@@ -63,7 +63,7 @@ static NSRange purgeRange;
     // speak the next phrase
     if (phraseQueue.count > 0)
     {
-        [sender startSpeakingString: phraseQueue[0]];
+        [sender startSpeakingString: [phraseQueue objectAtIndex:0]];
     }
 }
 @end
@@ -96,10 +96,10 @@ void gli_initialize_tts(void)
             NSString * lang = [NSString stringWithCString: gli_conf_speak_language
                                                  encoding: NSUTF8StringEncoding];
 
-            NSArray<NSString *> * voices = [NSSpeechSynthesizer availableVoices];
+            NSArray * voices = [NSSpeechSynthesizer availableVoices];
             for (NSString * voice in voices)
             {
-                NSDictionary<NSString *, id> * attr = [NSSpeechSynthesizer attributesForVoice: voice];
+                NSDictionary * attr = [NSSpeechSynthesizer attributesForVoice: voice];
                 if ([lang isEqualToString: [attr objectForKey: NSVoiceLocaleIdentifier]])
                 {
                     [synth setVoice: voice];
@@ -121,7 +121,7 @@ static void ttsmac_add_phrase(NSString * phrase)
     // if the queue was empty we need to explicitly start speaking
     if (phraseQueue.count == 1)
     {
-        [synth startSpeakingString: phraseQueue[0]];
+        [synth startSpeakingString: [phraseQueue objectAtIndex:0]];
     }
 }
 


### PR DESCRIPTION
Unless I've misunderstood, Gargoyle no longer compiles out-of-the-box on OS X 10.7 (Xcode 4.6.2). This PR contains the changes I had to make in order for it to compile.