### PR TITLE
Allow passing a game to gargoyle's .desktop entry

### DIFF
--- a/garglk/gargoyle.desktop
+++ b/garglk/gargoyle.desktop
@@ -5,6 +5,6 @@ Name=Gargoyle
 GenericName=Interactive Fiction interpreter
 Comment=Interactive Fiction multi-interpreter that supports all major IF formats
 Icon=gargoyle-house
-Exec=gargoyle
+Exec=gargoyle %f
 Categories=Game;
 MimeType=application/x-adrift;application/x-advsys;application/x-agt;application/x-alan;application/x-blorb;application/x-glulx;application/x-hugo;application/x-level9;application/x-magscroll;application/x-tads;application/x-t3vm-image;application/x-zmachine;


### PR DESCRIPTION
This allows e.g. dragging a game to the toolbar icon, or associating a file extension with gargoyle in Gnome.

See:
https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=882768