### PR TITLE
Revert changes to main.c obviated by 5f7cb6a

### DIFF
--- a/garglk/main.c
+++ b/garglk/main.c
@@ -24,9 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#ifndef WIN32
-#include <limits.h>
-#endif
 
 #include "glk.h"
 #include "glkstart.h"
@@ -34,15 +31,6 @@
 
 int main(int argc, char *argv[])
 {
-#ifdef WIN32
-    char full[_MAX_PATH];
-    if (argc > 1 && _fullpath(full, argv[argc - 1], _MAX_PATH) != NULL)
-        argv[argc - 1] = full;
-#else
-    char full[PATH_MAX];
-    if (argc > 1 && realpath(argv[argc - 1], full) != NULL)
-        argv[argc - 1] = full;
-#endif
     glkunix_startup_t startdata;
     startdata.argc = argc;
     startdata.argv = malloc(argc * sizeof(char*));


### PR DESCRIPTION
Since after 5f7cb6a669a750652693460c7e435551fab49c7c the working dir is
not changed, there is no longer a reason to canonicalize the game path.
The code this commit reverts causes weird behavior especially with
symlinks:
Files expected to be in the 'current' dir of the supplied game path
cannot be found if the the game is a symlink to a file in another
directory. This behavior is unexpected, and causes trouble in sandboxes (e.g. bazel)
where all the files might be symlinks that point to files in different
directories.

Revert "Fix b7b7924 to support win32"

This reverts commit 62c6c2fdffd429217cd2b99549e6efa47c928811.

Revert "Expand game filename to full path before startup"

This reverts commit b7b79243997a6a6f8a8a0db2ebeab2f63e864351.