### PR TITLE
Use the STL for event handling data structures

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -12,7 +12,7 @@ set(GARGLKINI "/etc/garglk.ini" CACHE STRING "Full path for garglk.ini")
 set(GARGLKPRE "" CACHE STRING "Binary prefix")
 
 add_library(garglk babeldata.c cgblorb.c cgdate.c cgfref.c cggestal.c cgmisc.c
-    cgstream.c cgstyle.c cgunicod.c config.c draw.cpp event.c fontdata.c
+    cgstream.c cgstyle.c cgunicod.c config.c draw.cpp event.cpp fontdata.c
     gi_blorb.c gi_dispa.c imgload.c imgscale.c winblank.c window.c wingfx.c
     wingrid.c winmask.c winpair.c wintext.c)
 c_standard(garglk 11)

--- a/garglk/Jamfile
+++ b/garglk/Jamfile
@@ -47,7 +47,7 @@ GARGSRCS =
     cgstyle.c cgstream.c cgunicod.c cgdate.c
     window.c winblank.c winpair.c wingrid.c
     wintext.c wingfx.c winmask.c
-    event.c draw.cpp config.c
+    event.cpp draw.cpp config.c
     imgload.c imgscale.c
     fontdata.c babeldata.c
     ;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -660,16 +660,8 @@ extern void gli_window_click(window_t *win, int x, int y);
 
 void gli_redraw_rect(int x0, int y0, int x1, int y1);
 
-void gli_input_guess_focus();
-void gli_input_more_focus();
-void gli_input_next_focus();
-void gli_input_scroll_focus();
 void gli_input_handle_key(glui32 key);
 void gli_input_handle_click(int x, int y);
-void gli_input_guess_focus(void);
-void gli_input_more_focus(void);
-void gli_input_next_focus(void);
-void gli_input_scroll_focus(void);
 void gli_event_store(glui32 type, window_t *win, glui32 val1, glui32 val2);
 
 extern stream_t *gli_new_stream(glui32 type, int readable, int writable,


### PR DESCRIPTION
As with previous STL changes, this removes a lot of custom data
structures in order to greatly simplify the code.

The behavior here is slightly changed: in the earlier version,
glk_select() would prioritize all external (input) events before all
internal events. That is, if a window resize event arrived and then an
input event, glk_select() would return the input event first and then
the resize event.

Now events are dispatched in the order received. This won't matter to
properly-written Glk programs, because they cannot assume what kind of
event will be returned by glk_select(), per §4 of the Glk spec: “This is
why you must always call glk_select() in a loop, and continue the loop
until you get the event you really want.”