### PR TITLE
[agility] Don't redeclare strcasecmp() and strncasecmp().

### DIFF
--- a/terps/agility/agility.h
+++ b/terps/agility/agility.h
@@ -42,6 +42,9 @@
 #include <string.h>
 #include <limits.h>
 
+/* For strcasecmp() and strncasecemp(). */
+#include <strings.h>
+
 /* Platform-specific configuration info */
 #include "config.h"
 

--- a/terps/agility/config.h
+++ b/terps/agility/config.h
@@ -293,8 +293,14 @@
  * AGiliTy code.  The os_glk.c module handles the translations.
  */
 #ifdef GLK  
+/*
+ * Gargoyle expects a Unix-like system (including Windows with MinGW);
+ * strcasecmp() and strncasecmp() are POSIX, so can be assumed to exist.
+ */
+#if 0
 #define NEED_STR_CMP			/* Inherited from PLAIN. */
 #define NEED_STRN_CMP			/* Inherited from PLAIN. */
+#endif
 #define BUFF_SIZE	0		/* Inherited from PLAIN. */
 #define CBUF_SIZE	(5000L)		/* Inherited from PLAIN. */
 #define INBUFF_SIZE	(1024)		/* Inherited from PLAIN. */


### PR DESCRIPTION
The Glk port assumes that these don't exist, which is a valid
assumption, because they're POSIX, not standard C; but Gargoyle requires
a POSIX environment, meaning these functions are guaranteed to exist.