### PR TITLE
Remove Gargoyle's filtering in favor of FreeType's

### DIFF
--- a/garglk/config.c
+++ b/garglk/config.c
@@ -411,17 +411,23 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
             gli_set_lcdfilter(arg);
 
         if (!strcmp(cmd, "lcdweights")) {
+            int i;
             char *start = arg;
             char *end;
+            unsigned char weights[5];
 
-            for (int i = 0; i < 5; ++i) {
-                gli_conf_lcd_weights[i] = strtoul(start, &end, 10);
+            for (i = 0; i < 5; ++i) {
+                weights[i] = strtoul(start, &end, 10);
 
                 if (start == end) {
                     break;
                 }
 
                 start = end;
+            }
+
+            if (i == 5) {
+                memcpy(gli_conf_lcd_weights, weights, sizeof weights);
             }
         }
 

--- a/garglk/config.c
+++ b/garglk/config.c
@@ -137,7 +137,6 @@ int gli_caret_shape = 2;
 int gli_link_style = 1;
 
 int gli_conf_lcd = 1;
-int gli_conf_lcd_filter = -1;
 unsigned char gli_conf_lcd_weights[5] = {28, 56, 85, 56, 28};
 
 int gli_wmarginx = 15;
@@ -409,7 +408,7 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
             gli_conf_lcd = atoi(arg);
 
         if (!strcmp(cmd, "lcdfilter"))
-            gli_conf_lcd_filter = atoi(arg);
+            gli_set_lcdfilter(arg);
 
         if (!strcmp(cmd, "lcdweights")) {
             char *start = arg;

--- a/garglk/config.c
+++ b/garglk/config.c
@@ -137,6 +137,8 @@ int gli_caret_shape = 2;
 int gli_link_style = 1;
 
 int gli_conf_lcd = 1;
+int gli_conf_lcd_filter = -1;
+unsigned char gli_conf_lcd_weights[5] = {28, 56, 85, 56, 28};
 
 int gli_wmarginx = 15;
 int gli_wmarginy = 15;
@@ -259,6 +261,8 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
         else if ((!strcmp(cmd, "monofont") || !strcmp(cmd, "propfont")))
             arg = strtok(NULL, "\r\n#");
         else if ((!strncmp(cmd, "mono", 4) || !strncmp(cmd, "prop", 4)) && strlen(cmd) == 5)
+            arg = strtok(NULL, "\r\n#");
+        else if (!strcmp(cmd, "lcdweights"))
             arg = strtok(NULL, "\r\n#");
         else if (!strcmp(cmd, "moreprompt"))
             arg = strtok(NULL, "\r\n");
@@ -403,6 +407,24 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
 
         if (!strcmp(cmd, "lcd"))
             gli_conf_lcd = atoi(arg);
+
+        if (!strcmp(cmd, "lcdfilter"))
+            gli_conf_lcd_filter = atoi(arg);
+
+        if (!strcmp(cmd, "lcdweights")) {
+            char *start = arg;
+            char *end;
+
+            for (int i = 0; i < 5; ++i) {
+                gli_conf_lcd_weights[i] = strtoul(start, &end, 10);
+
+                if (start == end) {
+                    break;
+                }
+
+                start = end;
+            }
+        }
 
         if (!strcmp(cmd, "caretshape"))
             gli_caret_shape = atoi(arg);

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -117,13 +117,13 @@ void gli_set_lcdfilter(const char *filter)
 {
     use_freetype_preset_filter = true;
 
-    if (strcasecmp(filter, "none") == 0) {
+    if (strcmp(filter, "none") == 0) {
         freetype_preset_filter = FT_LCD_FILTER_NONE;
-    } else if (strcasecmp(filter, "default") == 0) {
+    } else if (strcmp(filter, "default") == 0) {
         freetype_preset_filter = FT_LCD_FILTER_DEFAULT;
-    } else if (strcasecmp(filter, "light") == 0) {
+    } else if (strcmp(filter, "light") == 0) {
         freetype_preset_filter = FT_LCD_FILTER_LIGHT;
-    } else if (strcasecmp(filter, "legacy") == 0) {
+    } else if (strcmp(filter, "legacy") == 0) {
         freetype_preset_filter = FT_LCD_FILTER_LEGACY;
     } else {
         use_freetype_preset_filter = false;

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -21,6 +21,7 @@
  *                                                                            *
  *****************************************************************************/
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -109,6 +110,26 @@ static const int gli_bpp = 4;
 static FT_Library ftlib;
 static FT_Matrix ftmat;
 
+static bool use_freetype_preset_filter = false;
+static FT_LcdFilter freetype_preset_filter = FT_LCD_FILTER_DEFAULT;
+
+void gli_set_lcdfilter(const char *filter)
+{
+    use_freetype_preset_filter = true;
+
+    if (strcasecmp(filter, "none") == 0) {
+        freetype_preset_filter = FT_LCD_FILTER_NONE;
+    } else if (strcasecmp(filter, "default") == 0) {
+        freetype_preset_filter = FT_LCD_FILTER_DEFAULT;
+    } else if (strcasecmp(filter, "light") == 0) {
+        freetype_preset_filter = FT_LCD_FILTER_LIGHT;
+    } else if (strcasecmp(filter, "legacy") == 0) {
+        freetype_preset_filter = FT_LCD_FILTER_LEGACY;
+    } else {
+        use_freetype_preset_filter = false;
+    }
+}
+
 /*
  * Font loading
  */
@@ -184,8 +205,8 @@ static void loadglyph(font_t *f, glui32 cid)
             FT_Outline_Transform(&f->face->glyph->outline, &ftmat);
 
         if (gli_conf_lcd) {
-            if (((gli_conf_lcd_filter >= 0) && (gli_conf_lcd_filter < 4)) || (gli_conf_lcd_filter == 16))
-                FT_Library_SetLcdFilter(ftlib, (FT_LcdFilter)gli_conf_lcd_filter);
+            if (use_freetype_preset_filter)
+                FT_Library_SetLcdFilter(ftlib, freetype_preset_filter);
             else
                 FT_Library_SetLcdFilterWeights(ftlib, gli_conf_lcd_weights);
 

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -228,6 +228,8 @@ extern int gli_tmarginx;
 extern int gli_tmarginy;
 
 extern int gli_conf_lcd;
+extern int gli_conf_lcd_filter;
+extern unsigned char gli_conf_lcd_weights[5];
 
 extern int gli_conf_graphics;
 extern int gli_conf_sound;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -709,6 +709,7 @@ int gli_draw_string_uni(int x, int y, int f, unsigned char *rgb, glui32 *text, i
 int gli_string_width_uni(int f, glui32 *text, int len, int spw);
 void gli_draw_caret(int x, int y);
 void gli_draw_picture(picture_t *pic, int x, int y, int x0, int y0, int x1, int y1);
+void gli_set_lcdfilter(const char *filter);
 
 void gli_startup(int argc, char *argv[]);
 void gli_read_config(int argc, char **argv);


### PR DESCRIPTION
Also adds two new configuration options, `lcdfilter` and `lcdweights`. See the commit's message for details; Github wants to format the ordered sub-lists with roman numerals when in this case it's important for them to be decimals. Rather than fight with Github's Markdown rendering weirdness, I'm just going to refer to the plaintext form that's in the commit message already.

One additional note about this commit: it does make text look significantly worse when using a gamma other than 1.0, since the 'gamma correction' is applied *after* filtering, rather than before. On the plus side, it makes text sharper (even with Gargoyle's filter weights).. But it also shows significantly worse color fringes.

This problem will be fixed once proper gamma-correct linear alpha blending is implemented in my next pull request.