### PR TITLE
Accurate gamma correction when rendering text

### DIFF
--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -91,7 +91,7 @@ struct font_s
  */
 
 static unsigned short gammamap[256];
-static unsigned short gammainv[256 << GAMMA_SHIFT];
+static unsigned char gammainv[256 << GAMMA_SHIFT];
 
 static const int gammamax = (256 << GAMMA_SHIFT) - 1;
 

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -37,7 +37,10 @@
 #include <math.h> /* for pow() */
 #include "uthash.h" /* for kerning cache */
 
+#define GAMMA_SHIFT 3
+
 #define mul255(a,b) (((a) * ((b) + 1)) >> 8)
+#define mulhigh(a,b) (((a) * ((b) + 1)) >> (8 + GAMMA_SHIFT))
 #define grayscale(r,g,b) ((30 * (r) + 59 * (g) + 11 * (b)) / 100)
 
 #ifdef _WIN32
@@ -87,7 +90,10 @@ struct font_s
  * Globals
  */
 
-static unsigned char gammamap[256];
+static unsigned short gammamap[256];
+static unsigned short gammainv[256 << GAMMA_SHIFT];
+
+static const int gammamax = (256 << GAMMA_SHIFT) - 1;
 
 static font_t gfont_table[8];
 
@@ -148,12 +154,6 @@ static int touni(int enc)
         case ENC_MDASH: return UNI_MDASH;
     }
     return enc;
-}
-
-static void gammacopy(unsigned char *dst, unsigned char *src, int n)
-{
-    while (n--)
-        *dst++ = gammamap[*src++];
 }
 
 static int findhighglyph(glui32 cid, fentry_t *entries, int length)
@@ -226,7 +226,7 @@ static void loadglyph(font_t *f, glui32 cid)
         glyphs[x].h = f->face->glyph->bitmap.rows;
         glyphs[x].pitch = f->face->glyph->bitmap.pitch;
         glyphs[x].data = malloc(datasize);
-        gammacopy(glyphs[x].data, f->face->glyph->bitmap.buffer, datasize);
+        memcpy(glyphs[x].data, f->face->glyph->bitmap.buffer, datasize);
     }
 
     if (cid < 256)
@@ -384,7 +384,10 @@ void gli_initialize_fonts(void)
     int i;
 
     for (i = 0; i < 256; i++)
-        gammamap[i] = pow(i / 255.0, gli_conf_gamma) * 255.0;
+        gammamap[i] = pow(i / 255.0, gli_conf_gamma) * gammamax + 0.5;
+
+    for (i = 0; i <= gammamax; i++)
+        gammainv[i] = pow(i / (float)gammamax, 1.0 / gli_conf_gamma) * 255.0 + 0.5;
 
     err = FT_Init_FreeType(&ftlib);
     if (err)
@@ -472,6 +475,79 @@ void gli_draw_pixel_lcd(int x, int y, unsigned char *alpha, unsigned char *rgb)
 #endif
 }
 
