### PR TITLE
Remove the global "current event" object

### DIFF
--- a/garglk/event.c
+++ b/garglk/event.c
@@ -27,9 +27,6 @@
 #include "glk.h"
 #include "garglk.h"
 
-/* A pointer to the place where the pending glk_select() will store its
-   event. When not inside a glk_select() call, this will be NULL. */
-event_t *gli_curevent = NULL;
 static eventqueue_t *gli_events_logged = NULL;
 static eventqueue_t *gli_events_polled = NULL;
 static int gli_first_event = FALSE;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -105,7 +105,6 @@ extern int gli_terminated;
 
 extern window_t *gli_rootwin;
 extern window_t *gli_focuswin;
-extern event_t *gli_curevent;
 
 extern int gli_force_redraw;
 extern int gli_more_focus;

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -681,34 +681,31 @@ void gli_select(event_t *event, int polled)
 {
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 
-    gli_curevent = event;
     gli_event_clearevent(event);
 
     winpoll();
-    gli_dispatch_event(gli_curevent, polled);
+    gli_dispatch_event(event, polled);
 
-    if (gli_curevent->type == evtype_None && !polled)
+    if (event->type == evtype_None && !polled)
     {
         while (![monitor timeout])
         {
             winloop();
-            gli_dispatch_event(gli_curevent, polled);
+            gli_dispatch_event(event, polled);
 
-            if (gli_curevent->type == evtype_None)
+            if (event->type == evtype_None)
                 [monitor sleep];
             else
                 break;
         }
     }
 
-    if (gli_curevent->type == evtype_None && [monitor timeout])
+    if (event->type == evtype_None && [monitor timeout])
     {
         gli_event_store(evtype_Timer, NULL, 0, 0);
-        gli_dispatch_event(gli_curevent, polled);
+        gli_dispatch_event(event, polled);
         [monitor reset];
     }
-
-    gli_curevent = NULL;
 
     [pool drain];
 }

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -416,28 +416,25 @@ void winrepaint(int x0, int y0, int x1, int y1)
 
 void gli_select(event_t *event, int polled)
 {
-    gli_curevent = event;
     gli_event_clearevent(event);
 
     app->processEvents();
 
-    gli_dispatch_event(gli_curevent, polled);
+    gli_dispatch_event(event, polled);
 
     if (!polled)
     {
-        while (gli_curevent->type == evtype_None && !window->timed_out())
+        while (event->type == evtype_None && !window->timed_out())
         {
             app->processEvents(QEventLoop::WaitForMoreEvents);
-            gli_dispatch_event(gli_curevent, polled);
+            gli_dispatch_event(event, polled);
         }
     }
 
-    if (gli_curevent->type == evtype_None && window->timed_out())
+    if (event->type == evtype_None && window->timed_out())
     {
         gli_event_store(evtype_Timer, nullptr, 0, 0);
-        gli_dispatch_event(gli_curevent, polled);
+        gli_dispatch_event(event, polled);
         window->reset_timeout();
     }
-
-    gli_curevent = nullptr;
 }


### PR DESCRIPTION
This stopped being necessary over 10 years ago when queued events were added.