### PR TITLE
Use more precise math when blending color values

### DIFF
--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -37,10 +37,11 @@
 #include <math.h> /* for pow() */
 #include "uthash.h" /* for kerning cache */
 
-#define GAMMA_SHIFT 3
+#define GAMMA_BITS 11
+#define GAMMA_MAX ((1 << GAMMA_BITS) - 1)
 
-#define mul255(a,b) (((a) * ((b) + 1)) >> 8)
-#define mulhigh(a,b) (((a) * ((b) + 1)) >> (8 + GAMMA_SHIFT))
+#define mul255(a,b) (((short)(a) * (b) + 127) / 255)
+#define mulhigh(a,b) (((int)(a) * (b) + (1 << (GAMMA_BITS - 1)) - 1) / GAMMA_MAX)
 #define grayscale(r,g,b) ((30 * (r) + 59 * (g) + 11 * (b)) / 100)
 
 typedef struct font_s font_t;
@@ -87,9 +88,7 @@ struct font_s
  */
 
 static unsigned short gammamap[256];
-static unsigned char gammainv[256 << GAMMA_SHIFT];
-
-static const int gammamax = (256 << GAMMA_SHIFT) - 1;
+static unsigned char gammainv[1 << GAMMA_BITS];
 
 static font_t gfont_table[8];
 
@@ -386,10 +385,10 @@ void gli_initialize_fonts(void)
     int i;
 
     for (i = 0; i < 256; i++)
-        gammamap[i] = pow(i / 255.0, gli_conf_gamma) * gammamax + 0.5;
+        gammamap[i] = pow(i / 255.0, gli_conf_gamma) * GAMMA_MAX + 0.5;
 
-    for (i = 0; i <= gammamax; i++)
-        gammainv[i] = pow(i / (float)gammamax, 1.0 / gli_conf_gamma) * 255.0 + 0.5;
+    for (i = 0; i <= GAMMA_MAX; i++)
+        gammainv[i] = pow(i / (float)GAMMA_MAX, 1.0 / gli_conf_gamma) * 255.0 + 0.5;
 
     err = FT_Init_FreeType(&ftlib);
     if (err)

--- a/garglk/draw.c
+++ b/garglk/draw.c
@@ -443,7 +443,7 @@ void gli_draw_pixel(int x, int y, unsigned char alpha, unsigned char *rgb)
 static void draw_pixel_gamma(int x, int y, unsigned char alpha, unsigned char *rgb)
 {
     unsigned char *p = gli_image_rgb + y * gli_image_s + x * gli_bpp;
-    unsigned short invalf = gammamax - (alpha * gammamax / 255);
+    unsigned short invalf = GAMMA_MAX - (alpha * GAMMA_MAX / 255);
     unsigned short bg[3] = {
         gammamap[p[0]],
         gammamap[p[1]],
@@ -469,9 +469,9 @@ static void draw_pixel_lcd_gamma(int x, int y, unsigned char *alpha, unsigned ch
 {
     unsigned char *p = gli_image_rgb + y * gli_image_s + x * gli_bpp;
     unsigned short invalf[3] = {
-        gammamax - (alpha[0] * gammamax / 255),
-        gammamax - (alpha[1] * gammamax / 255),
-        gammamax - (alpha[2] * gammamax / 255)
+        GAMMA_MAX - (alpha[0] * GAMMA_MAX / 255),
+        GAMMA_MAX - (alpha[1] * GAMMA_MAX / 255),
+        GAMMA_MAX - (alpha[2] * GAMMA_MAX / 255)
     };
     unsigned short bg[3] = {
         gammamap[p[0]],

--- a/garglk/wingfx.c
+++ b/garglk/wingfx.c
@@ -27,7 +27,7 @@
 #include "glk.h"
 #include "garglk.h"
 
-#define mul255(a,b) (((a) * ((b) + 1)) >> 8)
+#define mul255(a,b) (((short)(a) * (b) + 127) / 255)
 
 static void
 drawpicture(picture_t *src, window_graphics_t *dst,


### PR DESCRIPTION
# Change summary:

1. Changed `GAMMA_SHIFT` to `GAMMA_BITS` to more clearly portray its meaning
2. Changed `gammamax` to `GAMMA_MAX`, #defined for use in other constants
3. Changed `mul255()` and `mulhigh()` to use more precise math

# Rationale for changes:

In the past, the `mul255()` macro has been used to perform a 'multiply' operation on two pixel values, such that the two values multiply as if they were in the range of 0.0 to 1.0. This has basically only been used as part of the math for blending two colors based on an alpha value.

When I implemented gamma correction, I added an additional `mulhigh()` macro that behaved in much the same way, but with a maximum value that was determined by the `GAMMA_SHIFT` defined constant. `GAMMA_SHIFT` was made because that's how it's done in the FreeType demos' source code, but what it represents is how many more bits linear light values can use compared to standard 8-bit light values.

I wrote the `mulhigh()` macro to use the same basic formula as the `mul255()` macro, mostly because I was lazy and didn't want to double-check to see if there was any better way to do the math. The math for `mul255()` did work after all, even if it occasionally caused off-by-1 errors in the results.

However, after some experimentation, I've found that there's a more accurate way to implement both macros. I've also put some additional thought into using the term `GAMMA_SHIFT`, as it slightly obscures what the value is actually meant to represent: the number of bits to use for linear light values.

## Math Overview

The old math for the `mul255()` macro was as follows:  
`(a * (b + 1)) / 256`

However, the division at the end was implemented as `>> 8`, which likely is a little bit faster than division. However, dividing by 256, when the values are actually in the range of 0 to 255, is what makes the `b + 1` part necessary.

While marginally slower since it lacks bitshifting, this is much more accurate:  
`(a * b + 127) / 255`

Note that while the original method used `(b + 1)`, this new method does not use parentheses around the 'b' and the value being added. Instead, the value (which is now 127) is being added After 'a' and 'b' are multiplied together.

This is because to be honest, the '+ 127' isn't actually necessary for accuracy, but without it (simply `a * b / 255`) the results would essentially be 'floored'; that is to say, the following two are equivalent:

1. `a * b / 255`
2. `floor(((float)a / 255.0) * ((float)b / 255.0) * 255.0)`

By adding 127 to the product of 'a' and 'b', however, the result will be rounded
instead of floored. It's essentially the same as adding 0.5 before flooring.

The math is the same for `mulhigh()`, though instead of a hardcoded division by 255 and addition of 127 it uses `GAMMA_MAX` and `((1 << (GAMMA_BITS - 1)) - 1)`, respectively.

**Edit**: Whoops, forgot to include the last `- 1` when describing that bit at the end.