### PR TITLE
Centralize config file discovery

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -21,7 +21,7 @@ if(INTERFACE STREQUAL "QT")
 endif()
 
 add_library(garglk babeldata.c cgblorb.c cgdate.c cgfref.c cggestal.c
-    cgmisc.c cgstream.c cgstyle.c cgunicod.c config.c draw.cpp event.cpp
+    cgmisc.c cgstream.c cgstyle.c cgunicod.c config.cpp draw.cpp event.cpp
     gi_blorb.c gi_dispa.c imgload.c imgscale.c winblank.c window.c
     wingfx.c wingrid.c winmask.c winpair.c wintext.c)
 c_standard(garglk 11)

--- a/garglk/Jamfile
+++ b/garglk/Jamfile
@@ -28,7 +28,7 @@ GARGSRCS =
     cgstyle.c cgstream.c cgunicod.c cgdate.c
     window.c winblank.c winpair.c wingrid.c
     wintext.c wingfx.c winmask.c
-    event.cpp draw.cpp config.c
+    event.cpp draw.cpp config.cpp
     imgload.c imgscale.c
     babeldata.c
     ;

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -313,7 +313,7 @@ font_t::font_t(const struct font &font)
     int err = 0;
     char fontpath[1024];
     float aspect, size;
-    const char *family;
+    std::string family;
     std::vector<std::function<bool(const struct font &, char *, size_t)>> font_paths = {
         font_path_user,
         font_path_fallback_system,
@@ -338,10 +338,7 @@ font_t::font_t(const struct font &font)
         return get_font_path(font, fontpath, sizeof fontpath) && FT_New_Face(ftlib, fontpath, 0, &face) == 0;
     }))
     {
-        if (family == nullptr || family[0] == 0)
-            winabort("No font family specified for %s %s, and fallback %s not found", type_to_name(font.type), style_to_name(font.style), font.fallback);
-        else
-            winabort("Unable to find font %s for %s %s, and fallback %s not found", family, type_to_name(font.type), style_to_name(font.style), font.fallback);
+        winabort("Unable to find font %s for %s %s, and fallback %s not found", family.c_str(), type_to_name(font.type), style_to_name(font.style), font.fallback);
     }
 
     if (strlen(fontpath) >= 4)

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -32,6 +32,11 @@
 #define GARGLK_GARGLK_H
 
 #ifdef __cplusplus
