### PR TITLE
SNDSDL: Don't error on music callback with resid 0

### DIFF
--- a/garglk/sndsdl.c
+++ b/garglk/sndsdl.c
@@ -395,7 +395,7 @@ void glk_schannel_set_volume_ext(schanid_t chan, glui32 vol,
 /* Notify the music channel completion */
 static void music_completion_callback()
 {
-    if (!music_channel || !music_channel->resid)
+    if (!music_channel)
     {
         gli_strict_warning("music callback failed");
         return;


### PR DESCRIPTION
It seems GLK Resource IDs are zero-based according to spec (although I haven't found a game that actually uses a sound with id 0), so it is wrong to throw an error on a music callback with resid 0.

If we want to catch errors here, we will need to use a different value, but that is out of scope for this PR.