### PR TITLE
Use non-negative constants for colors

### DIFF
--- a/garglk/glk.h
+++ b/garglk/glk.h
@@ -475,10 +475,10 @@ extern void garglk_unput_string_uni(glui32 *str);
 extern glui32 garglk_unput_string_count(const char *str);
 extern glui32 garglk_unput_string_count_uni(const glui32 *str);
 
-#define zcolor_Transparent   (-4)
-#define zcolor_Cursor        (-3)
-#define zcolor_Current       (-2)
-#define zcolor_Default       (-1)
+#define zcolor_Transparent   ((glui32)0xfffffffc)
+#define zcolor_Cursor        ((glui32)0xfffffffd)
+#define zcolor_Current       ((glui32)0xfffffffe)
+#define zcolor_Default       ((glui32)0xffffffff)
 
 extern void garglk_set_zcolors(glui32 fg, glui32 bg);
 extern void garglk_set_zcolors_stream(strid_t str, glui32 fg, glui32 bg);


### PR DESCRIPTION
Colors are stored in a glui32, so these negative values will wrap.
There's nothing technically wrong with the negative values, but
semantically using a value that directly fits into a glui32 makes more
sense, and can prevent compiler warnings (Oracle Developer Studio warns
on initializing an unsigned object with a negative value, for example).

Theoretically this isn't 100% compatible, as it's currently completely
legal to do something like:

short x = zcolor_Default;
glui32 y = x;

The conversion from 0xfffffffc (for example) to short is implementation-
defined, whereas the conversion from -4 to short is well-defined, and
then the conversion from short to glui32 is also well-defined. But
nobody writes code like this, and even if they did, modern 2's
complement systems do the right thing anyway.