### PR TITLE
Allow system libraries to be used instead of the bundled libraries

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -67,10 +67,14 @@ if $(OS) = MINGW
         [ FDirName $(TOP) support libpng ]
         [ FDirName $(TOP) support zlib ]
         ;
-    InstallLib $(LIBDIR) : libfreetype-6.dll ;
-    InstallLib $(LIBDIR) : libjpeg-8.dll ;
-    InstallLib $(LIBDIR) : libpng16-16.dll ;
-    InstallLib $(LIBDIR) : zlib1.dll ;
+
+    if $(MINGW_USE_SYSTEM_LIBRARIES) != yes
+    {
+        InstallLib $(LIBDIR) : libfreetype-6.dll ;
+        InstallLib $(LIBDIR) : libjpeg-8.dll ;
+        InstallLib $(LIBDIR) : libpng16-16.dll ;
+        InstallLib $(LIBDIR) : zlib1.dll ;
+    }
 }
 
 if $(STATIC)

--- a/Jamrules
+++ b/Jamrules
@@ -79,10 +79,19 @@ switch $(PLATFORM)
         SUFDLL  = .dll ;
         LINKLIBS = -lcomdlg32 -lgdi32 -lwinmm -lm ;
         SHRLINKLIBS = -lcomdlg32 -lgdi32 -lwinmm -lm ;
-        SHRLINKLIBS += $(TOP)/support/freetype/libfreetype-6.dll ;
-        SHRLINKLIBS += $(TOP)/support/libjpeg/libjpeg-8.dll ;
-        SHRLINKLIBS += $(TOP)/support/libpng/libpng16-16.dll ;
-        SHRLINKLIBS += $(TOP)/support/zlib/zlib1.dll ;
+        PACKAGES = "" ;
+
+         if $(MINGW_USE_SYSTEM_LIBRARIES) = yes
+         {
+             PACKAGES = "$(PACKAGES) freetype2 libjpeg libpng zlib" ;
+         }
+         else
+         {
+            SHRLINKLIBS += $(TOP)/support/freetype/libfreetype-6.dll ;
+            SHRLINKLIBS += $(TOP)/support/libjpeg/libjpeg-8.dll ;
+            SHRLINKLIBS += $(TOP)/support/libpng/libpng16-16.dll ;
+            SHRLINKLIBS += $(TOP)/support/zlib/zlib1.dll ;
+         }
 
         GARGLKCCFLAGS = -std=gnu99 ;
 
@@ -94,11 +103,15 @@ switch $(PLATFORM)
 
         if $(USESDL) = yes
         {
-            PKGCONFIG = "$(PKGCONF) sdl2 SDL2_mixer" ;
+            PACKAGES = "$(PACKAGES) sdl2 SDL2_mixer" ;
+        }
+
+        if $(PACKAGES)
+        {
             # the 'only-I' bit is important to avoid SDL messing with main()
-            GARGLKCCFLAGS += "`$(PKGCONFIG) --cflags-only-I`" ;
-            LINKLIBS += "`$(PKGCONFIG) --libs`" ;
-            SHRLINKLIBS += "`$(PKGCONFIG) --libs`" ;
+            GARGLKCCFLAGS += "`$(PKGCONF) $(PACKAGES) --cflags-only-I`" ;
+            LINKLIBS += "`$(PKGCONF) $(PACKAGES) --libs`" ;
+            SHRLINKLIBS += "`$(PKGCONF) $(PACKAGES) --libs`" ;
         }
 
         if $(USETTS) = yes

