### PR TITLE
Additional sound formats used by Hugo games

### DIFF
--- a/garglk/sndsdl.c
+++ b/garglk/sndsdl.c
@@ -46,6 +46,7 @@
 /* non-standard types */
 #define giblorb_ID_MP3  (giblorb_make_id('M', 'P', '3', ' '))
 #define giblorb_ID_WAVE (giblorb_make_id('W', 'A', 'V', 'E'))
+#define giblorb_ID_MIDI (giblorb_make_id('M', 'I', 'D', 'I'))
 
 #define SDL_CHANNELS 64
 #define GLK_MAXVOLUME 0x10000
@@ -525,12 +526,27 @@ static glui32 load_sound_resource(glui32 snd, long *len, char **buf)
         if (*len > 4 && !memcmp(*buf, "WAVE", 4))
             return giblorb_ID_WAVE;
 
+        if (*len > 4 && !memcmp(*buf, "RIFF", 4))
+            return giblorb_ID_WAVE;
+
+        /* midi */
+        if (*len > 4 && !memcmp(*buf, "MThd", 4))
+            return giblorb_ID_MIDI;
+
         /* s3m */
         if (*len > 0x30 && !memcmp(*buf + 0x2c, "SCRM", 4))
             return giblorb_ID_MOD;
 
         /* XM */
         if (*len > 20 && !memcmp(*buf, "Extended Module: ", 17))
+            return giblorb_ID_MOD;
+
+        /* Whatever MOD format Dragon Hunt uses */
+        if (*len > 11 && !memcmp(*buf, "introfronty", 11))
+            return giblorb_ID_MOD;
+
+        /* Whatever MOD format Enceladus uses */
+        if (*len > 11 && !memcmp(*buf, "elysium", 7))
             return giblorb_ID_MOD;
 
         /* MOD */
@@ -646,7 +662,7 @@ static glui32 play_compressed(schanid_t chan, char *ext)
 }
 
 /** Start a mod music channel */
-static glui32 play_mod(schanid_t chan, long len)
+static glui32 play_mod(schanid_t chan, long len, char *ext)
 {
     FILE *file;
     char *tn;
@@ -672,9 +688,16 @@ static glui32 play_mod(schanid_t chan, long len)
 
     chan->status = CHANNEL_MUSIC;
     /* The fscking mikmod lib want to read the mod only from disk! */
-    tempdir = getenv("TEMP");
-    if (tempdir == NULL) tempdir = ".";
-    tn = tempnam(tempdir, "gargtmp");
+    tempdir = getenv("TMPDIR");
+    /* malloc size of string tempdir + "XXXXXX.' + 3 letter extension + terminator */
+    tn = malloc(strlen(tempdir) + strlen("XXXXXX.mod") + 1);
+    sprintf(tn, "%sXXXXXX", tempdir);
+#if defined(WIN32) || defined(_WIN32) || defined(WINDOWS)
+    _mktemp_s(tn, strlen(tn));
+#else
+    mkstemp(tn);
+#endif
+    sprintf(tn, "%s.%s", tn, ext);
     file = fopen(tn, "wb");
     fwrite(chan->sdl_memory, 1, len, file);
     fclose(file);
@@ -751,7 +774,11 @@ glui32 glk_schannel_play_ext(schanid_t chan, glui32 snd, glui32 repeats, glui32 
             break;
 
         case giblorb_ID_MOD:
-            result = play_mod(chan, len);
+            result = play_mod(chan, len, "mod");
+            break;
+
+        case giblorb_ID_MIDI:
+            result = play_mod(chan, len, "mid");
             break;
 
         default:


### PR DESCRIPTION
This adds support for the MOD formats used by the Hugo games Enceladus and Dragon Hunt, and the WAVE format used by Hugo Tetris. It also tries to add support for General MIDI, but because the only game that uses it, Crimson Spring, won't start in Gargoyle (and never has, as far as I can tell) it is as yet untested. 

Use of the apparently unsafe tempnam() function is removed here as well.

EDIT: I have only tested this on macOS, and it would be good if someone tried it on Windows.

Enceladus can be downloaded here: https://ifdb.tads.org/viewgame?id=lwqcpp5od2vmslg
And Dragon Hunt here: https://ifdb.tads.org/viewgame?id=htl5pcglo0yjs0cy