### PR TITLE
Fix fonts being subpixel filtered twice

### DIFF
--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -212,10 +212,12 @@ static void loadglyph(font_t *f, glui32 cid)
         if (f->make_oblique)
             FT_Outline_Transform(&f->face->glyph->outline, &ftmat);
 
-        if (gli_conf_lcd)
+        if (gli_conf_lcd) {
+            FT_Library_SetLcdFilter(ftlib, FT_LCD_FILTER_NONE);
             err = FT_Render_Glyph(f->face->glyph, FT_RENDER_MODE_LCD);
-        else
+        } else
             err = FT_Render_Glyph(f->face->glyph, FT_RENDER_MODE_LIGHT);
+
         if (err)
             winabort("FT_Render_Glyph");
 

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -31,6 +31,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_OUTLINE_H
+#include FT_LCD_FILTER_H
 
 #include <math.h> /* for pow() */
 #include "uthash.h" /* for kerning cache */


### PR DESCRIPTION
Gargoyle does its own subpixel filtering of rendered fonts. This used to work fine with versions of FreeType prior to 2.10.3, but 2.10.3 and up use a default set of filter weights.

Previously, one would need to explicitly set the filter weights for any filtering to occur, leaving Gargoyle free to perform the filtering itself.