### PR TITLE
Correct visual glitches and functional regressions when running under Gnome+Wayland (with CSD)

### DIFF
--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -556,30 +556,29 @@ void winopen(void)
 
     frame = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     gtk_widget_set_can_focus(frame, TRUE);
-    gtk_widget_set_events(frame, GDK_BUTTON_PRESS_MASK
-                               | GDK_BUTTON_RELEASE_MASK
-                               | GDK_POINTER_MOTION_MASK
-                               | GDK_POINTER_MOTION_HINT_MASK
-                               | GDK_SCROLL_MASK);
-    g_signal_connect(frame, "button_press_event",
-                       G_CALLBACK(onbuttondown), NULL);
-    g_signal_connect(frame, "button_release_event",
-                       G_CALLBACK(onbuttonup), NULL);
-    g_signal_connect(frame, "scroll_event",
-                       G_CALLBACK(onscroll), NULL);
     g_signal_connect(frame, "key_press_event",
                        G_CALLBACK(onkeydown), NULL);
     g_signal_connect(frame, "key_release_event",
                        G_CALLBACK(onkeyup), NULL);
     g_signal_connect(frame, "destroy",
                        G_CALLBACK(onquit), "WM destroy");
-    g_signal_connect(frame, "motion_notify_event",
-        G_CALLBACK(onmotion), NULL);
 
     canvas = gtk_drawing_area_new();
+    gtk_widget_set_events(canvas, GDK_BUTTON_PRESS_MASK
+                               | GDK_BUTTON_RELEASE_MASK
+                               | GDK_POINTER_MOTION_MASK
+                               | GDK_POINTER_MOTION_HINT_MASK
+                               | GDK_SCROLL_MASK);
+    g_signal_connect(canvas, "button_press_event",
+                       G_CALLBACK(onbuttondown), NULL);
+    g_signal_connect(canvas, "button_release_event",
+                       G_CALLBACK(onbuttonup), NULL);
+    g_signal_connect(canvas, "scroll_event",
+                       G_CALLBACK(onscroll), NULL);
+    g_signal_connect(canvas, "motion_notify_event",
+        G_CALLBACK(onmotion), NULL);
+
     g_signal_connect(canvas, "size_allocate",
-                       G_CALLBACK(onresize), NULL);
-    g_signal_connect(canvas, "size_request",
                        G_CALLBACK(onresize), NULL);
     g_signal_connect(canvas, "draw",
                        G_CALLBACK(ondraw), NULL);

--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -611,6 +611,11 @@ void winopen(void)
 
     wintitle();
 
+    gtk_window_set_geometry_hints(GTK_WINDOW(frame),
+      GTK_WIDGET(frame), &geom,
+      GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE);
+//    gtk_window_set_default_size(GTK_WINDOW(frame), defw, defh);
+
     gtk_widget_show(canvas);
     gtk_widget_show(frame);
 

--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -579,7 +579,7 @@ void winopen(void)
     canvas = gtk_drawing_area_new();
     g_signal_connect(frame, "size_allocate",
                        G_CALLBACK(onresize), NULL);
-    g_signal_connect(frame, "draw",
+    g_signal_connect(canvas, "draw",
                        G_CALLBACK(ondraw), NULL);
     gtk_container_add(GTK_CONTAINER(frame), canvas);
 

--- a/garglk/sysgtk.c
+++ b/garglk/sysgtk.c
@@ -577,11 +577,15 @@ void winopen(void)
         G_CALLBACK(onmotion), NULL);
 
     canvas = gtk_drawing_area_new();
-    g_signal_connect(frame, "size_allocate",
+    g_signal_connect(canvas, "size_allocate",
+                       G_CALLBACK(onresize), NULL);
+    g_signal_connect(canvas, "size_request",
                        G_CALLBACK(onresize), NULL);
     g_signal_connect(canvas, "draw",
                        G_CALLBACK(ondraw), NULL);
     gtk_container_add(GTK_CONTAINER(frame), canvas);
+
+    gtk_widget_set_size_request(canvas, defw, defh);
 
     imcontext = gtk_im_multicontext_new();
     g_signal_connect(imcontext, "commit",
@@ -607,12 +611,6 @@ void winopen(void)
     }
 
     wintitle();
-
-    gtk_window_set_geometry_hints(GTK_WINDOW(frame),
-        GTK_WIDGET(frame), &geom,
-        GDK_HINT_MIN_SIZE | GDK_HINT_MAX_SIZE
-        );
-    gtk_window_set_default_size(GTK_WINDOW(frame), defw, defh);
 
     gtk_widget_show(canvas);
     gtk_widget_show(frame);


### PR DESCRIPTION
This patch series resolves all of the visual glitches and functional regressions described in #434 when running under Gnome+Wayland, with no new regressuins under Gnome+X11

Untested under KDE and other non-Gnome environments.