### PR TITLE
Fix TADS on ARM64

### DIFF
--- a/terps/tads/tads2/os.h
+++ b/terps/tads/tads2/os.h
@@ -75,7 +75,7 @@ extern "C" {
 #ifdef __ppc__
 #define _M_PPC
 #else
-#ifdef __x86_64__
+#if defined __x86_64__ || defined __aarch64__
 #define _M_IX86_64
 #else
 #ifndef _M_IX86


### PR DESCRIPTION
This is a very simple fix for #409. It makes TADS use the x86_64 header when building on ARM64.

There is a less hacky fix described [here](https://intfiction.org/t/please-test-spatterlight-on-apple-silicon/52476/9) which replaces the x86 headers with a platform-agnostic header, but I had a really hard time making it work on Spatterlight. In the end I got it to work by setting the TADS targets to build as C++11, but I never understood why it was needed.

I tried implementing this in Gargoyle [here](https://github.com/angstsmurf/garglk/tree/tads), but couldn't make it build.

Also, the fact that the TADS source files use Windows line endings makes them a pain to edit, but hopefully I didn't change any to the wrong format.