### PR TITLE
Use Unicode for the more prompt

### DIFF
--- a/garglk/config.c
+++ b/garglk/config.c
@@ -125,7 +125,9 @@ int gli_override_fg_val = 0;
 int gli_override_bg_val = 0;
 int gli_override_reverse = 0;
 
-char *gli_more_prompt = "\207 more \207";
+static const char *base_more_prompt = "— more —";
+glui32 *gli_more_prompt;
+glui32 gli_more_prompt_len;
 int gli_more_align = 0;
 int gli_more_font = PROPB;
 
@@ -271,7 +273,7 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
             continue;
 
         if (!strcmp(cmd, "moreprompt"))
-            gli_more_prompt = strdup(arg);
+            base_more_prompt = strdup(arg);
 
         if (!strcmp(cmd, "morecolor"))
         {
@@ -631,6 +633,11 @@ void gli_startup(int argc, char *argv[])
         glkunix_set_base_file(argv[argc-1]);
 
     gli_read_config(argc, argv);
+
+    gli_more_prompt = malloc((1 + strlen(base_more_prompt)) * sizeof *gli_more_prompt);
+    if (gli_more_prompt == NULL)
+        winabort("Unable to allocate memory for more prompt");
+    gli_more_prompt_len = gli_parse_utf8((unsigned char *)base_more_prompt, strlen(base_more_prompt), gli_more_prompt, strlen(base_more_prompt));
 
     memcpy(gli_tstyles_def, gli_tstyles, sizeof(gli_tstyles_def));
     memcpy(gli_gstyles_def, gli_gstyles, sizeof(gli_gstyles_def));

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -112,18 +112,7 @@ extern int gli_more_focus;
 extern int gli_cellw;
 extern int gli_cellh;
 
-/* Usurp C1 space for ligatures and smart typography glyphs */
-#define ENC_LIG_FI 128
-#define ENC_LIG_FL 129
-#define ENC_LSQUO 130
-#define ENC_RSQUO 131
-#define ENC_LDQUO 132
-#define ENC_RDQUO 133
-#define ENC_NDASH 134
-#define ENC_MDASH 135
-#define ENC_FLOWBREAK 136
-
-/* These are the Unicode versions */
+/* Unicode ligatures and smart typography glyphs */
 #define UNI_LIG_FI	0xFB01
 #define UNI_LIG_FL	0xFB02
 #define UNI_LSQUO	0x2018
@@ -283,7 +272,8 @@ extern float gli_conf_monosize;
 extern float gli_conf_propaspect;
 extern float gli_conf_monoaspect;
 
-extern char *gli_more_prompt;
+extern glui32 *gli_more_prompt;
+extern glui32 gli_more_prompt_len;
 extern int gli_more_align;
 extern int gli_more_font;
 
@@ -702,8 +692,6 @@ void gli_draw_pixel(int x, int y, unsigned char alpha, unsigned char *rgb);
 void gli_draw_pixel_lcd(int x, int y, unsigned char *alpha, unsigned char *rgb);
 void gli_draw_clear(unsigned char *rgb);
 void gli_draw_rect(int x, int y, int w, int h, unsigned char *rgb);
-int gli_draw_string(int x, int y, int f, unsigned char *rgb, unsigned char *text, int len, int spacewidth);
-int gli_string_width(int f, unsigned char *text, int len, int spw);
 int gli_draw_string_uni(int x, int y, int f, unsigned char *rgb, glui32 *text, int len, int spacewidth);
 int gli_string_width_uni(int f, glui32 *text, int len, int spw);
 void gli_draw_caret(int x, int y);

--- a/garglk/wintext.c
+++ b/garglk/wintext.c
@@ -664,8 +664,8 @@ void win_textbuffer_redraw(window_t *win)
                 x1/GLI_SUBPIX - x/GLI_SUBPIX, gli_leading,
                 color);
 
-        w = gli_string_width(gli_more_font,
-                gli_more_prompt, strlen(gli_more_prompt), -1);
+        w = gli_string_width_uni(gli_more_font,
+                gli_more_prompt, gli_more_prompt_len, -1);
 
         if (gli_more_align == 1)    /* center */
             x = x0 + SLOP + (x1 - x0 - w - SLOP * 2) / 2;
@@ -673,9 +673,9 @@ void win_textbuffer_redraw(window_t *win)
             x = x1 - SLOP - w;
 
         color = gli_override_fg_set ? gli_more_color : win->fgcolor;
-        gli_draw_string(x, y + gli_baseline,
+        gli_draw_string_uni(x, y + gli_baseline,
                 gli_more_font, color,
-                gli_more_prompt, strlen(gli_more_prompt), -1);
+                gli_more_prompt, gli_more_prompt_len, -1);
         y1 = y; /* don't want pictures overdrawing "[more]" */
 
         /* try to claim the focus */


### PR DESCRIPTION
This allows the removal of several functions which served only to
support non-Unicode text, and the more prompt was the last user of these
functions.