### PR TITLE
(Do not merge) Hi-DPI, rebased

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -38,7 +38,7 @@
 bool gli_utf8input = true;
 bool gli_utf8output = true;
 
-int gli_hires = 1;
+bool gli_hires = true;
 float gli_backingscalefactor = 1.0f;
 float gli_zoom = 1.0f;
 
@@ -494,6 +494,10 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
             gli_conf_sound = std::stoi(arg);
         } else if (cmd == "fullscreen") {
             gli_conf_fullscreen = std::stoi(arg);
+        } else if (cmd == "hires") {
+            gli_hires = std::stoi(arg);
+        } else if (cmd == "zoom") {
+            gli_zoom = std::stoi(arg);
         } else if (cmd == "speak") {
             gli_conf_speak = std::stoi(arg);
         } else if (cmd == "speak_input") {

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -38,6 +38,10 @@
 bool gli_utf8input = true;
 bool gli_utf8output = true;
 
+int gli_hires = 1;
+float gli_backingscalefactor = 1.0f;
+float gli_zoom = 1.0f;
+
 struct gli_font_files gli_conf_prop, gli_conf_mono, gli_conf_prop_override, gli_conf_mono_override;
 
 std::string gli_conf_monofont = "Gargoyle Mono";
@@ -120,6 +124,7 @@ int gli_more_font = PROPB;
 unsigned char gli_scroll_bg[3] = { 0xb0, 0xb0, 0xb0 };
 unsigned char gli_scroll_fg[3] = { 0x80, 0x80, 0x80 };
 int gli_scroll_width = 0;
+int gli_scroll_width_save = 8;
 
 int gli_caret_shape = 2;
 int gli_link_style = 1;
@@ -468,6 +473,7 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
             gli_link_style = !!std::stoi(arg);
         } else if (cmd == "scrollwidth") {
             gli_scroll_width = std::stoi(arg);
+            gli_scroll_width_save = gli_scroll_width;
         } else if (cmd == "scrollbg") {
             parsecolor(arg, gli_scroll_bg);
         } else if (cmd == "scrollfg") {
@@ -603,6 +609,24 @@ void gli_startup(int argc, char *argv[])
 
     if (!gli_baseline)
         gli_baseline = gli_conf_propsize + 0.5;
+
+   if (gli_hires)
+        gli_zoom *= gli_backingscalefactor;
+    gli_baseline = gli_zoom_int(gli_baseline);
+    gli_conf_monosize = gli_conf_monosize * gli_zoom;
+    gli_conf_propsize = gli_conf_propsize * gli_zoom;
+    gli_leading = gli_zoom_int(gli_leading);
+    gli_scroll_width_save = gli_zoom_int(gli_scroll_width_save);
+    gli_tmarginx = gli_zoom_int(gli_tmarginx);
+    gli_tmarginy = gli_zoom_int(gli_tmarginy);
+    gli_wborderx = gli_zoom_int(gli_wborderx);
+    gli_wbordery = gli_zoom_int(gli_wbordery);
+    gli_wmarginx = gli_zoom_int(gli_wmarginx);
+    gli_wmarginx_save = gli_zoom_int(gli_wmarginx_save);
+    gli_wmarginy = gli_zoom_int(gli_wmarginy);
+    gli_wmarginy_save = gli_zoom_int(gli_wmarginy_save);
+    gli_wpaddingx = gli_zoom_int(gli_wpaddingx);
+    gli_wpaddingy = gli_zoom_int(gli_wpaddingy);
 
     gli_initialize_tts();
     if (gli_conf_speak)

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -497,7 +497,7 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
         } else if (cmd == "hires") {
             gli_hires = std::stoi(arg);
         } else if (cmd == "zoom") {
-            gli_zoom = std::stoi(arg);
+            gli_zoom = std::stof(arg);
         } else if (cmd == "speak") {
             gli_conf_speak = std::stoi(arg);
         } else if (cmd == "speak_input") {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -118,6 +118,8 @@ typedef struct window_graphics_s window_graphics_t;
 #define HISTORYLEN 100
 
 #define GLI_SUBPIX 8
+#define gli_zoom_int(x) ((x) * gli_zoom + 0.5)
+#define gli_unzoom_int(x) ((x) / gli_zoom + 0.5)
 
 extern char gli_program_name[256];
 extern char gli_program_info[256];
@@ -237,6 +239,10 @@ extern int gli_wpaddingy;
 extern int gli_tmarginx;
 extern int gli_tmarginy;
 
+extern int gli_hires;
+extern float gli_backingscalefactor;
+extern float gli_zoom;
+
 extern bool gli_conf_lcd;
 extern unsigned char gli_conf_lcd_weights[5];
 
@@ -270,6 +276,7 @@ extern bool gli_conf_lockrows;
 extern unsigned char gli_scroll_bg[3];
 extern unsigned char gli_scroll_fg[3];
 extern int gli_scroll_width;
+extern int gli_scroll_width_save;
 
 extern int gli_baseline;
 extern int gli_leading;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -243,7 +243,7 @@ extern int gli_wpaddingy;
 extern int gli_tmarginx;
 extern int gli_tmarginy;
 
-extern int gli_hires;
+extern bool gli_hires;
 extern float gli_backingscalefactor;
 extern float gli_zoom;
 

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -117,6 +117,10 @@ typedef struct window_graphics_s window_graphics_t;
 #define SCROLLBACK 512
 #define HISTORYLEN 100
 
+/* limit number of text rows/columns */
+#define MAX_TEXT_COLUMNS 255
+#define MAX_TEXT_ROWS 255
+
 #define GLI_SUBPIX 8
 #define gli_zoom_int(x) ((x) * gli_zoom + 0.5)
 #define gli_unzoom_int(x) ((x) / gli_zoom + 0.5)

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -117,10 +117,6 @@ typedef struct window_graphics_s window_graphics_t;
 #define SCROLLBACK 512
 #define HISTORYLEN 100
 
-/* limit number of text rows/columns */
-#define MAX_TEXT_COLUMNS 255
-#define MAX_TEXT_ROWS 255
-
 #define GLI_SUBPIX 8
 #define gli_zoom_int(x) ((x) * gli_zoom + 0.5)
 #define gli_unzoom_int(x) ((x) / gli_zoom + 0.5)

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -44,10 +44,7 @@ sound         1               # enable sound
 
 fullscreen    0               # set to 1 for fullscreen
 
-hires         1               # set to 1 to enable Retina display (macOS) / HiDPI (Windows)
-zoom          1.0             # set display zoom
-
-hires         1               # set to 1 to enable Retina display (macOS) / HiDPI (Windows)
+hires         1               # set to 1 to enable Retina display on macOS
 zoom          1.0             # set display zoom
 
 

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -42,7 +42,13 @@ caps          0               # Force uppercase input  -- 0=off 1=on
 graphics      1               # enable graphics
 sound         1               # enable sound
 
-fullscreen    0               # set to 1 for fullscreen (Windows/Unix only)
+fullscreen    0               # set to 1 for fullscreen
+
+hires         1               # set to 1 to enable Retina display (macOS) / HiDPI (Windows)
+zoom          1.0             # set display zoom
+
+hires         1               # set to 1 to enable Retina display (macOS) / HiDPI (Windows)
+zoom          1.0             # set display zoom
 
 
 #===============================================================================

--- a/garglk/launcher.plist
+++ b/garglk/launcher.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSHighResolutionCapable</key>
-	<false/>
 	<key>CFBundleExecutable</key>
 	<string>Gargoyle</string>
 	<key>CFBundleDisplayName</key>

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -127,6 +127,8 @@ static const char *winfilters[] =
 {
     [[self openGLContext] makeCurrentContext];
     NSRect rect = [self bounds];
+    if ([self wantsBestResolutionOpenGLSurface])
+        rect = [self convertRectToBacking: rect];
     glViewport(0.0, 0.0, NSWidth(rect), NSHeight(rect));
 }
 
@@ -143,7 +145,8 @@ static const char *winfilters[] =
                  styleMask: (unsigned int) windowStyle
                    backing: (NSBackingStoreType) bufferingType
                      defer: (BOOL) deferCreation
-                   process: (pid_t) pid;
+                   process: (pid_t) pid
+                    retina: (int) retina;
 - (void) sendEvent: (NSEvent *) event;
 - (NSEvent *) retrieveEvent;
 - (void) sendChars: (NSEvent *) event;
@@ -171,6 +174,7 @@ static const char *winfilters[] =
                    backing: (NSBackingStoreType) bufferingType
                      defer: (BOOL) deferCreation
                    process: (pid_t) pid
+                    retina: (int) retina
 {
     self = [super initWithContentRect: contentRect
                             styleMask: windowStyle
@@ -178,6 +182,8 @@ static const char *winfilters[] =
                                 defer: deferCreation];
 
     GargoyleView * view = [[GargoyleView alloc] initWithFrame: contentRect pixelFormat: [GargoyleView defaultPixelFormat]];
+    if (retina)
+        [view setWantsBestResolutionOpenGLSurface:YES];
     [self setContentView: view];
 
     eventlog = [[NSMutableArray alloc] initWithCapacity: 100];
@@ -610,6 +616,8 @@ static BOOL isTextbufferEvent(NSEvent * evt)
 - (BOOL) initWindow: (pid_t) processID
               width: (unsigned int) width
              height: (unsigned int) height
+             retina: (int) retina
+         fullscreen: (BOOL) fullscreen
 {
     if (!(processID > 0))
         return NO;
@@ -617,16 +625,26 @@ static BOOL isTextbufferEvent(NSEvent * evt)
     unsigned int style = NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask | NSResizableWindowMask;
 
     /* set up the window */
-    GargoyleWindow * window = [[GargoyleWindow alloc] initWithContentRect: NSMakeRect(0,0, width, height)
+    NSRect rect = NSMakeRect(0, 0, width, height);
+    if (retina)
+    {
+        NSView * tmpview = [[NSView alloc] initWithFrame: rect];
+        rect = [tmpview convertRectFromBacking: rect];
+        [tmpview release];
+    }
+    GargoyleWindow * window = [[GargoyleWindow alloc] initWithContentRect: rect
                                                                 styleMask: style
                                                                   backing: NSBackingStoreBuffered
                                                                     defer: NO
-                                                                  process: processID];
+                                                                  process: processID
+                                                                   retina: retina];
 
     [window makeKeyAndOrderFront: window];
     [window center];
     [window setReleasedWhenClosed: YES];
     [window setDelegate: self];
+    if (fullscreen)
+        [window toggleFullScreen: self];
 
     [windows setObject: window forKey: [NSNumber numberWithInt: processID]];
 
@@ -651,10 +669,31 @@ static BOOL isTextbufferEvent(NSEvent * evt)
 
     if (window)
     {
-        return [[window contentView] bounds];
+        id view = [window contentView];
+        NSRect rect = [view bounds];
+        if ([view wantsBestResolutionOpenGLSurface])
+            rect = [view convertRectToBacking: rect];
+        return rect;
     }
 
     return NSZeroRect;
+}
+
+- (NSPoint) getWindowPoint: (pid_t) processID
+                  forEvent: (NSEvent *) event;
+{
+    GargoyleWindow * window = [windows objectForKey: [NSNumber numberWithInt: processID]];
+
+    if (window)
+    {
+        id view = [window contentView];
+        NSPoint point = [event locationInWindow];
+        if ([view wantsBestResolutionOpenGLSurface])
+            point = [view convertPointToBacking: point];
+        return point;
+    }
+
+    return NSZeroPoint;
 }
 
 - (NSString *) getWindowCharString: (pid_t) processID

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -125,7 +125,7 @@ static const char *winfilters[] =
 
     /* Adapt to the current window backing scale factor */
     NSRect box = [self convertRectToBacking: [self bounds]];
-    float viewportScaleFactor = [self.window backingScaleFactor] / self.backingScaleFactor;
+    float viewportScaleFactor = [self.window backingScaleFactor] / 2;
     float viewportWidth = textureWidth * viewportScaleFactor;
     float viewportHeight = textureHeight * viewportScaleFactor;
     float y = NSHeight(box) - viewportHeight;

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -66,7 +66,8 @@
               width: (unsigned int) width
              height: (unsigned int) height
              retina: (int) retina
-         fullscreen: (BOOL) fullscreen;
+         fullscreen: (BOOL) fullscreen
+    backgroundColor: (NSColor *) backgroundColor;
 
 - (NSEvent *) getWindowEvent: (pid_t) processID;
 

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -64,11 +64,16 @@
 
 - (BOOL) initWindow: (pid_t) processID
               width: (unsigned int) width
-             height: (unsigned int) height;
+             height: (unsigned int) height
+             retina: (int) retina
+         fullscreen: (BOOL) fullscreen;
 
 - (NSEvent *) getWindowEvent: (pid_t) processID;
 
 - (NSRect) getWindowSize: (pid_t) processID;
+
+- (NSPoint) getWindowPoint: (pid_t) processID
+                  forEvent: (NSEvent *) event;
 
 - (NSString *) getWindowCharString: (pid_t) processID;
 

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -363,6 +363,13 @@ void wininit(int *argc, char **argv)
 {
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 
+    /* get the backing scale factor */
+    NSRect rect = NSMakeRect(0, 0, 1000, 1);
+    NSView * tmpview = [[NSView alloc] initWithFrame: rect];
+    rect = [tmpview convertRectToBacking: rect];
+    [tmpview release];
+    gli_backingscalefactor = NSWidth(rect)/1000.;
+
     /* establish link to launcher */
     NSString * linkName = [NSString stringWithUTF8String: getenv("GargoyleApp")];
     NSConnection * link = [NSConnection connectionWithRegisteredName: linkName host: NULL];
@@ -402,7 +409,9 @@ void winopen(void)
 
     [gargoyle initWindow: processID
                    width: defw
-                  height: defh];
+                  height: defh
+                  retina: gli_hires
+              fullscreen: gli_conf_fullscreen];
 
     wintitle();
     winresize();
@@ -528,7 +537,7 @@ void winkey(NSEvent *evt)
 
 void winmouse(NSEvent *evt)
 {
-    NSPoint coords = [evt locationInWindow];
+    NSPoint coords = [gargoyle getWindowPoint: processID forEvent: evt];
 
     int x = coords.x;
     int y = gli_image_h - coords.y;

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -304,12 +304,14 @@ void winresize(void)
 {
     NSRect viewRect = [gargoyle getWindowSize: processID];
 
-    if (gli_image_w == (unsigned int) viewRect.size.width
-            && gli_image_h == (unsigned int) viewRect.size.height)
+    unsigned int vw = (unsigned int) (NSWidth(viewRect) * gli_backingscalefactor);
+    unsigned int vh = (unsigned int) (NSHeight(viewRect) * gli_backingscalefactor);
+
+    if (gli_image_w == vw && gli_image_h == vh)
         return;
 
-    gli_image_w = (unsigned int) viewRect.size.width;
-    gli_image_h = (unsigned int) viewRect.size.height;
+    gli_image_w = vw;
+    gli_image_h = vh;
     gli_image_s = ((gli_image_w * 4 + 3) / 4) * 4;
 
     /* initialize offline bitmap store */
@@ -406,12 +408,17 @@ void winopen(void)
 
     unsigned int defw = gli_wmarginx * 2 + gli_cellw * gli_cols;
     unsigned int defh = gli_wmarginy * 2 + gli_cellh * gli_rows;
+    NSColor * windowColor = [NSColor colorWithCalibratedRed: (float) gli_window_color[0] / 255.0f
+                                                      green: (float) gli_window_color[1] / 255.0f
+                                                       blue: (float) gli_window_color[2] / 255.0f
+                                                      alpha: 1.0f];
 
     [gargoyle initWindow: processID
                    width: defw
                   height: defh
                   retina: gli_hires
-              fullscreen: gli_conf_fullscreen];
+              fullscreen: gli_conf_fullscreen
+         backgroundColor: windowColor];
 
     wintitle();
     winresize();
@@ -539,8 +546,8 @@ void winmouse(NSEvent *evt)
 {
     NSPoint coords = [gargoyle getWindowPoint: processID forEvent: evt];
 
-    int x = coords.x;
-    int y = gli_image_h - coords.y;
+    int x = coords.x * gli_backingscalefactor;
+    int y = gli_image_h - (coords.y * gli_backingscalefactor);
 
     /* disregard most events outside of content window */
     if ((coords.y < 0 || y < 0 || x < 0 || x > gli_image_w)

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -31,6 +31,10 @@
 #define LINES 24
 #define COLS 70
 
+/* limit number of text rows/columns */
+#define MAX_TEXT_COLUMNS 255
+#define MAX_TEXT_ROWS 255
+
 bool gli_force_redraw = true;
 bool gli_more_focus = false;
 

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -58,22 +58,42 @@ static void gli_windows_rearrange(void)
     {
         rect_t box;
 
-        if (gli_conf_lockcols)
+        if (gli_conf_lockcols && gli_cols <= MAX_TEXT_COLUMNS )
         {
+            /* Lock the number of columns */
             int desired_width = gli_wmarginx_save * 2 + gli_cellw * gli_cols;
             if (desired_width > gli_image_w)
                 gli_wmarginx = gli_wmarginx_save;
             else
-                gli_wmarginx = (gli_image_w - gli_cellw * gli_cols)/2;
+                gli_wmarginx = (gli_image_w - gli_cellw * gli_cols) / 2;
+        }
+        else
+        {
+            /* Limit the maximum number of columns */
+            int max_width = gli_wmarginx_save * 2 + gli_cellw * MAX_TEXT_COLUMNS;
+            if (max_width < gli_image_w)
+                gli_wmarginx = (gli_image_w - gli_cellw * MAX_TEXT_COLUMNS) / 2;
+            else
+                gli_wmarginx = gli_wmarginx_save;
         }
 
-        if (gli_conf_lockrows)
+        if (gli_conf_lockrows && gli_rows <= MAX_TEXT_ROWS)
         {
+            /* Lock the number of rows */
             int desired_height = gli_wmarginy_save * 2 + gli_cellh * gli_rows;
             if (desired_height > gli_image_h)
                 gli_wmarginy = gli_wmarginy_save;
             else
-                gli_wmarginy = (gli_image_h - gli_cellh * gli_rows)/2;
+                gli_wmarginy = (gli_image_h - gli_cellh * gli_rows) / 2;
+        }
+        else
+        {
+            /* Limit the maximum number of rows */
+            int max_height = gli_wmarginy_save * 2 + gli_cellh * MAX_TEXT_ROWS;
+            if (max_height < gli_image_h)
+                gli_wmarginy = (gli_image_h - gli_cellh * MAX_TEXT_ROWS) / 2;
+            else
+                gli_wmarginy = gli_wmarginy_save;
         }
 
         box.x0 = gli_wmarginx;

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -265,8 +265,6 @@ winid_t glk_window_open(winid_t splitwin,
             break;
         case wintype_Graphics:
             newwin->data = win_graphics_create(newwin);
-            if (method & winmethod_Fixed)
-                size = gli_zoom_int(size);
             break;
         case wintype_Pair:
             gli_strict_warning("window_open: cannot open pair window directly");

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -245,6 +245,8 @@ winid_t glk_window_open(winid_t splitwin,
             break;
         case wintype_Graphics:
             newwin->data = win_graphics_create(newwin);
+            if (method & winmethod_Fixed)
+                size = gli_zoom_int(size);
             break;
         case wintype_Pair:
             gli_strict_warning("window_open: cannot open pair window directly");
@@ -475,7 +477,11 @@ void glk_window_get_arrangement(window_t *win, glui32 *method, glui32 *size,
         val |= winmethod_NoBorder;
 
     if (size)
+    {
         *size = dwin->size;
+        if (dwin->key && (dwin->key->type == wintype_Graphics) && (dwin->dir == winmethod_Fixed))
+            *size = gli_unzoom_int(*size);
+    }
     if (keywin)
     {
         if (dwin->key)
@@ -564,6 +570,8 @@ void glk_window_set_arrangement(window_t *win, glui32 method, glui32 size, winid
     dwin->division = method & winmethod_DivisionMask;
     dwin->key = key;
     dwin->size = size;
+    if (key && (key->type == wintype_Graphics) && (newdir == winmethod_Fixed))
+        dwin->size = gli_zoom_int(dwin->size);
     dwin->wborder = ((method & winmethod_BorderMask) == winmethod_Border);
 
     dwin->vertical = (dwin->dir == winmethod_Left || dwin->dir == winmethod_Right);
@@ -602,8 +610,8 @@ void glk_window_get_size(window_t *win, glui32 *width, glui32 *height)
             hgt = hgt / gli_cellh;
             break;
         case wintype_Graphics:
-            wid = win->bbox.x1 - win->bbox.x0;
-            hgt = win->bbox.y1 - win->bbox.y0;
+            wid = gli_unzoom_int((win->bbox.x1 - win->bbox.x0));
+            hgt = gli_unzoom_int(win->bbox.y1 - win->bbox.y0);
             break;
     }
 

--- a/garglk/window.c
+++ b/garglk/window.c
@@ -630,7 +630,7 @@ void glk_window_get_size(window_t *win, glui32 *width, glui32 *height)
             hgt = hgt / gli_cellh;
             break;
         case wintype_Graphics:
-            wid = gli_unzoom_int((win->bbox.x1 - win->bbox.x0));
+            wid = gli_unzoom_int(win->bbox.x1 - win->bbox.x0);
             hgt = gli_unzoom_int(win->bbox.y1 - win->bbox.y0);
             break;
     }

--- a/garglk/wingfx.c
+++ b/garglk/wingfx.c
@@ -177,7 +177,7 @@ void win_graphics_click(window_graphics_t *dwin, int sx, int sy)
 
     if (win->mouse_request)
     {
-        gli_event_store(evtype_MouseInput, win, x, y);
+        gli_event_store(evtype_MouseInput, win, gli_unzoom_int(x), gli_unzoom_int(y));
         win->mouse_request = false;
         if (gli_conf_safeclicks)
             gli_forceclick = true;
@@ -185,7 +185,7 @@ void win_graphics_click(window_graphics_t *dwin, int sx, int sy)
 
     if (win->hyper_request)
     {
-        glui32 linkval = gli_get_hyperlink(sx, sy);
+        glui32 linkval = gli_get_hyperlink(gli_unzoom_int(sx), gli_unzoom_int(sy));
         if (linkval)
         {
             gli_event_store(evtype_Hyperlink, win, linkval, 0);
@@ -203,6 +203,8 @@ bool win_graphics_draw_picture(window_graphics_t *dwin,
 {
     picture_t *pic = gli_picture_load(image);
     glui32 hyperlink = dwin->owner->attr.hyper;
+    xpos = gli_zoom_int(xpos);
+    ypos = gli_zoom_int(ypos);
 
     if (!pic)
         return false;
@@ -218,6 +220,8 @@ bool win_graphics_draw_picture(window_graphics_t *dwin,
         imagewidth = pic->w;
         imageheight = pic->h;
     }
+    imagewidth = gli_zoom_int(imagewidth);
+    imageheight = gli_zoom_int(imageheight);
 
     drawpicture(pic, dwin, xpos, ypos, imagewidth, imageheight, hyperlink);
 
@@ -233,6 +237,10 @@ void win_graphics_erase_rect(window_graphics_t *dwin, bool whole,
     int y1 = y0 + height;
     int x, y;
     int hx0, hx1, hy0, hy1;
+    x0 = gli_zoom_int(x0);
+    y0 = gli_zoom_int(y0);
+    x1 = gli_zoom_int(x1);
+    y1 = gli_zoom_int(y1);
 
     if (whole)
     {
@@ -279,6 +287,10 @@ void win_graphics_fill_rect(window_graphics_t *dwin, glui32 color,
     unsigned char col[3];
     int x1 = x0 + width;
     int y1 = y0 + height;
+    x0 = gli_zoom_int(x0);
+    y0 = gli_zoom_int(y0);
+    x1 = gli_zoom_int(x1);
+    y1 = gli_zoom_int(y1);
     int x, y;
     int hx0, hx1, hy0, hy1;
 

--- a/garglk/winpair.c
+++ b/garglk/winpair.c
@@ -115,7 +115,7 @@ void win_pair_rearrange(window_t *win, rect_t *box)
                             split = dwin->size * gli_cellh;
                         break;
                     case wintype_Graphics:
-                        split = dwin->size;
+                        split = gli_zoom_int(dwin->size);
                         break;
                     default:
                         split = 0;

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -1788,6 +1788,12 @@ glui32 win_textbuffer_draw_picture(window_textbuffer_t *dwin,
         tmp = gli_picture_scale(pic, width, height);
         pic = tmp;
     }
+    else
+    {
+        picture_t *tmp;
+        tmp = gli_picture_scale(pic, gli_zoom_int(pic->w), gli_zoom_int(pic->h));
+        pic = tmp;
+    }
 
     hyperlink = dwin->owner->attr.hyper;
 


### PR DESCRIPTION
This is just a reminder that we still have a Hi-DPI implementation that is actually in pretty good shape.

Unfortunately it now looks as if I wrote parts of this code rather than @hkleinsorgen and @townba. Perhaps there is some Git magic that can rectify this? There is nothing new from me included here.

All the bugs also remain. They are most apparent in games which implement a split screen with a graphics window on top, such as [Andromeda 1983](https://ifdb.tads.org/viewgame?id=k7gryitw24knktcc). Something seems to go awry when calculating the horizontal split window height. EDIT: Fixed by b747731.

Instead of this:
<img width="872" alt="Skärmavbild 2020-01-03 kl  19 56 00" src="https://user-images.githubusercontent.com/5066755/71742778-2247eb00-2e63-11ea-8f1d-8a0460f599a4.png">
we get this:
<img width="990" alt="Skärmavbild 2020-01-03 kl  19 53 40" src="https://user-images.githubusercontent.com/5066755/71742790-28d66280-2e63-11ea-9da3-e94e3fb850eb.png">
The weird grey artefacts appear when resizing the window by dragging the corner.