### PR TITLE
Support building TADS with LLP64

### DIFF
--- a/tads/tads2/h_ix86_64.h
+++ b/tads/tads2/h_ix86_64.h
@@ -79,7 +79,7 @@ typedef unsigned short hix_uint16;
 #define osrndsz(s) (((s)+3) & ~3)
 
 /* round a pointer to worst-case alignment boundary */
-#define osrndpt(p) ((uchar *)((((ulong)(p)) + 3) & ~3))
+#define osrndpt(p) ((uchar *)((((unsigned long long)(p)) + 7) & ~7))
 
 /* read unaligned portable unsigned 2-byte value, returning int */
 #define osrp2(p) ((int)*(hix_uint16 *)(p))

--- a/tads/tads3/vmrefcnt.h
+++ b/tads/tads3/vmrefcnt.h
@@ -59,13 +59,13 @@ public:
     void add_ref(void *from, const char *msg)
     {
         add_ref();
-        printf("add_ref(this=%lx, cnt=%ld, from=%lx, %s)\n",
-               (long)this, cnt.get(), (long)from, msg);
+        printf("add_ref(this=%llx, cnt=%ld, from=%llx, %s)\n",
+               (unsigned long long)this, cnt.get(), (unsigned long long)from, msg);
     }
     void release_ref(void *from, const char *msg)
     {
-        printf("release_ref(this=%lx, cnt=%ld, from=%lx, %s)\n",
-               (long)this, cnt.get()-1, (long)from, msg);
+        printf("release_ref(this=%llx, cnt=%ld, from=%llx, %s)\n",
+               (unsigned long long)this, cnt.get()-1, (unsigned long long)from, msg);
         release_ref();
     }
     
@@ -164,8 +164,8 @@ public:
     /* debugging version */
     void release_ref(void *from, const char *msg)
     {
-        printf("release_ref(this=%lx, cnt=%ld, from=%lx, %s)\n",
-               (long)this, cnt.get()-1, (long)from, msg);
+        printf("release_ref(this=%llx, cnt=%ld, from=%llx, %s)\n",
+               (unsigned long long)this, cnt.get()-1, (unsigned long long)from, msg);
         release_ref();
     }
 


### PR DESCRIPTION
Specifically TADS assumes that a long is large enough to hold a pointer,
but on LLP64, it's not. This causes a build error with
x86_64-w64-mingw32.

This probably should be uintptr_t but that makes format strings ugly and
unsigned long long is fine until 128-bit systems come out.