### PR TITLE
Expose the garglk_fileref_get_name function with GLK_MODULE_FILEREF_GET_NAME

### DIFF
--- a/garglk/glk.h
+++ b/garglk/glk.h
@@ -57,6 +57,7 @@ typedef int32_t glsi32;
 #define GLK_MODULE_HYPERLINKS
 #define GLK_MODULE_DATETIME
 #define GLK_MODULE_GARGLKTEXT
+#define GLK_MODULE_FILEREF_GET_NAME
 
 /* These types are opaque object identifiers. They're pointers to opaque
     C structures, which are defined differently by each library. */

--- a/tads/osglk.c
+++ b/tads/osglk.c
@@ -520,6 +520,10 @@ int os_askfile(const char *prompt, char *fname_buf, int fname_buf_len,
     frefid_t fileref;
     glui32 gprompt, gusage;
 
+#ifndef GLK_MODULE_FILEREF_GET_NAME
+    return OS_AFE_FAILURE;
+#endif
+
     if (prompt_type == OS_AFP_OPEN)
         gprompt = filemode_Read;
     else

--- a/terps/agility/os_glk.c
+++ b/terps/agility/os_glk.c
@@ -5922,7 +5922,7 @@ gagt_get_user_file (glui32 usage, glui32 fmode, const char *fdtype)
    * underlying file descriptor or FILE* from a Glk stream either. :-(
    */
 
-#ifdef GARGLK
+#ifdef GLK_MODULE_FILEREF_GET_NAME
   retfile = fopen(garglk_fileref_get_name(fileref), fdtype);
 #else
 

--- a/terps/alan2/exe.c
+++ b/terps/alan2/exe.c
@@ -1526,7 +1526,16 @@ void save()
   char str[256];
   AtrElem *atr;
 
-#ifndef GARGLK
+#ifdef GLK_MODULE_FILEREF_GET_NAME
+
+  frefid_t fref;
+  fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Write, 0);
+  if (fref == NULL)
+    error(M_SAVEFAILED);
+  strcpy(str, garglk_fileref_get_name(fref));
+  glk_fileref_destroy(fref);
+
+#else
 
   /* First save ? */
   if (savfnm[0] == '\0') {
@@ -1542,15 +1551,6 @@ void save()
 #else
   gets(str);
 #endif
-
-#else
-
-frefid_t fref;
-fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Write, 0);
-if (fref == NULL)
-	error(M_SAVEFAILED);
-strcpy(str, garglk_fileref_get_name(fref));
-glk_fileref_destroy(fref);
 
 #endif
 
@@ -1628,7 +1628,16 @@ void restore()
   char savedVersion[4];
   char savedName[256];
 
-#ifndef GARGLK
+#ifdef GLK_MODULE_FILEREF_GET_NAME
+
+  frefid_t fref;
+  fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Read, 0);
+  if (fref == NULL)
+    error(M_SAVEFAILED);
+  strcpy(str, garglk_fileref_get_name(fref));
+  glk_fileref_destroy(fref);
+
+#else
 
   /* First save ? */
   if (savfnm[0] == '\0') {
@@ -1643,15 +1652,6 @@ void restore()
 #else
   gets(str);
 #endif
-
-#else
-
-frefid_t fref;
-fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Read, 0);
-if (fref == NULL)
-	error(M_SAVEFAILED);
-strcpy(str, garglk_fileref_get_name(fref));
-glk_fileref_destroy(fref);
 
 #endif
 


### PR DESCRIPTION
Expose the garglk_fileref_get_name function through GLK_MODULE_FILEREF_GET_NAME so other Glk implementations can add it.

I realised this was necessary while investigating why TADS couldn't save/restore in emglken/Lectrote.

https://intfiction.org/t/lectrote-1-3-8/47931/16?u=dannii

I also patched TADS's `os_askfile` function so that if GLK_MODULE_FILEREF_GET_NAME isn't defined it will just error, rather than saying it succeeded only for another function down the line to error. (This is instead of guarding the function call directly with `#ifdef GARGLK` as you did in cspiegel/terps.)