### PR TITLE
Clean up/use include guards

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -28,6 +28,9 @@
  * http://www.eblong.com/zarf/glk/index.html
  */
 
+#ifndef GARGLK_GARGLK_H
+#define GARGLK_GARGLK_H
+
 #include <stddef.h>
 #include <stdio.h>
 
@@ -796,3 +799,5 @@ int attrequal(attr_t *a1, attr_t *a2);
 unsigned char *attrfg(style_t *styles, attr_t *attr);
 unsigned char *attrbg(style_t *styles, attr_t *attr);
 int attrfont(style_t *styles, attr_t *attr);
+
+#endif

--- a/garglk/garversion.h
+++ b/garglk/garversion.h
@@ -20,4 +20,9 @@
  *                                                                            *
  *****************************************************************************/
 
+#ifndef GARGLK_VERSION_H
+#define GARGLK_VERSION_H
+
 #define VERSION "2019.1"
+
+#endif

--- a/garglk/gi_blorb.h
+++ b/garglk/gi_blorb.h
@@ -1,5 +1,5 @@
-#ifndef _GI_BLORB_H
-#define _GI_BLORB_H
+#ifndef GARGLK_GI_BLORB_H
+#define GARGLK_GI_BLORB_H
 
 /* gi_blorb.h: Blorb library layer for Glk API.
     gi_blorb version 1.4.

--- a/garglk/gi_dispa.h
+++ b/garglk/gi_dispa.h
@@ -1,5 +1,5 @@
-#ifndef _GI_DISPA_H
-#define _GI_DISPA_H
+#ifndef GARGLK_GI_DISPA_H
+#define GARGLK_GI_DISPA_H
 
 /* gi_dispa.h: Header file for dispatch layer of Glk API, version 0.7.2.
     Designed by Andrew Plotkin <erkyrath@eblong.com>

--- a/garglk/glk.h
+++ b/garglk/glk.h
@@ -20,8 +20,8 @@
  *                                                                            *
  *****************************************************************************/
 
-#ifndef GLK_H
-#define GLK_H
+#ifndef GARGLK_GLK_H
+#define GARGLK_GLK_H
 
 /* glk.h: Header file for Glk API, version 0.7.3.
     Designed by Andrew Plotkin <erkyrath@eblong.com>

--- a/garglk/glkstart.h
+++ b/garglk/glkstart.h
@@ -21,8 +21,8 @@
     doesn't have to exist. In practice, it's small.
 */
 
-#ifndef GT_START_H
-#define GT_START_H
+#ifndef GARGLK_GT_START_H
+#define GARGLK_GT_START_H
 
 /* We define our own TRUE and FALSE and NULL, because ANSI
     is a strange world. */

--- a/garglk/launcher.h
+++ b/garglk/launcher.h
@@ -22,6 +22,9 @@
  *                                                                            *
  *****************************************************************************/
 
+#ifndef GARGLK_LAUNCHER_H
+#define GARGLK_LAUNCHER_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -39,3 +42,5 @@ __attribute__((__format__(__printf__, 1, 2)))
 extern void winmsg(const char *fmt, ...);
 extern int winterp(const char *path, const char *exe, const char *flags, const char *game);
 extern int rungame(const char *path, const char *game);
+
+#endif

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -21,6 +21,9 @@
  *                                                                            *
  *****************************************************************************/
 
+#ifndef GARGLK_SYSMAC_M
+#define GARGLK_SYSMAC_M
+
 #ifdef __ppc__
 #define UTF32StringEncoding NSUTF32BigEndianStringEncoding
 #else
@@ -98,3 +101,5 @@
 - (void) setCursor: (unsigned int) cursor;
 
 @end
+
+#endif

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -1,5 +1,5 @@
-#ifndef SYS_QT_H
-#define SYS_QT_H
+#ifndef GARGLK_SYSQT_H
+#define GARGLK_SYSQT_H
 
 #include <QCloseEvent>
 #include <QKeyEvent>


### PR DESCRIPTION
This includes adding guards where they didn't exist, and changing the
names of guards to be consistent (and to avoid undefined behavior:
names starting with _[A-Z] are reserved for the implementation).