### PR TITLE
Add special handling for the last two sounds in Lurking Horror

### DIFF
--- a/terps/bocfel/screen.c
+++ b/terps/bocfel/screen.c
@@ -1703,6 +1703,7 @@ static bool istream_read_from_file(struct input *input)
         break;
 #ifdef GLK_MODULE_SOUND
     case evtype_SoundNotify:
+        sound_ended();
         if (sound_routine != 0) {
             uint16_t current_routine = sound_routine;
             sound_routine = 0;
@@ -1990,6 +1991,7 @@ static bool get_input(uint16_t timer, uint16_t routine, struct input *input)
             break;
 #ifdef GLK_MODULE_SOUND
         case evtype_SoundNotify:
+            sound_ended();
             if (sound_routine != 0) {
                 uint16_t current_routine = sound_routine;
                 sound_routine = 0;

--- a/terps/bocfel/sound.h
+++ b/terps/bocfel/sound.h
@@ -16,6 +16,7 @@ extern uint16_t sound_routine;
 
 void init_sound(void);
 bool sound_loaded(void);
+void sound_ended(void);
 
 void zsound_effect(void);
 


### PR DESCRIPTION
The Lurking Horror expects its last sound effects to be queued when issued, so we intercept them and make sure that they are played when the preceding effects are finished.

This PR is based on #415.

I attached a save file from Lurking Horror release 221 / serial number 870918.
Just PUT LINE IN SOCKET. For the next effect: WAIT. THROW STONE AT CREATURE. GET STONE.
[Lurking.zip](https://github.com/garglk/garglk/files/6325637/Lurking.zip)
