### PR TITLE
Fix several warnings in interpreters

### DIFF
--- a/terps/agility/os_glk.c
+++ b/terps/agility/os_glk.c
@@ -812,7 +812,7 @@ agt_statline (const char *cp_string)
 
   free (gagt_status_buffer);
   gagt_status_buffer = gagt_malloc (strlen (cp_string) + 1);
-  gagt_cp_to_iso (cp_string, gagt_status_buffer);
+  gagt_cp_to_iso ((const unsigned char *)cp_string, (unsigned char *)gagt_status_buffer);
 
   gagt_debug ("agt_statline", "string='%s'", cp_string);
 }
@@ -1821,7 +1821,7 @@ agt_puts (const char *cp_string)
        * add string and packed text attributes to the current line buffer.
        */
       iso_string = gagt_malloc (length + 1);
-      gagt_cp_to_iso (cp_string, iso_string);
+      gagt_cp_to_iso ((const unsigned char *)cp_string, (unsigned char *)iso_string);
       packed = gagt_pack_current_attributes ();
       gagt_string_append (&gagt_current_buffer, iso_string, packed);
 
@@ -3002,7 +3002,7 @@ gagt_compare_special_line (const char *compare, const gagt_lineref_t line)
    */
   return strlen (compare) == line->real_length
          && gagt_strncasecmp (compare,
-                              line->buffer.data + line->indent,
+                              (char *)line->buffer.data + line->indent,
                               line->real_length) == 0;
 }
 
@@ -3338,7 +3338,7 @@ gagt_display_line (const gagt_lineref_t line, glui32 current_style,
     }
 
   /* Display this line segment. */
-  set_style = gagt_display_text_element (line->buffer.data + start,
+  set_style = gagt_display_text_element ((const char *)line->buffer.data + start,
                                          line->buffer.attributes + start,
                                          length, current_style, fixed_width);
 
@@ -3487,7 +3487,7 @@ gagt_display_auto (void)
 
   /* Output any help hint and unterminated line from the line buffer. */
   style = gagt_display_provide_help_hint (style);
-  style = gagt_display_text_element (gagt_current_buffer.data,
+  style = gagt_display_text_element ((char *)gagt_current_buffer.data,
                                      gagt_current_buffer.attributes,
                                      gagt_current_buffer.length, style, FALSE);
 }
@@ -3536,7 +3536,7 @@ gagt_display_manual (int fixed_width)
 
   /* Output any help hint and unterminated line from the line buffer. */
   style = gagt_display_provide_help_hint (style);
-  style = gagt_display_text_element (gagt_current_buffer.data,
+  style = gagt_display_text_element ((char *)gagt_current_buffer.data,
                                      gagt_current_buffer.attributes,
                                      gagt_current_buffer.length,
                                      style, fixed_width);
@@ -3579,7 +3579,7 @@ gagt_display_debug (void)
                  line->font_hint == HINT_FIXED_WIDTH ? 'F' : '_');
       glk_put_string (buffer);
 
-      glk_put_buffer (line->buffer.data, line->buffer.length);
+      glk_put_buffer ((char *)line->buffer.data, line->buffer.length);
       glk_put_char ('\n');
     }
 
@@ -3591,7 +3591,7 @@ gagt_display_debug (void)
                gagt_help_requested ? "HR" : "__");
       glk_put_string (buffer);
 
-      glk_put_buffer (gagt_current_buffer.data, gagt_current_buffer.length);
+      glk_put_buffer ((char *)gagt_current_buffer.data, gagt_current_buffer.length);
     }
 
   gagt_help_requested = FALSE;
@@ -5280,7 +5280,7 @@ agt_input (int in_type)
            * Convert the string from Glk's ISO 8859 Latin-1 to IBM cp 437,
            * add to any script, and return it.
            */
-          gagt_iso_to_cp (buffer, buffer);
+          gagt_iso_to_cp ((unsigned char *)buffer, (unsigned char *)buffer);
           if (script_on)
             textputs (scriptfile, buffer);
           return buffer;
@@ -5369,7 +5369,7 @@ agt_input (int in_type)
   /*
    * Convert from Glk's ISO 8859 Latin-1 to IBM cp 437, and add to any script.
    */
