### PR TITLE
Adjust the SDK-checking glob in gargoyle_osx.sh

### DIFF
--- a/gargoyle_osx.sh
+++ b/gargoyle_osx.sh
@@ -13,16 +13,20 @@ else
   HOMEBREW_OR_MACPORTS_LOCATION="$(pushd "$(dirname $(which port))/.." > /dev/null ; pwd -P ; popd > /dev/null)"
 fi
 
-# XCode 10+ min target SDK is 10.9 (Mavericks) due to removal of libstdc++
+# If building with XCode 10+ (SDK 10.14+ Mojave), the minimum target SDK is
+# 10.9 (Mavericks), due to removal of libstdc++.
 SDK_VERSION=$(xcrun --show-sdk-version)
 echo "SDK_VERSION $SDK_VERSION"
 
 case $SDK_VERSION in
-  *10.1[4-9]* )
-    MACOS_MIN_VER=10.9
+  *10.[7-9]* )
+    MACOS_MIN_VER=10.7
+    ;;
+  *10.1[0-3]* )
+    MACOS_MIN_VER=10.7
     ;;
   * )
-    MACOS_MIN_VER=10.7
+    MACOS_MIN_VER=10.9
     ;;
 esac
 echo "MACOS_MIN_VER $MACOS_MIN_VER"


### PR DESCRIPTION
Instead of an open-ended check for 10.14+, it now checks for SDK 10.7 through 10.13. Those get a minimum target of 10.7. Everything else gets a minimum target of 10.9.

(I could be finicky and fail with an error on 10.6 or earlier, but I don't think it's worth the effort.)