+static void draw_pixel_gamma(int x, int y, unsigned char alpha, unsigned char *rgb)
+{
+    unsigned char *p = gli_image_rgb + y * gli_image_s + x * gli_bpp;
+    unsigned short invalf = gammamax - (alpha * gammamax / 255);
+    unsigned short bg[3] = {
+        gammamap[p[0]],
+        gammamap[p[1]],
+        gammamap[p[2]]
+    };
+    unsigned short fg[3] = {
+        gammamap[rgb[0]],
+        gammamap[rgb[1]],
+        gammamap[rgb[2]]
+    };
+
+    if (x < 0 || x >= gli_image_w)
+        return;
+    if (y < 0 || y >= gli_image_h)
+        return;
+#ifdef WIN32
+    p[0] = gammainv[fg[2] + mulhigh((int)bg[0] - fg[2], invalf)];
+    p[1] = gammainv[fg[1] + mulhigh((int)bg[1] - fg[1], invalf)];
+    p[2] = gammainv[fg[0] + mulhigh((int)bg[2] - fg[0], invalf)];
+#elif defined EFL_1BPP
+    int gray = grayscale( fg[0], fg[1], fg[2] );
+    p[0] = gammainv[gray + mulhigh((int)bg[0] - gray, invalf)];
+#else
+    p[0] = gammainv[fg[2] + mulhigh((int)bg[0] - fg[2], invalf)];
+    p[1] = gammainv[fg[1] + mulhigh((int)bg[1] - fg[1], invalf)];
+    p[2] = gammainv[fg[0] + mulhigh((int)bg[2] - fg[0], invalf)];
+    p[3] = 0xFF;
+#endif
+}
+
+static void draw_pixel_lcd_gamma(int x, int y, unsigned char *alpha, unsigned char *rgb)
+{
+    unsigned char *p = gli_image_rgb + y * gli_image_s + x * gli_bpp;
+    unsigned short invalf[3] = {
+        gammamax - (alpha[0] * gammamax / 255),
+        gammamax - (alpha[1] * gammamax / 255),
+        gammamax - (alpha[2] * gammamax / 255)
+    };
+    unsigned short bg[3] = {
+        gammamap[p[0]],
+        gammamap[p[1]],
+        gammamap[p[2]]
+    };
+    unsigned short fg[3] = {
+        gammamap[rgb[0]],
+        gammamap[rgb[1]],
+        gammamap[rgb[2]]
+    };
+
+    if (x < 0 || x >= gli_image_w)
+        return;
+    if (y < 0 || y >= gli_image_h)
+        return;
+#ifdef WIN32
+    p[0] = gammainv[fg[2] + mulhigh((int)bg[0] - fg[2], invalf[2])];
+    p[1] = gammainv[fg[1] + mulhigh((int)bg[1] - fg[1], invalf[1])];
+    p[2] = gammainv[fg[0] + mulhigh((int)bg[2] - fg[0], invalf[0])];
+#elif defined EFL_1BPP
+    int gray = grayscale( fg[0], fg[1], fg[2] );
+    int invalfgray = grayscale( invalf[0], invalf[1], invalf[2] );
+    p[0] = gammainv[gray + mulhigh((int)bg[0] - gray, invalfgray)];
+#else
+    p[0] = gammainv[fg[2] + mulhigh((int)bg[0] - fg[2], invalf[2])];
+    p[1] = gammainv[fg[1] + mulhigh((int)bg[1] - fg[1], invalf[1])];
+    p[2] = gammainv[fg[0] + mulhigh((int)bg[2] - fg[0], invalf[0])];
+    p[3] = 0xFF;
+#endif
+}
+
 
 static inline void draw_bitmap(bitmap_t *b, int x, int y, unsigned char *rgb)
 {
@@ -494,6 +570,31 @@ static inline void draw_bitmap_lcd(bitmap_t *b, int x, int y, unsigned char *rgb
         for (i = 0, j = 0; i < b->w; i += 3, j ++)
         {
             gli_draw_pixel_lcd(x + b->lsb + j, y - b->top + k, b->data + k * b->pitch + i, rgb);
+        }
+    }
+}
+
+static inline void draw_bitmap_gamma(bitmap_t *b, int x, int y, unsigned char *rgb)
+{
+    int i, k, c;
+    for (k = 0; k < b->h; k++)
+    {
+        for (i = 0; i < b->w; i ++)
+        {
+            c = b->data[k * b->pitch + i];
+            draw_pixel_gamma(x + b->lsb + i, y - b->top + k, c, rgb);
+        }
+    }
+}
+
+static inline void draw_bitmap_lcd_gamma(bitmap_t *b, int x, int y, unsigned char *rgb)
+{
+    int i, j, k;
+    for (k = 0; k < b->h; k++)
+    {
+        for (i = 0, j = 0; i < b->w; i += 3, j ++)
+        {
+            draw_pixel_lcd_gamma(x + b->lsb + j, y - b->top + k, b->data + k * b->pitch + i, rgb);
         }
     }
 }
