### PR TITLE
Use CMake when building for macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,13 +17,8 @@ jobs:
       - name: Install packages
         run: brew install sdl2 sdl2_mixer libvorbis jam
 
-      - name: Build (CMake)
-        run: |
-          mkdir build
-          cd build
-          cmake ..
-          make -j`sysctl -n hw.logicalcpu`
-          make install
+      - name: Build
+        run: sh gargoyle_osx.sh
 
       - name: Build (legacy Jam)
-        run: sh gargoyle_osx.sh
+        run: jam -sUSETTS=yes -sBUNDLEFONTS=no -sMAC_USEHOMEBREW=yes -sMACOS_MIN_VER=10.9 -j`sysctl -n hw.ncpu`

--- a/INSTALL
+++ b/INSTALL
@@ -1,10 +1,6 @@
 # GENERAL INSTRUCTIONS
 
-To compile Gargoyle for Unix or Windows you will need CMake 3.1 or newer. For
-macOS, you will need jam 2.5.
-
-These instructions are for CMake. Jam support is deprecated and used only for
-macOS. See below for macOS build information.
+To compile Gargoyle you will need CMake 3.1 or newer.
 
 The following are required to build Gargoyle on Unix, in addition to a standard
 development environment (compiler, linker, etc.):
@@ -121,7 +117,6 @@ For the MacPorts packages you'll need, type:
   sudo port install jpeg
   sudo port install freetype
   sudo port install pkgconfig
-  sudo port install jam
 
 If you're using Homebrew, instead type:
 
@@ -132,7 +127,6 @@ If you're using Homebrew, instead type:
   brew install libvorbis
   brew install freetype
   brew install pkg-config
-  brew install jam
 
 Once the packages are installed, type:
 
@@ -152,10 +146,10 @@ No surprise there.
 old Mac and get the result to run on new Macs. The reverse does not work
 reliably.
 
-Therefore, I did the current build on MacOS 10.7 "Lion". (The Jamfile
-and other support files in this package are now set up for 10.7, and
-the resulting app runs on 10.7 and up. Unlike previous Gargoyle
-releases, it does not support the PPC architecture.)
+Therefore, I did the current build on MacOS 10.7 "Lion". (Support files
+in this package are now set up for 10.7, and the resulting app runs on
+10.7 and up. Unlike previous Gargoyle releases, it does not support the
+PPC architecture.)
 
 - You need to install Unix packages with MacPorts.
 

--- a/gargoyle_osx.sh
+++ b/gargoyle_osx.sh
@@ -53,7 +53,12 @@ mkdir -p "$BUNDLE/Resources/Fonts"
 mkdir -p "$BUNDLE/PlugIns"
 
 rm -rf $GARGDIST
-jam "-sUSETTS=yes" "-sBUNDLEFONTS=no" "-sMAC_USEHOMEBREW=${MAC_USEHOMEBREW}" "-j${NUMJOBS}" "-sMACOS_MIN_VER=${MACOS_MIN_VER}" install
+mkdir -p build-osx
+cd build-osx
+cmake .. -DWITH_BUNDLED_FONTS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOS_MIN_VER}
+make -j${NUMJOBS}
+make install
+cd -
 
 # Copy the main executable to the MacOS directory;
 cp "$GARGDIST/gargoyle" "$BUNDLE/MacOS/Gargoyle"


### PR DESCRIPTION
As noted elsewhere, the Jam files are still included, and the Mac Action still does a Jam build in order to ensure that nothing breaks there. But if there are no problems with CMake on macOS, then the Jam files will be removed.