### PR TITLE
Bocfel: Fix time display quirk in Cutthroats

### DIFF
--- a/terps/bocfel/screen.c
+++ b/terps/bocfel/screen.c
@@ -1977,8 +1977,18 @@ void zshow_status(void)
 
   if(status_is_time())
   {
-    snprintf(rhs, sizeof rhs, "Time: %d:%02d%s ", (first + 11) % 12 + 1, second, first < 12 ? "am" : "pm");
-    if(strlen(rhs) > width) snprintf(rhs, sizeof rhs, "%02d:%02d", first, second);
+    unsigned int hour = first;
+    unsigned int min = second;
+    if (hour == 0)
+    {
+      hour = 12;
+    }
+    else if (hour > 12)
+    {
+      hour -= 12;
+    }
+    snprintf(rhs, sizeof rhs, "Time: %d:%02d%s ", hour, min, hour < 12 ? "am" : "pm");
+    if(strlen(rhs) > width) snprintf(rhs, sizeof rhs, "%02d:%02d", hour, min);
   }
   else
   {


### PR DESCRIPTION
If you drop your watch (can be done at the first move) the status bar should display Time: 99:99 pm. The original Amiga interpreter doesn't, but that is probably a bug.

For explanation and discussion, see:
https://intfiction.org/t/invalid-values-for-time-in-v3-games/43928