### PR TITLE
Allow wildcards to be used for styles when setting colors

### DIFF
--- a/garglk/config.c
+++ b/garglk/config.c
@@ -468,18 +468,27 @@ static void readoneconfig(char *fname, char *argv0, char *gamefile)
             char *style = strtok(arg, "\r\n\t ");
             char *fg = strtok(NULL, "\r\n\t ");
             char *bg = strtok(NULL, "\r\n\t ");
-            int i = atoi(style);
-            if (i < 0 || i >= style_NUMSTYLES || fg == NULL || bg == NULL)
+            style_t *styles = cmd[0] == 't' ? gli_tstyles : gli_gstyles;
+
+            if (fg == NULL || bg == NULL)
                 continue;
-            if (cmd[0] == 't')
+
+            if (strcmp(style, "*") == 0)
             {
-                parsecolor(fg, gli_tstyles[i].fg);
-                parsecolor(bg, gli_tstyles[i].bg);
+                for (int i = 0; i < style_NUMSTYLES; i++)
+                {
+                    parsecolor(fg, styles[i].fg);
+                    parsecolor(bg, styles[i].bg);
+                }
             }
             else
             {
-                parsecolor(fg, gli_gstyles[i].fg);
-                parsecolor(bg, gli_gstyles[i].bg);
+                int i = atoi(style);
+                if (i < 0 || i >= style_NUMSTYLES)
+                    continue;
+
+                parsecolor(fg, styles[i].fg);
+                parsecolor(bg, styles[i].bg);
             }
         }
 


### PR DESCRIPTION
This allows compression from this:

tcolor  0 e7e8e9 31363b
tcolor  1 e7e8e9 31363b
tcolor  2 e7e8e9 31363b
tcolor  3 e7e8e9 31363b
tcolor  4 e7e8e9 31363b
tcolor  5 e7e8e9 31363b
tcolor  6 e7e8e9 31363b
tcolor  7 e7e8e9 31363b
tcolor  8 e7e8e9 31363b
tcolor  9 e7e8e9 31363b
tcolor 10 e7e8e9 31363b

To this:

tcolor * e7e8e9 31363b