### PR TITLE
Significantly improve the gamma correction for more natural looking text rendering

### DIFF
--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -97,10 +97,10 @@ int gli_image_w = 0;
 int gli_image_h = 0;
 unsigned char *gli_image_rgb = NULL;
 
-#if defined(WIN32)
-static const int gli_bpp = 3;
-#elif defined EFL_1BPP
+#ifdef EFL_1BPP
 static const int gli_bpp = 1;
+#elifdef WIN32
+static const int gli_bpp = 3;
 #else
 static const int gli_bpp = 4;
 #endif
@@ -430,18 +430,17 @@ void gli_draw_pixel(int x, int y, unsigned char alpha, unsigned char *rgb)
         return;
     if (y < 0 || y >= gli_image_h)
         return;
-#ifdef WIN32
-    p[0] = rgb[2] + mul255((short)p[0] - rgb[2], invalf);
-    p[1] = rgb[1] + mul255((short)p[1] - rgb[1], invalf);
-    p[2] = rgb[0] + mul255((short)p[2] - rgb[0], invalf);
-#elif defined EFL_1BPP
+
+#ifdef EFL_1BPP
     int gray = grayscale( rgb[0], rgb[1], rgb[2] );
     p[0] = gray + mul255((short)p[0] - gray, invalf);
 #else
     p[0] = rgb[2] + mul255((short)p[0] - rgb[2], invalf);
     p[1] = rgb[1] + mul255((short)p[1] - rgb[1], invalf);
     p[2] = rgb[0] + mul255((short)p[2] - rgb[0], invalf);
+#ifndef WIN32
     p[3] = 0xFF;
+#endif
 #endif
 }
 
@@ -456,11 +455,8 @@ void gli_draw_pixel_lcd(int x, int y, unsigned char *alpha, unsigned char *rgb)
         return;
     if (y < 0 || y >= gli_image_h)
         return;
-#ifdef WIN32
-    p[0] = rgb[2] + mul255((short)p[0] - rgb[2], invalf[2]);
-    p[1] = rgb[1] + mul255((short)p[1] - rgb[1], invalf[1]);
-    p[2] = rgb[0] + mul255((short)p[2] - rgb[0], invalf[0]);
-#elif defined EFL_1BPP
+
+#ifdef EFL_1BPP
     int gray = grayscale( rgb[0], rgb[1], rgb[2] );
     int invalfgray = grayscale( invalf[0], invalf[1], invalf[2] );
     p[0] = gray + mul255((short)p[0] - gray, invalfgray);
@@ -468,7 +464,9 @@ void gli_draw_pixel_lcd(int x, int y, unsigned char *alpha, unsigned char *rgb)
     p[0] = rgb[2] + mul255((short)p[0] - rgb[2], invalf[2]);
     p[1] = rgb[1] + mul255((short)p[1] - rgb[1], invalf[1]);
     p[2] = rgb[0] + mul255((short)p[2] - rgb[0], invalf[0]);
+#ifndef WIN32
     p[3] = 0xFF;
+#endif
 #endif
 }
 
@@ -511,17 +509,15 @@ void gli_draw_clear(unsigned char *rgb)
         p = gli_image_rgb + y * gli_image_s;
         for (x = 0; x < gli_image_w; x++)
         {
-#ifdef WIN32
-            *p++ = rgb[2];
-            *p++ = rgb[1];
-            *p++ = rgb[0];
-#elif defined EFL_1BPP
+#ifdef EFL_1BPP
             *p++ = gray;
 #else
             *p++ = rgb[2];
             *p++ = rgb[1];
             *p++ = rgb[0];
+#ifndef WIN32
             *p++ = 0xFF;
+#endif
 #endif
         }
     }
@@ -554,17 +550,15 @@ void gli_draw_rect(int x0, int y0, int w, int h, unsigned char *rgb)
         unsigned char *p = p0;
         for (x = x0; x < x1; x++)
         {
-#ifdef WIN32
-            *p++ = rgb[2];
-            *p++ = rgb[1];
-            *p++ = rgb[0];
-#elif defined EFL_1BPP
+#ifdef EFL_1BPP
             *p++ = gray;
 #else
             *p++ = rgb[2];
             *p++ = rgb[1];
             *p++ = rgb[0];
+#ifndef WIN32
             *p++ = 0xFF;
+#endif
 #endif
         }
         p0 += gli_image_s;