-  gagt_iso_to_cp (buffer, buffer);
+  gagt_iso_to_cp ((unsigned char *)buffer, (unsigned char *)buffer);
   if (script_on)
     textputs (scriptfile, buffer);
 
@@ -5437,7 +5437,7 @@ agt_getkey (rbool echo_char)
            * Convert from Glk's ISO 8859 Latin-1 to IBM cp 437, add to any
            * script, and return the character.
            */
-          gagt_iso_to_cp (buffer, buffer);
+          gagt_iso_to_cp ((unsigned char *)buffer, (unsigned char *)buffer);
           if (script_on)
             textputs (scriptfile, buffer);
           return buffer[0];
@@ -5489,7 +5489,7 @@ agt_getkey (rbool echo_char)
    * Convert from Glk's ISO 8859 Latin-1 to IBM cp 437, and add to any
    * script.
    */
-  gagt_iso_to_cp (buffer, buffer);
+  gagt_iso_to_cp ((unsigned char *)buffer, (unsigned char *)buffer);
   if (script_on)
     textputs (scriptfile, buffer);
 

--- a/terps/jacl/jacl.c
+++ b/terps/jacl/jacl.c
@@ -1570,7 +1570,7 @@ convert_to_utf32 (unsigned char *text)
 	    return 0;
 	}
 
-	text_len = strlen(text);
+	text_len = strlen((char *)text);
 
 	if (!text_len) {
 	    return 0;

--- a/terps/level9/Glk/glk.c
+++ b/terps/level9/Glk/glk.c
@@ -5886,7 +5886,7 @@ os_save_file (gln_byte * ptr, int bytes)
     }
 
   /* Write game state. */
-  glk_put_buffer_stream (stream, ptr, bytes);
+  glk_put_buffer_stream (stream, (char *)ptr, bytes);
 
   glk_stream_close (stream, NULL);
   glk_fileref_destroy (fileref);
@@ -5933,7 +5933,7 @@ os_load_file (gln_byte * ptr, int *bytes, int max)
     }
 
   /* Restore saved game data. */
-  *bytes = glk_get_buffer_stream (stream, ptr, max);
+  *bytes = glk_get_buffer_stream (stream, (char *)ptr, max);
 
   glk_stream_close (stream, NULL);
   glk_fileref_destroy (fileref);

--- a/terps/magnetic/Generic/defs.h
+++ b/terps/magnetic/Generic/defs.h
@@ -39,7 +39,15 @@
 
 #if UCHAR_MAX==0xff
 typedef unsigned char type8;
-typedef signed char   type8s;
+// The name implies a signed type, but this appears to generally be used
+// where "char" normally would (i.e. for C strings); that is, the fact
+// that it is signed does not appear to matter, and making it signed
+// causes all sorts of diagnostics due to the fact that "signed char"
+// and "char" are different types, even if "char" is signed. In any
+// case, making it "char" causes a lot fewer warnings, and regardless of
+// whether it's signed or plain char, the "solution" will be casting,
+// and this requires fewer casts.
+typedef char type8s;
 #else
 #error "Can't find an 8-bit integer type"
 #endif
@@ -351,7 +359,7 @@ struct ms_hint
 {
   type16  elcount;
   type16  nodetype;
-  type8 * content;
+  type8s * content;
   type16  links[MAX_HITEMS];
   type16  parent;
 };

--- a/terps/magnetic/Generic/emu.c
+++ b/terps/magnetic/Generic/emu.c
@@ -344,7 +344,7 @@ type8 anim_repeat = 0;
 #define MAX_HINTS 260
 #define MAX_HCONTENTS 30000
 struct ms_hint* hints = 0;
-type8* hint_contents = 0;
+type8s* hint_contents = 0;
 const type8s no_hints[] = "[Hints are not available.]\n";
 const type8s not_supported[] = "[This function is not supported.]\n";
 
@@ -2685,7 +2685,7 @@ void output_number(type16 number)
 	ms_putchar('0'+number);
 }
 
