### PR TITLE
Mac build script tweak

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -132,4 +132,81 @@ problem. That library is trying to load out of MacPorts or Homebrew, and
 the interpreter will fail on most other Macs (which do not have those repos
 installed).
 
+- MacOS code signing and notarization
 
+For a fully accessible build on MacOS 10.15 (Catalina), you need to both
+sign and notarize the app before packaging it up. (Unsigned builds still
+run on 10.15, but you have to right-click and select "Open". The user 
+warnings for just launching the app normally are more derisive than before.)
+
+To do this:
+
+First, obviously, you need an Apple developer account.
+
+Create an app-specific password with the name "altool". Copy the password
+down once it's created. (You can't re-download it from Apple, you can only
+delete it and create a new one.) The instructions on this are here:
+
+https://support.apple.com/en-us/HT204397 "Using app-specific passwords"
+
+Verify that this password works:
+
+    xcrun altool --list-providers -u "$APPLE_ID"
+
+APPLE_ID is the account name (probably an email address) for your
+developer account. This will ask for a password. Use the altool password
+that you just created above. The response will look something like:
+
+    ProviderName   ProviderShortname      WWDRTeamID 
+    -------------- ---------------------- ---------- 
+    Andrew Plotkin AndrewPlotkin176400769 BK75QRDQ9E 
+
+Build Gargoyle.app using the gargoyle_osx.sh. But delete the .dmg file;
+we're going to create a new one later.
+
+Code-sign the app: (The "-o runtime" argument specifies that you want
+a "hardened" app, which is a requirement.)
+
+    codesign -o runtime --deep --sign "$CERT_NAME" Gargoyle.app
+
+The CERT_NAME is the name of your Developer ID Application certificate
+in Keychain-Access. For me, this is:
+"Developer ID Application: Andrew Plotkin (BK75QRDQ9E)".
+
+Zip up the signed app for notarization:
+
+    ditto -c -k --keepParent Gargoyle.app Gargoyle.zip
+
+Send it off to be notarized:
+
+    xcrun altool --notarize-app --primary-bundle-id 'com.googlecode.garglk.Launcher' --username "$APPLE_ID" --asc-provider "$PROV_SHORT_NAME" --file Gargoyle.zip
+
+This will also ask for the altool password. PROV_SHORT_NAME is the
+ProviderShortname you saw above. For me, it's AndrewPlotkin176400769.
+
+If this succeeds, you'll see something like:
+
+    No errors uploading 'Gargoyle.zip'.
+    RequestUUID = 4745e9e4-87c2-4509-89cf-d08d84181234
+
+Wait for Apple to send you email about this request. It's supposed to take "up to an hour"; I got a response within a few minutes.
+
+Now look at the response details:
+
+    xcrun altool --notarization-info "$REQ_UUID" -u "$APPLE_ID"
+
+This will give a success/failure message, plus a LogFileURL for more
+info. Look at the log file to make sure there are neither errors nor
+warnings.
+
+If it all looks good, update the app with the notarization info:
+
+    xcrun stapler staple Gargoyle.app
+
+(This doesn't need any extra arguments because Apple maintains a
+public database of all successful notarizations. The stapler tool
+looks up all necessary info online.)
+
+Finally, re-run the command to create the DMG file:
+
+    hdiutil create -fs "HFS+J" -ov -srcfolder Gargoyle.app/ gargoyle-2019.1-mac.dmg

--- a/gargoyle_osx.sh
+++ b/gargoyle_osx.sh
@@ -15,15 +15,17 @@ fi
 
 # XCode 10+ min target SDK is 10.9 (Mavericks) due to removal of libstdc++
 SDK_VERSION=$(xcrun --show-sdk-version)
+echo "SDK_VERSION $SDK_VERSION"
 
 case $SDK_VERSION in
-  *10.14* )
+  *10.1[4-9]* )
     MACOS_MIN_VER=10.9
     ;;
   * )
     MACOS_MIN_VER=10.7
     ;;
 esac
+echo "MACOS_MIN_VER $MACOS_MIN_VER"
 
 # Use as many CPU cores as possible
 NUMJOBS=$(sysctl -n hw.ncpu)

--- a/gargoyle_osx.sh
+++ b/gargoyle_osx.sh
@@ -123,6 +123,6 @@ cp fonts/LinLibertine*.otf $BUNDLE/Resources/Fonts
 cp fonts/NotoSerif*.ttf $BUNDLE/Resources/Fonts
 
 echo "Creating DMG..."
-hdiutil create -ov -srcfolder Gargoyle.app/ "gargoyle-$GARVERSION-mac.dmg"
+hdiutil create -fs "HFS+J" -ov -srcfolder Gargoyle.app/ "gargoyle-$GARVERSION-mac.dmg"
 
 echo "Done."


### PR DESCRIPTION
Build correctly on MacOS 10.15 *or* if you have the latest Xcode installed on an earlier OS.

SDK_VERSION is 10.15 in these cases. The case statement was only checking for 10.14. Now it checks for 10.14 to 10.19, which is a temporary fix in some sense, but I'm sure we'll be revising the script before MacOS 10.20 ships.
