### PR TITLE
Remove unused, commented-out EFL notification code

### DIFF
--- a/garglk/sysefl.c
+++ b/garglk/sysefl.c
@@ -57,8 +57,6 @@ static char filepath[MaxBuffer];
 
 static Ecore_Timer *timerid = NULL;
 static volatile int timeouts = 0;
-static Ecore_Timer *notifyid = NULL;
-static volatile int notify = 0;
 
 /* buffer for clipboard text */
 static char *cliptext = NULL;
@@ -100,21 +98,9 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
-static Eina_Bool do_nothing(void *data)
-{
-    return ECORE_CALLBACK_CANCEL;
-}
-
 void gli_notification_waiting(void)
 {
-    /* if (notifyid != NULL)
-    {
-        ecore_timer_del( notifyid );
-        notifyid = NULL;
-    }
-
-    notifyid = ecore_timer_add( 0.001, do_nothing, NULL );
-    notify = 1; */
+    /* stub */
 }
 
 void winabort(const char *fmt, ...)
@@ -645,24 +631,18 @@ void gli_select(event_t *event, int polled)
     if (!polled)
     {
         poll_event_queue = EINA_FALSE;
-        while (gli_curevent->type == evtype_None && !timeouts && !notify)
+        while (gli_curevent->type == evtype_None && !timeouts)
         {
             ecore_main_loop_begin();
             gli_dispatch_event(gli_curevent, polled);
         }
     }
 
-    if (gli_curevent->type == evtype_None)
+    if (gli_curevent->type == evtype_None && timeouts)
     {
-        if (notify)
-            notify = 0;
-
-        if (timeouts)
-        {
-            gli_event_store(evtype_Timer, NULL, 0, 0);
-            gli_dispatch_event(gli_curevent, polled);
-            timeouts = 0;
-        }
+        gli_event_store(evtype_Timer, NULL, 0, 0);
+        gli_dispatch_event(gli_curevent, polled);
+        timeouts = 0;
     }
 
     gli_curevent = NULL;

--- a/garglk/syseoi.c
+++ b/garglk/syseoi.c
@@ -59,8 +59,6 @@ static char filepath[MaxBuffer];
 
 static Ecore_Timer *timerid = NULL;
 static volatile int timeouts = 0;
-static Ecore_Timer *notifyid = NULL;
-static volatile int notify = 0;
 
 /* buffer for clipboard text */
 static char *cliptext = NULL;
@@ -146,21 +144,9 @@ void glk_request_timer_events(glui32 millisecs)
     }
 }
 
-static Eina_Bool do_nothing(void *data)
-{
-    return ECORE_CALLBACK_CANCEL;
-}
-
 void gli_notification_waiting(void)
 {
-    /* if (notifyid != NULL)
-    {
-        ecore_timer_del( notifyid );
-        notifyid = NULL;
-    }
-
-    notifyid = ecore_timer_add( 0.001, do_nothing, NULL );
-    notify = 1; */
+    /* stub */
 }
 
 void winabort(const char *fmt, ...)
@@ -764,7 +750,7 @@ void gli_select(event_t *event, int polled)
     if (!polled)
     {
         poll_event_queue = EINA_FALSE;
-        while (gli_curevent->type == evtype_None && !timeouts && !notify)
+        while (gli_curevent->type == evtype_None && !timeouts)
         {
             ecore_main_loop_begin();
             gli_dispatch_event(gli_curevent, polled);
@@ -773,15 +759,9 @@ void gli_select(event_t *event, int polled)
 
     if (gli_curevent->type == evtype_None && timeouts)
     {
-        if (notify)
-            notify = 0;
-
-        if (timeouts)
-        {
-            gli_event_store(evtype_Timer, NULL, 0, 0);
-            gli_dispatch_event(gli_curevent, polled);
-            timeouts = 0;
-        }
+        gli_event_store(evtype_Timer, NULL, 0, 0);
+        gli_dispatch_event(gli_curevent, polled);
+        timeouts = 0;
     }
 
     gli_curevent = NULL;


### PR DESCRIPTION
There is not point in keeping this code around. Even if it had worked, it would have been an ugly hack.

This reverts commit 4e06194c4a630cc8fb3893fac669403de0f106db.