### PR TITLE
gtk: Partial workaround for visual glitches when running under GNOME3

### DIFF
--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -587,6 +587,8 @@ void winopen(void)
     g_signal_connect(imcontext, "commit",
         G_CALLBACK(oninput), NULL);
 
+    gtk_window_set_decorated(GTK_WINDOW(frame), FALSE);
+
     if (gli_conf_fullscreen)
     {
         GdkMonitor *monitor;


### PR DESCRIPTION
by unconditionally telling GTK that we we aren't doing client-side
decorations.  Fixes window scrolling and typing not showing up until
enter is pressed,

Unfortunately window still does not have a title bar or adjustment
handles, but it's at least usable.