### PR TITLE
Handle input methods

### DIFF
--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -205,6 +205,27 @@ void Window::resizeEvent(QResizeEvent *event)
     event->accept();
 }
 
+QVariant View::inputMethodQuery(Qt::InputMethodQuery query) const {
+    switch (query)
+    {
+    case Qt::ImEnabled:
+        return QVariant(true);
+    default:
+        return QVariant();
+    }
+}
+
+// Handle compose key events (probably other input method events too).
+// See https://stackoverflow.com/questions/28793356/qt-and-dead-keys-in-a-custom-widget
+void View::inputMethodEvent(QInputMethodEvent *event) {
+    if (!event->commitString().isEmpty())
+    {
+        QKeyEvent key_event(QEvent::KeyPress, 0, Qt::NoModifier, event->commitString());
+        keyPressEvent(&key_event);
+    }
+    event->accept();
+}
+
 void View::paintEvent(QPaintEvent *event)
 {
     if (!gli_drawselect)

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -19,9 +19,13 @@ public:
     View(QWidget *parent) : QWidget(parent) {
         setFocusPolicy(Qt::StrongFocus);
         setMouseTracking(true);
+        setAttribute(Qt::WA_InputMethodEnabled, true);
     }
 
+    QVariant inputMethodQuery(Qt::InputMethodQuery query) const override;
+
 protected:
+    void inputMethodEvent(QInputMethodEvent *event) override;
     void paintEvent(QPaintEvent *) override;
     void keyPressEvent(QKeyEvent *) override;
     void mouseMoveEvent(QMouseEvent *) override;


### PR DESCRIPTION
This isn't well-documented as far as I can tell, but at the very least
this allows for the compose key on X11 to work.