### PR TITLE
Update the unput functions to return the number of unput characters

### DIFF
--- a/garglk/cgstream.c
+++ b/garglk/cgstream.c
@@ -923,13 +923,13 @@ static void gli_put_buffer_uni(stream_t *str, glui32 *buf, glui32 len)
     }
 }
 
-static void gli_unput_buffer(stream_t *str, char *buf, glui32 len)
+static glui32 gli_unput_buffer(stream_t *str, const char *buf, glui32 len)
 {
     glui32 lx;
-    unsigned char *cx;
+    const unsigned char *cx;
 
     if (!str || !str->writable)
-        return;
+        return 0;
 
     if (str->type == strtype_Window)
     {
@@ -943,7 +943,7 @@ static void gli_unput_buffer(stream_t *str, char *buf, glui32 len)
             else
             {
                 gli_strict_warning("unput_buffer: window has pending line request");
-                return;
+                return 0;
             }
         }
         for (lx=0, cx=buf+len-1; lx<len; lx++, cx--)
@@ -954,16 +954,20 @@ static void gli_unput_buffer(stream_t *str, char *buf, glui32 len)
         }
         if (str->win->echostr)
             gli_unput_buffer(str->win->echostr, buf, len);
+
+        return lx;
     }
+
+    return 0;
 }
 
-static void gli_unput_buffer_uni(stream_t *str, glui32 *buf, glui32 len)
+static glui32 gli_unput_buffer_uni(stream_t *str, const glui32 *buf, glui32 len)
 {
     glui32 lx;
-    glui32 *cx;
+    const glui32 *cx;
 
     if (!str || !str->writable)
-        return;
+        return 0;
 
     if (str->type == strtype_Window)
     {
@@ -977,7 +981,7 @@ static void gli_unput_buffer_uni(stream_t *str, glui32 *buf, glui32 len)
             else
             {
                 gli_strict_warning("unput_buffer: window has pending line request");
-                return;
+                return 0;
             }
         }
         for (lx=0, cx=buf+len-1; lx<len; lx++, cx--)
@@ -988,7 +992,11 @@ static void gli_unput_buffer_uni(stream_t *str, glui32 *buf, glui32 len)
         }
         if (str->win->echostr)
             gli_unput_buffer_uni(str->win->echostr, buf, len);
+
+        return lx;
     }
+
+    return 0;
 }
 
 static void gli_set_style(stream_t *str, glui32 val)
@@ -1882,7 +1890,7 @@ void glk_put_string(char *s)
     gli_put_buffer(gli_currentstr, s, strlen(s));
 }
 
-glui32 strlen_uni(glui32 *s)
+glui32 strlen_uni(const glui32 *s)
 {
     glui32 length = 0;
     while (*s++) length++;
@@ -1952,6 +1960,16 @@ void garglk_unput_string(char *s)
 void garglk_unput_string_uni(glui32 *s)
 {
     gli_unput_buffer_uni(gli_currentstr, s, strlen_uni(s));
+}
+
+glui32 garglk_unput_string_count(const char *s)
+{
+    return gli_unput_buffer(gli_currentstr, s, strlen(s));
+}
+
+glui32 garglk_unput_string_count_uni(const glui32 *s)
+{
+    return gli_unput_buffer_uni(gli_currentstr, s, strlen_uni(s));
 }
 
 void glk_set_style(glui32 val)

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -786,7 +786,7 @@ void gli_putchar_utf8(glui32 val, FILE *fl);
 glui32 gli_getchar_utf8(FILE *fl);
 glui32 gli_parse_utf8(unsigned char *buf, glui32 buflen, glui32 *out, glui32 outlen);
 
-glui32 strlen_uni(glui32 *s);
+glui32 strlen_uni(const glui32 *s);
 
 void gli_put_hyperlink(glui32 linkval, unsigned int x0, unsigned int y0, unsigned int x1, unsigned int y1);
 glui32 gli_get_hyperlink(unsigned int x, unsigned int y);

--- a/garglk/glk.h
+++ b/garglk/glk.h
@@ -471,6 +471,10 @@ extern void garglk_set_config(const char *name);
 extern void garglk_unput_string(char *str);
 extern void garglk_unput_string_uni(glui32 *str);
 
+/* These variants are the same as above but return the number of characters that were unput. */
+extern glui32 garglk_unput_string_count(const char *str);
+extern glui32 garglk_unput_string_count_uni(const glui32 *str);
+
 #define zcolor_Transparent   (-4)
 #define zcolor_Cursor        (-3)
 #define zcolor_Current       (-2)


### PR DESCRIPTION
@angstsmurf This represents a change in the garglk API, so I'd like your input, since Spatterlight implements garglk extensions.  This is needed for a more complete fix for a Beyond Zork bug.  I can't find the actual issue (I thought it was #399 but maybe not); 

Anyway, you might recall that there was one fix that required the subtraction of the preloaded text length in order to get proper cursor placement.  I was going on the assumption that preloaded text would always match printed text (as is the case in BZ), but of course the Z-machine allows preloaded text to be different from anything on screen.  Instead of the length of preloaded text, the length of unput text needs to be counted, so I modified the unput functions to return a count of how many characters got removed.

If there's a better fix that doesn't involve changing the API I'm all for it, but so far this is what I've come up with.

