### PR TITLE
Replace /bin/ash shell with /bin/sh

### DIFF
--- a/terps/nitfol/nitfol
+++ b/terps/nitfol/nitfol
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 # This is a shell wrapper that finds an appropriate nitfol in your path
 # and runs it.  Requires 'which' and sh.  (only tested with bash, so YMMV)
 


### PR DESCRIPTION
Use /bin/sh as the majority of the scripts does.
Currently the ash shell is not widely used and was superseded by dash
shell in many linux distributions.