+#include <string>
+#include <vector>
+
+std::vector<std::string> gli_configs(const std::string &exedir, const std::string &gamepath);
+
 extern "C" {
 #endif
 
@@ -263,13 +268,13 @@ enum FACES { MONOR, MONOB, MONOI, MONOZ, PROPR, PROPB, PROPI, PROPZ };
 enum TYPES { MONOF, PROPF };
 enum STYLES { FONTR, FONTB, FONTI, FONTZ };
 
-extern char *gli_conf_propfont;
+extern const char *gli_conf_propfont;
 extern char *gli_conf_propr;
 extern char *gli_conf_propb;
 extern char *gli_conf_propi;
 extern char *gli_conf_propz;
 
-extern char *gli_conf_monofont;
+extern const char *gli_conf_monofont;
 extern char *gli_conf_monor;
 extern char *gli_conf_monob;
 extern char *gli_conf_monoi;

--- a/garglk/launcher.cpp
+++ b/garglk/launcher.cpp
@@ -35,6 +35,7 @@
 #include "glk.h"
 #include "glkstart.h"
 #include "gi_blorb.h"
+#include "garglk.h"
 #include "launcher.h"
 
 #define T_ADRIFT    "scare"
@@ -66,11 +67,9 @@ struct Launch {
 
 static bool call_winterp(const char *path, const std::string &interpreter, const std::string &flags, const char *game)
 {
-    char exe[MaxBuffer];
+    std::string exe = std::string(GARGLKPRE) + interpreter;
 
-    std::snprintf(exe, sizeof exe, "%s%s", GARGLKPRE, interpreter.c_str());
-
-    return winterp(path, exe, flags.c_str(), game);
+    return winterp(path, exe.c_str(), flags.c_str(), game);
 }
 
 static bool runblorb(const char *path, const char *game, const struct Launch &launch)
@@ -146,13 +145,13 @@ static bool runblorb(const char *path, const char *game, const struct Launch &la
     }
 }
 
-static bool findterp_impl(const char *file, const char *target, struct Launch &launch)
+static bool findterp(const std::string &file, const std::string &target, struct Launch &launch)
 {
     char buf[MaxBuffer];
     char *cmd, *arg, *opt;
     bool accept = false;
 
-    std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen(file, "r"), std::fclose);
+    std::unique_ptr<std::FILE, decltype(&std::fclose)> f(std::fopen(file.c_str(), "r"), std::fclose);
     if (!f)
         return false;
 
@@ -168,7 +167,7 @@ static bool findterp_impl(const char *file, const char *target, struct Launch &l
             for (size_t i = 0; i < std::strlen(buf); i++)
                 buf[i] = std::tolower(static_cast<unsigned char>(buf[i]));
 
-            accept = std::strstr(buf, target) != nullptr;
+            accept = std::strstr(buf, target.c_str()) != nullptr;
         }
 
         if (!accept)
@@ -195,97 +194,36 @@ static bool findterp_impl(const char *file, const char *target, struct Launch &l
     return !launch.terp.empty();
 }
 
-static bool findterp(const char *config, const char *story, struct Launch &launch)
+static void configterp(const std::string &exedir, const std::string &gamepath, struct Launch &launch)
 {
-    const char *s;
-    char ext[MaxBuffer];
-
-    s = std::strrchr(story, '.');
-    if (s != nullptr)
-        std::snprintf(ext, sizeof ext, "*%s", s);
-    else
-        std::snprintf(ext, sizeof ext, "*.*");
-
-    return findterp_impl(config, story, launch) || findterp_impl(config, ext, launch);
-}
-
-static void configterp(const char *path, const char *game, struct Launch &launch)
-{
-    char config[MaxBuffer];
-    char story[MaxBuffer];
-    const char *s1;
-    char *s2;
+    std::string config;
+    std::string story = gamepath;
 
     /* set up story */
-    s1 = std::strrchr(game,'\\');
-    if (s1 == nullptr)
-        s1 = std::strrchr(game, '/');
+    auto slash = story.rfind('\\');
+    if (slash == std::string::npos)
+        slash = story.find_last_of('/');
+    if (slash != std::string::npos)
+        story = story.substr(slash + 1);
 
-    if (s1 != nullptr)
-        std::snprintf(story, sizeof story, "%s", s1 + 1);
+    if (story.empty())
+        return;
+
+    for (char &c : story)
+        c = std::tolower(static_cast<unsigned char>(c));
+
+    std::string ext = story;
+    auto dot = story.rfind('.');
+    if (dot != std::string::npos)
+        ext.replace(0, dot, "*");
     else
-        std::snprintf(story, sizeof story, "%s", game);
+        ext = "*.*";
 
-    if (std::strlen(story) == 0)
-        return;
-
-    for (size_t i = 0; i < std::strlen(story); i++)
-        story[i] = std::tolower(static_cast<unsigned char>(story[i]));
-
-    /* game file .ini */
-    std::strcpy(config, game);
-    s2 = std::strrchr(config, '.');
-    if (s2 != nullptr)
-        std::strcpy(s2, ".ini");
-    else
-        std::strcat(config, ".ini");
-
-    if (findterp(config, story, launch))
-        return;
-
-    /* game directory .ini */
-    std::strcpy(config, game);
-    s2 = std::strrchr(config, '\\');
-    if (s2 == nullptr)
-        s2 = std::strrchr(config, '/');
-
-    if (s2 != nullptr)
-        std::strcpy(s2 + 1, "garglk.ini");
-    else
-        std::strcpy(config, "garglk.ini");
-
-    if (findterp(config, story, launch))
-        return;
-
-    /* current directory .ini */
-    if (findterp("garglk.ini", story, launch))
-        return;
-
-    /* various environment directories */
-    std::vector<const char *> env_vars = {"XDG_CONFIG_HOME", "HOME", "GARGLK_INI"};
-    for (const auto &var : env_vars)
+    for (const auto &config : gli_configs(exedir, gamepath))
     {
-        const char *dir = std::getenv(var);
-        if (dir != nullptr)
-        {
-            std::snprintf(config, sizeof config, "%s/.garglkrc", dir);
-            if (findterp(config, story, launch))
-                return;
-
-            std::snprintf(config, sizeof config, "%s/garglk.ini", dir);
-            if (findterp(config, story, launch))
-                return;
-        }
+        if (findterp(config, story, launch) || findterp(config, ext, launch))
+            return;
     }
-
-    /* system directory */
-    if (findterp(GARGLKINI, story, launch))
-        return;
-
-    /* install directory */
-    std::snprintf(config, sizeof config, "%s/garglk.ini", path);
-    if (findterp(config, story, launch))
-        return;
 }
 
 struct Interpreter {

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -120,10 +120,6 @@ int winterp(const char *path, const char *exe, const char *flags, const char *ga
 {
     QString argv0 = QDir(path).absoluteFilePath(exe);
 
-#ifndef _WIN32
-    setenv("GARGLK_INI", path, 0);
-#endif
-
     QStringList args;
 
     if (std::strstr(flags, "-") != nullptr)


### PR DESCRIPTION
The config file is needed in both the launcher and the Glk library
itself. The launcher uses the config file to possibly determine which
interpreter to use, while the Glk library uses it for its configuration
in general. That is to say, the "terp" entries in the config file are
used by the launcher, and the rest by garglk.

Gargoyle searches in several places for its config file, and both the
launcher and garglk had code to handle lookups. However, they disagreed
slightly on how to look things up.

The new code adds a function which returns all possible config file
locations so both the launcher and garglk will always get the same list
of config files.