### PR TITLE
Actually don't require Babel if USEBABEL='no'

### DIFF
--- a/garglk/config.c
+++ b/garglk/config.c
@@ -617,5 +617,7 @@ void gli_startup(int argc, char *argv[])
     gli_initialize_sound();
 
     winopen();
+#ifdef BABEL_HANDLER
     gli_initialize_babel();
+#endif
 }


### PR DESCRIPTION
An error would pop up at link-time if `USEBABEL` was set to `no` in `Jamrules`.
This fixes it.