### PR TITLE
Bocfel: Fix display of negative numbers in status bar

### DIFF
--- a/terps/bocfel/screen.c
+++ b/terps/bocfel/screen.c
@@ -1953,7 +1953,7 @@ void zshow_status(void)
 #ifdef ZTERP_GLK
   glui32 width, height;
   char rhs[64];
-  int first = variable(0x11), second = variable(0x12);
+  int16_t first = variable(0x11), second = variable(0x12);
 
   if(statuswin.id == NULL) return;
 


### PR DESCRIPTION
In at least the z3 versions of Zork I, a score of -10 is displayed as 65256 in Bocfel (and Yazmin and Lectrote, but not in Frotz.)

In release 75 and later, you can get a score of -10 by typing
```
> open mailbox, take leaflet, throw leaflet at me
```
as you first move.

Reported by user Morningstar in [this thread](https://intfiction.org/t/mac-voiceover-users-wanted-for-testing-again/48653/4).

I don't know if this is the best fix or what regressions it may cause.