@@ -923,17 +917,15 @@ void gli_draw_picture(picture_t *src, int x0, int y0, int dx0, int dy0, int dx1,
 #ifdef EFL_1BPP
             unsigned char sgray = grayscale(sr, sg, sb);
 #endif
-#ifdef WIN32
-            dp[x*3+0] = sb + mul255(dp[x*3+0], na);
-            dp[x*3+1] = sg + mul255(dp[x*3+1], na);
-            dp[x*3+2] = sr + mul255(dp[x*3+2], na);
-#elif defined EFL_1BPP
+#ifdef EFL_1BPP
             dp[x] = sgray + mul255(dp[x], na);
 #else
             dp[x*4+0] = sb + mul255(dp[x*4+0], na);
             dp[x*4+1] = sg + mul255(dp[x*4+1], na);
             dp[x*4+2] = sr + mul255(dp[x*4+2], na);
+#ifndef WIN32
             dp[x*4+3] = 0xFF;
+#endif
 #endif
         }
         sp += src->w * 4;

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -951,16 +951,17 @@ void gli_draw_picture(picture_t *src, int x0, int y0, int dx0, int dy0, int dx1,
             unsigned char sb = mul255(sp[x*4+2], sa);
 #ifdef EFL_1BPP
             unsigned char sgray = grayscale(sr, sg, sb);
-#endif
-#ifdef EFL_1BPP
+
             dp[x] = sgray + mul255(dp[x], na);
+#elifdef WIN32
+            dp[x*3+0] = sb + mul255(dp[x*3+0], na);
+            dp[x*3+1] = sg + mul255(dp[x*3+1], na);
+            dp[x*3+2] = sr + mul255(dp[x*3+2], na);
 #else
             dp[x*4+0] = sb + mul255(dp[x*4+0], na);
             dp[x*4+1] = sg + mul255(dp[x*4+1], na);
             dp[x*4+2] = sr + mul255(dp[x*4+2], na);
-#ifndef WIN32
             dp[x*4+3] = 0xFF;
-#endif
 #endif
         }
         sp += src->w * 4;

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -91,7 +91,7 @@ struct font_s
 
 static unsigned short gammamap[256];
 static unsigned char gammainv[256 << GAMMA_SHIFT];
-static unsigned char filterweights = {28, 56, 85, 56, 28};
+static unsigned char filterweights[5] = {28, 56, 85, 56, 28};
 
 static font_t gfont_table[8];
 

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -105,7 +105,7 @@ unsigned char *gli_image_rgb = NULL;
 
 #ifdef EFL_1BPP
 static const int gli_bpp = 1;
-#elifdef WIN32
+#elif defined WIN32
 static const int gli_bpp = 3;
 #else
 static const int gli_bpp = 4;
@@ -949,7 +949,7 @@ void gli_draw_picture(picture_t *src, int x0, int y0, int dx0, int dy0, int dx1,
             unsigned char sgray = grayscale(sr, sg, sb);
 
             dp[x] = sgray + mul255(dp[x], na);
-#elifdef WIN32
+#elif defined WIN32
             dp[x*3+0] = sb + mul255(dp[x*3+0], na);
             dp[x*3+1] = sg + mul255(dp[x*3+1], na);
             dp[x*3+2] = sr + mul255(dp[x*3+2], na);

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -91,7 +91,7 @@ struct font_s
 
 static unsigned short gammamap[256];
 static unsigned char gammainv[256 << GAMMA_SHIFT];
-const FT_LcdFiveTapFilter filterweights = {28, 56, 85, 56, 28};
+static unsigned char filterweights = {28, 56, 85, 56, 28};
 
 static font_t gfont_table[8];
 
@@ -139,10 +139,6 @@ static void copy(unsigned char *dst, unsigned char *src, int n)
     while (n--)
         *dst++ = *src++;
 }
-
-#define m28(x) ((x * 28) / 255)
-#define m56(x) ((x * 56) / 255)
-#define m85(x) ((x * 85) / 255)
 
 static void copy_lcd(unsigned char *dst, unsigned char *src, int w, int h, int pitch)
 {

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -106,12 +106,8 @@ gfont 10      monor           # User2
 #
 # Default here is for black text on a white background.
 #
-# If you choose the reverse, light text on a dark background,
-# you may want to set gamma to 0.7 or similar to make the
-# text fatter.
-#
 # Depending on your screen you may want to tweak the gamma.
-# Good values to try are 0.7, 1.0 and 1.4.
+# Good values to try are 1.0, 1.8 and 2.2.
 #
 # There are separate colors for TextBuffer and TextGrid windows.
 # TextBuffers are main text windows, TextGrids are used mainly for

--- a/garglk/standalone.ini
+++ b/garglk/standalone.ini
@@ -107,12 +107,8 @@ gfont 10      monor           # User2
 #
 # Default here is for black text on a white background.
 #
-# If you choose the reverse, light text on a dark background,
-# you may want to set gamma to 0.7 or similar to make the
-# text fatter.
-#
 # Depending on your screen you may want to tweak the gamma.
-# Good values to try are 0.7, 1.0 and 1.4.
+# Good values to try are 1.0, 1.8 and 2.2.
 #
 # There are separate colors for TextBuffer and TextGrid windows.
 # TextBuffers are main text windows, TextGrids are used mainly for


### PR DESCRIPTION
It actually does mean a lot to me that Gargoyle actually cares about providing gamma-correct text rendering for those of us who want that. I'm not sure of any other open source programs that advertise that as a feature, let alone implement it.

Sadly, Gargoyle's gamma correction code was implemented incorrectly, and as a result there were various inconsistencies and problems with text rendering. Most noticeable was when you'd have light text on a dark background, as that would make the text very thin and hard to make out, even leading to a comment in the config files suggesting that people with dark themes use a gamma value that's lower than 1.0.

This should no longer be necessary with this code, and I've indeed removed the relevant comments from those config files. More details about that, and many of the other changes, are in the commit messages for the changes I've made. Some information about how gamma correction in general works - along with some of my earlier musings before actually trying to implement the code myself - can be found in the comments to issue #418, which this set of commits completely fixes.