--- a/licenses/flac.txt
+++ b/licenses/flac.txt
@@ -1,0 +1,29 @@
+Copyright (C) 2000-2009  Josh Coalson
+Copyright (C) 2011-2016  Xiph.Org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/libogg.txt
+++ b/licenses/libogg.txt
@@ -1,0 +1,28 @@
+Copyright (c) 2002, Xiph.org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/libopenmpt-modplug.txt
+++ b/licenses/libopenmpt-modplug.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2004-2020, OpenMPT contributors
+Copyright (c) 1997-2003, Olivier Lapicque
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the OpenMPT project nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/licenses/libopenmpt.txt
+++ b/licenses/libopenmpt.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2004-2021, OpenMPT contributors
+Copyright (c) 1997-2003, Olivier Lapicque
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the OpenMPT project nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/licenses/libvorbis.txt
+++ b/licenses/libvorbis.txt
@@ -1,0 +1,28 @@
+Copyright (c) 2002-2020 Xiph.org Foundation
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/terps/Jamfile
+++ b/terps/Jamfile
@@ -353,7 +353,10 @@ if $(MAKE_SCARE) = yes
 
     if $(OS) = MINGW
     {
-        SubDirHdrs $(TOP) support zlib ;
+        if $(MINGW_USE_SYSTEM_LIBRARIES) != yes
+        {
+            SubDirHdrs $(TOP) support zlib ;
+        }
     }
 
     Main $(GARGLKPRE)scare :
@@ -365,7 +368,10 @@ if $(MAKE_SCARE) = yes
 
     if $(OS) = MINGW
     {
-        SharedLinkLibraries $(GARGLKPRE)scare : zlib1.dll ;
+        if $(MINGW_USE_SYSTEM_LIBRARIES) != yes
+        {
+            SharedLinkLibraries $(GARGLKPRE)scare : zlib1.dll ;
+        }
     }
 
     APPS += $(GARGLKPRE)scare ;

--- a/windows.sh
+++ b/windows.sh
@@ -9,25 +9,25 @@ set -e
 
 [[ -e build/dist ]] && exit 1
 
-sdl_location=/opt/local
+mingw_location=/usr
 target=i686-w64-mingw32
-
-export PKG_CONFIG_PATH=${sdl_location}/${target}/lib/pkgconfig
 
 makensis="${HOME}/.wine/drive_c/Program Files (x86)/NSIS/makensis.exe"
 nproc=$(getconf _NPROCESSORS_ONLN)
 ver=$(${target}-gcc --version | head -1 | awk '{print $3}')
 
-jam -sC++=${target}-g++ -sCC=${target}-gcc -sOS=MINGW -sMINGWARCH=${target} -sCROSS=1 -sUSETTS=yes -dx -j${nproc}
-jam -sC++=${target}-g++ -sCC=${target}-gcc -sOS=MINGW -sMINGWARCH=${target} -sCROSS=1 -sUSETTS=yes -dx install
+jamargs="-sC++=${target}-g++ -sCC=${target}-gcc -sOS=MINGW -sMINGWARCH=${target} -sCROSS=1 -sUSETTS=yes -sMINGW_USE_SYSTEM_LIBRARIES=yes -dx"
+
+jam ${jamargs} -j${nproc}
+jam ${jamargs} install
 
 cp "/usr/lib/gcc/${target}/${ver}/libstdc++-6.dll" "build/dist"
 cp "/usr/lib/gcc/${target}/${ver}/libgcc_s_dw2-1.dll" "build/dist"
 cp "/usr/${target}/lib/libwinpthread-1.dll" "build/dist"
 
-for dll in SDL2 SDL2_mixer
+for dll in SDL2 SDL2_mixer libFLAC-8 libmodplug-1 libmpg123-0 libogg-0 libopenmpt-0 libvorbis-0 libvorbisfile-3
 do
-    cp "${sdl_location}/${target}/bin/${dll}.dll" "build/dist"
+    cp "${mingw_location}/${target}/bin/${dll}.dll" "build/dist"
 done
 
 wine "${makensis}" installer.nsi


### PR DESCRIPTION
The tentative plan is to remove the bundled libraries at some point and
just use system libraries. All required libraries easily build and
install with MinGW. DLLs will still be included with the binary
distribution, but not with the source. This allows the latest versions
of libraries to be used with limited pain.