### PR TITLE
Address a lot of warnings in the interprers

### DIFF
--- a/terps/CMakeLists.txt
+++ b/terps/CMakeLists.txt
@@ -59,6 +59,11 @@ if(WITH_ADVSYS)
         SRCS advsys/advmsg.c advsys/advtrm.c advsys/advprs.c
         advsys/advdbs.c advsys/advint.c advsys/advjunk.c advsys/advexe.c
         advsys/glkstart.c)
+
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        # This is a style choice in the code.
+        target_compile_options(advsys PRIVATE "-Wno-parentheses")
+    endif()
 endif()
 
 # ------------------------------------------------------------------------------
@@ -96,6 +101,11 @@ if(WITH_ALAN2)
         alan2/sysdep.c alan2/glkstart.c alan2/glkio.c alan2/alan.version.c
         MACROS GLK REVERSED
         POSIX)
+
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        # This is a style choice in the code.
+        target_compile_options(alan2 PRIVATE "-Wno-dangling-else")
+    endif()
 endif()
 
 # ------------------------------------------------------------------------------
@@ -150,7 +160,7 @@ if(WITH_BOCFEL)
         # The constants this complains about vary in value depending on
         # platform, so although the warning is correct when it occurs,
         # the checks are valid, and the warning unnecessary.
-        target_compile_options(bocfel PRIVATE -Wno-tautological-constant-out-of-range-compare)
+        target_compile_options(bocfel PRIVATE "-Wno-tautological-constant-out-of-range-compare")
     endif()
 endif()
 
@@ -164,6 +174,11 @@ if(WITH_GEAS)
         geas/geas-util.cc geas/geasglk.cc geas/geasglkterm.c geas/istring.cc
         geas/readfile.cc
         MACROS USE_INLINE)
+
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        # This is a style choice in the code.
+        target_compile_options(geas PRIVATE "-Wno-parentheses")
+    endif()
 endif()
 
 # ------------------------------------------------------------------------------
@@ -239,6 +254,11 @@ if(WITH_JACL)
         MACROS GLK
         MATH
         POSIX)
+
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        # This is a style choice in the code.
+        target_compile_options(jacl PRIVATE "-Wno-parentheses-equality")
+    endif()
 endif()
 
 # ------------------------------------------------------------------------------
@@ -255,6 +275,11 @@ if(WITH_LEVEL9)
         MACROS PRIVATE BITMAP_DECODER NEED_STRICMP_PROTOTYPE
         stricmp=gln_strcasecmp strnicmp=gln_strncasecmp
         MATH)
+
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        # This is a style choice in the code.
+        target_compile_options(level9 PRIVATE "-Wno-switch")
+    endif()
 endif()
 
 # ------------------------------------------------------------------------------

--- a/terps/alan2/debug.c
+++ b/terps/alan2/debug.c
@@ -391,7 +391,7 @@ void debug()
       c = buf[0];
       i = 0;
       sscanf(&buf[1], "%d", &i);
-    } while (buf && c == '\0');
+    } while (c == '\0');
 
     switch (toUpper(c)) {
     case 'H':

--- a/terps/geas/geas-runner.cc
+++ b/terps/geas/geas-runner.cc
@@ -2310,8 +2310,8 @@ void geas_implementation::run_script (string s, string &rv)
 	  gi->debug_print ("Expected param after 'destroy exit' in " + s);
 	  return;
 	}
-      string tok = eval_param (tok);
-      vector<string> args = split_param (tok);
+      string tok2 = eval_param (tok);
+      vector<string> args = split_param (tok2);
       if (args.size() != 2)
 	{
 	  gi->debug_print ("Expected two arguments in " + s);

--- a/terps/level9/level9.c
+++ b/terps/level9/level9.c
@@ -1504,7 +1504,7 @@ L9BOOL intinitialise(char*filename,char*picname)
 			error("\rWhat appears to be V1 game data was found, but the game was not recognised.\rEither this is an unknown V1 game file or, more likely, it is corrupted.\r");
 			return FALSE;
 		}
-		for (i=0;i<6;i++)
+		for (i=0;i<5;i++)
 		{
 			int off=L9V1Games[L9V1Game].L9Ptrs[i];
 			if (off<0)

--- a/terps/tads/CMakeLists.txt
+++ b/terps/tads/CMakeLists.txt
@@ -54,5 +54,10 @@ if(WITH_TADS)
         MACROS ${macros}
         POSIX)
 
+    if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+        # This is a style choice in the code.
+        target_compile_options(tadsr PRIVATE "-Wno-logical-not-parentheses")
+    endif()
+
     target_include_directories(tadsr PRIVATE . tads2 tads3)
 endif()


### PR DESCRIPTION
Most warnings are silenced simply by instruction Clang not to warn
about them. This is safe because these warnings are about cosmetic
issues, not material code issues.

A few warnings were due to actual dubious code, so there are some
material changes for those warnings.