-type16 output_text(const type8* text)
+type16 output_text(const type8s* text)
 {
 	type16 i;
 
@@ -2930,7 +2930,7 @@ void do_line_a(void)
 					{
 						type32 length = 0;
 						type16 tempo = 0;
-						type8* midi = sound_extract(code + a1reg + 3,&length,&tempo);
+						type8* midi = sound_extract((type8s *)code + a1reg + 3,&length,&tempo);
 						if (midi != NULL)
 							ms_playmusic(midi,length,tempo);
 					}

--- a/terps/magnetic/Glk/glk.c
+++ b/terps/magnetic/Glk/glk.c
@@ -5571,7 +5571,7 @@ ms_save_file (type8s * name, type8 * ptr, type16 size)
         }
 
       /* Write game state. */
-      glk_put_buffer_stream (stream, ptr, size);
+      glk_put_buffer_stream (stream, (char *)ptr, size);
 
       glk_stream_close (stream, NULL);
       glk_fileref_destroy (fileref);
@@ -5654,7 +5654,7 @@ ms_load_file (type8s * name, type8 * ptr, type16 size)
         }
 
       /* Restore saved game data. */
-      glk_get_buffer_stream (stream, ptr, size);
+      glk_get_buffer_stream (stream, (char *)ptr, size);
 
       glk_stream_close (stream, NULL);
       glk_fileref_destroy (fileref);

--- a/terps/tads/osbuffer.c
+++ b/terps/tads/osbuffer.c
@@ -74,7 +74,7 @@ void os_put_buffer (unsigned char *buf, size_t len)
     if (outlen)
         glk_put_buffer_uni(out, outlen);
     else
-        glk_put_buffer(buf, len);
+        glk_put_buffer((char *)buf, len);
 
     free(out);
 }

--- a/terps/tads/osglk.c
+++ b/terps/tads/osglk.c
@@ -375,7 +375,7 @@ static void os_status_redraw(void)
     glk_window_clear(statuswin);
     glk_set_window(statuswin);
     glk_set_style(style_User1);
-    os_put_buffer(buf, strlen(buf));
+    os_put_buffer((unsigned char *)buf, strlen(buf));
     glk_set_window(mainwin);
 }
 
@@ -687,7 +687,7 @@ int os_gets_timeout(unsigned char *buf, size_t bufl,
     }
     while (event.type != evtype_LineInput);
 
-    char *res = os_fill_buffer(buf, event.val1);
+    unsigned char *res = os_fill_buffer(buf, event.val1);
 
     /* stop timer and turn on line echo */
     if (timer)
@@ -701,14 +701,14 @@ int os_gets_timeout(unsigned char *buf, size_t bufl,
     {
         if (timeout)
         {
-            timelen = strlen(buf) + 1;
+            timelen = strlen((char *)buf) + 1;
             timebuf = malloc(timelen);
             memcpy(timebuf, buf, timelen);
         }
         else
         {
             glk_set_style(style_Input);
-            os_print(buf, strlen(buf));
+            os_print((char *)buf, strlen((char *)buf));
             os_print("\n", 1);
             glk_set_style(style_Normal);
         }

--- a/terps/tads/osglkban.c
+++ b/terps/tads/osglkban.c
@@ -391,7 +391,7 @@ void banner_contents_display(contentid_t contents)
 
     if (contents->newline)
     {
-        char ch = '\n';
+        unsigned char ch = '\n';
         os_put_buffer(&ch, 1);
     }
     
@@ -414,7 +414,7 @@ void banner_contents_display(contentid_t contents)
     }
 
     glk_set_style(contents->style);
-    os_put_buffer(contents->chars, len);
+    os_put_buffer((unsigned char *)contents->chars, len);
     glk_set_window(mainwin);
     banner_contents_display(contents->next);
 }


### PR DESCRIPTION
These are all warnings which indicate invalid code (mismatched
pointers). A compiler would be perfectly justified in refusing to
compile this code, given that these are constraint violations rather
than potential undefined behavior, or style issues.

Clang still raises several warnings, most of which are purely related to
style, although a few are more worrisome, while still being valid code.
Those will be examined in the future: the present commit is solely to
avoid constraint violations.