@@ -724,9 +825,9 @@ int gli_draw_string(int x, int y, int fidx, unsigned char *rgb,
         sx = x % GLI_SUBPIX;
 
                 if (gli_conf_lcd)
-                    draw_bitmap_lcd(&glyphs[sx], px, y, rgb);
+                    draw_bitmap_lcd_gamma(&glyphs[sx], px, y, rgb);
                 else
-                    draw_bitmap(&glyphs[sx], px, y, rgb);
+                    draw_bitmap_gamma(&glyphs[sx], px, y, rgb);
 
         if (spw >= 0 && c == ' ')
             x += spw;
@@ -782,9 +883,9 @@ int gli_draw_string_uni(int x, int y, int fidx, unsigned char *rgb,
         sx = x % GLI_SUBPIX;
 
                 if (gli_conf_lcd)
-                    draw_bitmap_lcd(&glyphs[sx], px, y, rgb);
+                    draw_bitmap_lcd_gamma(&glyphs[sx], px, y, rgb);
                 else
-                    draw_bitmap(&glyphs[sx], px, y, rgb);
+                    draw_bitmap_gamma(&glyphs[sx], px, y, rgb);
 
         if (spw >= 0 && c == ' ')
             x += spw;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -228,7 +228,6 @@ extern int gli_tmarginx;
 extern int gli_tmarginy;
 
 extern int gli_conf_lcd;
-extern int gli_conf_lcd_filter;
 extern unsigned char gli_conf_lcd_weights[5];
 
 extern int gli_conf_graphics;

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -42,8 +42,6 @@ caps          0               # Force uppercase input  -- 0=off 1=on
 graphics      1               # enable graphics
 sound         1               # enable sound
 
-lcd           1               # 0=grayscale 1=subpixel
-
 fullscreen    0               # set to 1 for fullscreen (Windows/Unix only)
 
 
@@ -101,17 +99,68 @@ gfont 10      monor           # User2
 
 
 #===============================================================================
+# Text LCD Filtering
+#-------------------------------------------------------------------------------
+#
+# When using LCD subpixel rendering, the filter used (if not set otherwise) will
+# be equivalent to the filter Gargoyle has always used. This looks fairly good
+# without gamma correction, but might be blurrier than some people prefer.
+#
+# The available values for lcdfilter are:
+#
+#   1: none (equiv. custom filter: 0 0 255 0 0)
+#      This filter looks very ugly and is not recommended. However, it is the
+#      absolute sharpest, and when used with the correct gamma value on a high-
+#      DPI display, can give the clearest and sharpest possible text.
+#
+#   2: default (equiv. custom filter: 8, 77, 86, 77, 8)
+#      This is not the default filter for Gargoyle, but it is FreeType's default
+#      filter for LCD rendering. It's similar to Gargoyle's, but a tad sharper,
+#      and is color balanced (the values for the filter add up to 256), unlike
+#      Gargoyle's filter (which add up to less than - but close to - 256, which
+#      can sometimes lead to slightly pale colors when using gamma correction).
+#
+#   3: light (equiv. custom filter: 0 85 86 85 0)
+#      This filter is color-balanced like the default one, but is as sharp as
+#      possible while also attempting to eliminate color fringes caused by the
+#      use of subpixel rendering. However, while using 'default' will also help
+#      eliminate such color fringes while not using gamma correction (by setting
+#      gamma to 1.0), this 'light' filter is less forgiving. Using 'light' is
+#      generally recommended most when using the appropriate gamma correction
+#      for your display.
+#
+#   4: legacy (no equiv. custom filter; uses different algorithm)
+#      This filter is similar to 'none', but with its effect significantly toned
+#      down. The result is a very sharp filter that might not be TOO noticeable.
+#      However, it was designed for fully hinted text that's been snapped to the
+#      pixel grid of the display, and causes severe color fringes otherwise.
+#      Since Gargoyle does not use font hinting, the color fringes caused by
+#      this filter can be just as noticeable as the ones caused by 'none'.
+#
+# If any other value is set, the custom filter is used. If one is not set, the
+# custom filter will use values equivalent to how Gargoyle has filtered subpixel
+# text in the past. By default, Gargoyle does not use gamma correction.
+#
+# When using gamma correction and LCD subpixel font rendering, it's recommended
+# to set lcdfilter to either 'default' or 'light'.
+#
+# If you choose your own filter, it's recommended to follow the advice at the
+# top of the following FreeType documentation page:
+# https://www.freetype.org/freetype2/docs/reference/ft2-lcd_rendering.html
+
+lcd           1               # 0=grayscale 1=subpixel
+lcdfilter     custom          # subpixel filter, set to 'default' if blurry
+lcdweights    28 56 85 56 28  # custom filter, default is Gargoyle's own
+
+
+#===============================================================================
 # Colors and style definitions
 #-------------------------------------------------------------------------------
 #
 # Default here is for black text on a white background.
 #
-# If you choose the reverse, light text on a dark background,
-# you may want to set gamma to 0.7 or similar to make the
-# text fatter.
-#
 # Depending on your screen you may want to tweak the gamma.
-# Good values to try are 0.7, 1.0 and 1.4.
+# Good values to try are 1.0, 1.8 and 2.2.
 #
 # There are separate colors for TextBuffer and TextGrid windows.
 # TextBuffers are main text windows, TextGrids are used mainly for

--- a/garglk/standalone.ini
+++ b/garglk/standalone.ini
@@ -38,8 +38,6 @@ caps          0               # Force input to uppercase -- 0=off 1=on
 graphics      1               # enable graphics
 sound         1               # enable sound
 
-lcd           1               # 0=grayscale 1=subpixel
-
 
 #===============================================================================
 # Fonts, sizes and spaces
@@ -102,17 +100,68 @@ gfont 10      monor           # User2
 
 
 #===============================================================================
+# Text LCD Filtering
+#-------------------------------------------------------------------------------
+#
+# When using LCD subpixel rendering, the filter used (if not set otherwise) will
+# be equivalent to the filter Gargoyle has always used. This looks fairly good
+# without gamma correction, but might be blurrier than some people prefer.
+#
+# The available values for lcdfilter are:
+#
+#   1: none (equiv. custom filter: 0 0 255 0 0)
+#      This filter looks very ugly and is not recommended. However, it is the
+#      absolute sharpest, and when used with the correct gamma value on a high-
+#      DPI display, can give the clearest and sharpest possible text.
+#
+#   2: default (equiv. custom filter: 8, 77, 86, 77, 8)
+#      This is not the default filter for Gargoyle, but it is FreeType's default
+#      filter for LCD rendering. It's similar to Gargoyle's, but a tad sharper,
+#      and is color balanced (the values for the filter add up to 256), unlike
+#      Gargoyle's filter (which add up to less than - but close to - 256, which
+#      can sometimes lead to slightly pale colors when using gamma correction).
+#
+#   3: light (equiv. custom filter: 0 85 86 85 0)
+#      This filter is color-balanced like the default one, but is as sharp as
+#      possible while also attempting to eliminate color fringes caused by the
+#      use of subpixel rendering. However, while using 'default' will also help
+#      eliminate such color fringes while not using gamma correction (by setting
+#      gamma to 1.0), this 'light' filter is less forgiving. Using 'light' is
+#      generally recommended most when using the appropriate gamma correction
+#      for your display.
+#
+#   4: legacy (no equiv. custom filter; uses different algorithm)
+#      This filter is similar to 'none', but with its effect significantly toned
+#      down. The result is a very sharp filter that might not be TOO noticeable.
+#      However, it was designed for fully hinted text that's been snapped to the
+#      pixel grid of the display, and causes severe color fringes otherwise.
+#      Since Gargoyle does not use font hinting, the color fringes caused by
+#      this filter can be just as noticeable as the ones caused by 'none'.
+#
+# If any other value is set, the custom filter is used. If one is not set, the
+# custom filter will use values equivalent to how Gargoyle has filtered subpixel
+# text in the past. By default, Gargoyle does not use gamma correction.
+#
+# When using gamma correction and LCD subpixel font rendering, it's recommended
+# to set lcdfilter to either 'default' or 'light'.
+#
+# If you choose your own filter, it's recommended to follow the advice at the
+# top of the following FreeType documentation page:
+# https://www.freetype.org/freetype2/docs/reference/ft2-lcd_rendering.html
+
+lcd           1               # 0=grayscale 1=subpixel
+lcdfilter     custom          # subpixel filter, set to 'default' if blurry
+lcdweights    28 56 85 56 28  # custom filter, default is Gargoyle's own
+
+
+#===============================================================================
 # Colors and style definitions
 #-------------------------------------------------------------------------------
 #
 # Default here is for black text on a white background.
 #
-# If you choose the reverse, light text on a dark background,
-# you may want to set gamma to 0.7 or similar to make the
-# text fatter.
-#
 # Depending on your screen you may want to tweak the gamma.
-# Good values to try are 0.7, 1.0 and 1.4.
+# Good values to try are 1.0, 1.8 and 2.2.
 #
 # There are separate colors for TextBuffer and TextGrid windows.
 # TextBuffers are main text windows, TextGrids are used mainly for


### PR DESCRIPTION
I've tried going with the 'alternate versions of functions' route this time, so that png and jpeg files are never rendered with inaccurate colors (at least, not due to my code here). I've also added some modifications to the configuration files, in particular adding documentation to the options added from #433.

I wasn't sure if `gamma` should be moved into the new section I made or not, and I figured before making that drastic of a change I'd get feedback on the modifications I'd already made.

**Edit**: Also, I should mention I've had a few ideas about how to allow someone to type in `srgb` or `rec709` instead of a number for the gamma value. Felt more important to get the code working without further configuration additions, though.