### PR TITLE
Allow the config file to be edited on Qt platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.3)
 
 file(READ "VERSION" GARGOYLE_VERSION)
 string(STRIP "${GARGOYLE_VERSION}" GARGOYLE_VERSION)
@@ -8,6 +8,18 @@ if(POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT HAS_LTO)
+endif()
+
+# At the moment C++17 is optional, and used in only one place. In the
+# near future, however, it will likely be required.
+# Completely disable on macOS, since although it claims C++17 support,
+# when building for older versions (as is done by gargoyle_osx.sh), not
+# all C++17 features are exposed. The C++17 code is unused on macOS
+# anyway, so there's no harm here.
+if("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES AND NOT APPLE)
+    set(CXX_VERSION 17)
+else()
+    set(CXX_VERSION 14)
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")

--- a/cmake/Modules/vtkEncodeString.cmake
+++ b/cmake/Modules/vtkEncodeString.cmake
@@ -1,0 +1,233 @@
+# Taken from VTK 9.1.0
+#
+# /*=========================================================================
+#
+#   Program:   Visualization Toolkit
+#   Module:    Copyright.txt
+#
+# Copyright (c) 1993-2015 Ken Martin, Will Schroeder, Bill Lorensen
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither name of Ken Martin, Will Schroeder, or Bill Lorensen nor the names
+#    of any contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# =========================================================================*/
+
+#[==[
+@file vtkEncodeString.cmake
+
+This module contains the @ref vtk_encode_string function which may be used to
+turn a file into a C string. This is primarily used within a program so that
+the content does not need to be retrieved from the filesystem at runtime, but
+can still be developed as a standalone file.
+#]==]
+
+set(_vtkEncodeString_script_file "${CMAKE_CURRENT_LIST_FILE}")
+
+#[==[
+@brief Encode a file as a C string at build time
+
+Adds a rule to turn a file into a C string. Note that any Unicode characters
+will not be replaced with escaping, so it is recommended to avoid their usage
+in the input.
+
+~~~
+vtk_encode_string
+  INPUT           <input>
+  [NAME           <name>]
+  [EXPORT_SYMBOL  <symbol>]
+  [EXPORT_HEADER  <header>]
+  [HEADER_OUTPUT  <variable>]
+  [SOURCE_OUTPUT  <variable>]
+  [BINARY] [NUL_TERMINATE])
+~~~
+
+The only required variable is `INPUT`, however, it is likely that at least one
+of `HEADER_OUTPUT` or `SOURCE_OUTPUT` will be required to add them to a
+library.
+
+  * `INPUT`: (Required) The path to the file to be embedded. If a relative path
+    is given, it will be interpreted as being relative to
+    `CMAKE_CURRENT_SOURCE_DIR`.
+  * `NAME`: This is the base name of the files that will be generated as well
+    as the variable name for the C string. It defaults to the basename of the
+    input without extensions.
+  * `EXPORT_SYMBOL`: The symbol to use for exporting the variable. By default,
+    it will not be exported. If set, `EXPORT_HEADER` must also be set.
+  * `EXPORT_HEADER`: The header to include for providing the given export
+    symbol. If set, `EXPORT_SYMBOL` should also be set.
+  * `HEADER_OUTPUT`: The variable to store the generated header path.
+  * `SOURCE_OUTPUT`: The variable to store the generated source path.
+  * `BINARY`: If given, the data will be written as an array of `unsigned char`
+    bytes.
+  * `NUL_TERMINATE`: If given, the binary data will be `NUL`-terminated. Only
+    makes sense with the `BINARY` flag. This is intended to be used if
+    embedding a file as a C string exceeds compiler limits on string literals
+    in various compilers.
+#]==]
+function (vtk_encode_string)
+  cmake_parse_arguments(PARSE_ARGV 0 _vtk_encode_string
+    "BINARY;NUL_TERMINATE"
+    "INPUT;NAME;EXPORT_SYMBOL;EXPORT_HEADER;HEADER_OUTPUT;SOURCE_OUTPUT"
+    "")
+
+  if (_vtk_encode_string_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR
+      "Unrecognized arguments to vtk_encode_string: "
+      "${_vtk_encode_string_UNPARSED_ARGUMENTS}")
+  endif ()
+
+  if (NOT DEFINED _vtk_encode_string_INPUT)
+    message(FATAL_ERROR
+      "Missing `INPUT` for vtk_encode_string.")
+  endif ()
+
+  if (NOT DEFINED _vtk_encode_string_NAME)
+    get_filename_component(_vtk_encode_string_NAME
+      "${_vtk_encode_string_INPUT}" NAME_WE)
+  endif ()
+
+  if (DEFINED _vtk_encode_string_EXPORT_SYMBOL AND
+      NOT DEFINED _vtk_encode_string_EXPORT_HEADER)
+    message(FATAL_ERROR
+      "Missing `EXPORT_HEADER` when using `EXPORT_SYMBOL`.")
+  endif ()
+
+  if (DEFINED _vtk_encode_string_EXPORT_HEADER AND
+      NOT DEFINED _vtk_encode_string_EXPORT_SYMBOL)
+    message(WARNING
+      "Missing `EXPORT_SYMBOL` when using `EXPORT_HEADER`.")
+  endif ()
+
+  if (NOT _vtk_encode_string_BINARY AND _vtk_encode_string_NUL_TERMINATE)
+    message(FATAL_ERROR
+      "The `NUL_TERMINATE` flag only makes sense with the `BINARY` flag.")
+  endif ()
+
+  set(_vtk_encode_string_header
+    "${CMAKE_CURRENT_BINARY_DIR}/${_vtk_encode_string_NAME}.h")
+  set(_vtk_encode_string_source
+    "${CMAKE_CURRENT_BINARY_DIR}/${_vtk_encode_string_NAME}.cxx")
+
+  if (IS_ABSOLUTE "${_vtk_encode_string_INPUT}")
+    set(_vtk_encode_string_input
+      "${_vtk_encode_string_INPUT}")
+  else ()
+    set(_vtk_encode_string_input
+      "${CMAKE_CURRENT_SOURCE_DIR}/${_vtk_encode_string_INPUT}")
+  endif ()
+
+  add_custom_command(
+    OUTPUT  ${_vtk_encode_string_header}
+            ${_vtk_encode_string_source}
+    DEPENDS "${_vtkEncodeString_script_file}"
+            "${_vtk_encode_string_input}"
+    COMMAND "${CMAKE_COMMAND}"
+            "-Dsource_dir=${CMAKE_CURRENT_SOURCE_DIR}"
+            "-Dbinary_dir=${CMAKE_CURRENT_BINARY_DIR}"
+            "-Dsource_file=${_vtk_encode_string_input}"
+            "-Doutput_name=${_vtk_encode_string_NAME}"
+            "-Dexport_symbol=${_vtk_encode_string_EXPORT_SYMBOL}"
+            "-Dexport_header=${_vtk_encode_string_EXPORT_HEADER}"
+            "-Dbinary=${_vtk_encode_string_BINARY}"
+            "-Dnul_terminate=${_vtk_encode_string_NUL_TERMINATE}"
+            "-D_vtk_encode_string_run=ON"
+            -P "${_vtkEncodeString_script_file}")
+
+  if (DEFINED _vtk_encode_string_SOURCE_OUTPUT)
+    set("${_vtk_encode_string_SOURCE_OUTPUT}"
+      "${_vtk_encode_string_source}"
+      PARENT_SCOPE)
+  endif ()
+
+  if (DEFINED _vtk_encode_string_HEADER_OUTPUT)
+    set("${_vtk_encode_string_HEADER_OUTPUT}"
+      "${_vtk_encode_string_header}"
+      PARENT_SCOPE)
+  endif ()
+endfunction ()
+
+if (_vtk_encode_string_run AND CMAKE_SCRIPT_MODE_FILE)
+  set(output_header "${binary_dir}/${output_name}.h")
+  set(output_source "${binary_dir}/${output_name}.cxx")
+
+  file(WRITE "${output_header}" "")
+  file(WRITE "${output_source}" "")
+
+  file(APPEND "${output_header}"
+    "#ifndef ${output_name}_h\n#define ${output_name}_h\n\n")
+  if (export_symbol)
+    file(APPEND "${output_header}"
+      "#include \"${export_header}\"\n\n${export_symbol} ")
+  endif ()
+
+  if (IS_ABSOLUTE "${source_file}")
+    set(source_file_full "${source_file}")
+  else ()
+    set(source_file_full "${source_dir}/${source_file}")
+  endif ()
+  set(hex_arg)
+  if (binary)
+    set(hex_arg HEX)
+  endif ()
+  file(READ "${source_file_full}" original_content ${hex_arg})
+
+  if (binary)
+    if (nul_terminate)
+      string(APPEND original_content "00")
+    endif ()
+    string(LENGTH "${original_content}" output_size)
+    math(EXPR output_size "${output_size} / 2")
+    file(APPEND "${output_header}"
+      "extern const unsigned char ${output_name}[${output_size}];\n\n#endif\n")
+
+    file(APPEND "${output_source}"
+      "#include \"${output_name}.h\"\n\nconst unsigned char ${output_name}[${output_size}] = {\n")
+    string(REGEX REPLACE "\([0-9a-f][0-9a-f]\)" ",0x\\1" escaped_content "${original_content}")
+    # Hard line wrap the file.
+    string(REGEX REPLACE "\(..........................................................................,\)" "\\1\n" escaped_content "${escaped_content}")
+    # Remove the leading comma.
+    string(REGEX REPLACE "^," "" escaped_content "${escaped_content}")
+    file(APPEND "${output_source}"
+      "${escaped_content}\n")
+    file(APPEND "${output_source}"
+      "};\n")
+  else ()
+    file(APPEND "${output_header}"
+      "extern const char *${output_name};\n\n#endif\n")
+
+    # Escape literal backslashes.
+    string(REPLACE "\\" "\\\\" escaped_content "${original_content}")
+    # Escape literal double quotes.
+    string(REPLACE "\"" "\\\"" escaped_content "${escaped_content}")
+    # Turn newlines into newlines in the C string.
+    string(REPLACE "\n" "\\n\"\n\"" escaped_content "${escaped_content}")
+
+    file(APPEND "${output_source}"
+      "#include \"${output_name}.h\"\n\nconst char *${output_name} =\n")
+    file(APPEND "${output_source}"
+      "\"${escaped_content}\";\n")
+  endif ()
+endif ()

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(vtkEncodeString)
+
 configure_file("garversion.h.in" "${CMAKE_CURRENT_LIST_DIR}/garversion.h")
 
 option(WITH_LAUNCHER "Build the launcher (i.e. the gargoyle executable)" ON)
@@ -5,6 +7,7 @@ option(BUILD_SHARED_LIBS "Build a shared libgarglk instead of a static library" 
 
 if(UNIX AND NOT APPLE)
     option(WITH_FREEDESKTOP "Install freedesktop.org application, icon, and MIME files" ON)
+    set(GARGLKINI "/etc/garglk.ini" CACHE STRING "Full path for garglk.ini")
 endif()
 
 if(APPLE)
@@ -14,17 +17,27 @@ else()
 endif()
 
 set(WITH_TTS "AUTO" CACHE STRING "Enable text-to-speech support (ON/OFF/AUTO)")
-set(GARGLKINI "/etc/garglk.ini" CACHE STRING "Full path for garglk.ini")
 set(GARGLKPRE "" CACHE STRING "Binary prefix")
 set(SOUND "SDL" CACHE STRING "Backend to use for sound (SDL, QT, or none)")
 
+vtk_encode_string(
+    INPUT garglk.ini
+    NAME garglkini
+    BINARY NUL_TERMINATE
+    HEADER_OUTPUT GARGLKINI_H
+    SOURCE_OUTPUT GARGLKINI_CXX
+)
+
+set_property(SOURCE config.cpp PROPERTY COMPILE_DEFINITIONS GARGLKINI_H="${GARGLKINI_H}")
+
 if(INTERFACE STREQUAL "QT")
     set(CMAKE_AUTOMOC ON)
+    set_property(SOURCE garglkini.cxx PROPERTY SKIP_AUTOMOC ON)
 endif()
 
 add_library(garglk babeldata.c style.c config.cpp draw.cpp
     event.cpp imgload.c imgscale.c winblank.c window.c wingfx.c
-    wingrid.c winmask.c winpair.c wintext.c
+    wingrid.c winmask.c winpair.c wintext.c ${GARGLKINI_CXX}
 
     # These can't be a library in cheapglk/ because they contain
     # references to code in garglk, and garglk contains references to
@@ -39,9 +52,12 @@ add_library(garglk babeldata.c style.c config.cpp draw.cpp
 target_include_directories(garglk PRIVATE .)
 
 c_standard(garglk 11)
-cxx_standard(garglk 14)
+cxx_standard(garglk ${CXX_VERSION})
 warnings(garglk)
+
+if(UNIX AND NOT APPLE)
 target_compile_definitions(garglk PRIVATE "GARGLKINI=\"${GARGLKINI}\"")
+endif()
 
 if(INTERFACE STREQUAL "COCOA")
     target_sources(garglk PRIVATE sysmac.mm)
@@ -58,7 +74,7 @@ if(WITH_LAUNCHER)
     target_link_libraries(gargoyle PRIVATE garglk)
     target_compile_definitions(gargoyle PRIVATE "_XOPEN_SOURCE=600")
     c_standard(gargoyle 11)
-    cxx_standard(gargoyle 14)
+    cxx_standard(gargoyle ${CXX_VERSION})
     warnings(gargoyle)
 
     target_compile_definitions(gargoyle PRIVATE "GARGLKINI=\"${GARGLKINI}\"" "GARGLKPRE=\"${GARGLKPRE}\"")
@@ -82,7 +98,7 @@ endif()
 
 add_library(garglkmain STATIC main.c)
 c_standard(garglkmain 11)
-cxx_standard(garglkmain 14)
+cxx_standard(garglkmain ${CXX_VERSION})
 warnings(garglkmain)
 target_include_directories(garglkmain PRIVATE cheapglk)
 

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -43,13 +43,30 @@ enum FILEFILTERS { FILTER_SAVE, FILTER_TEXT, FILTER_DATA };
 
 namespace garglk {
 
+// This represents a possible configuration file (garglk.ini).
+struct ConfigFile {
+    ConfigFile(const std::string &path_, bool user_) : path(path_), user(user_) {
+    }
+
+    // The path to the file itself.
+    std::string path;
+
+    // If true, this config file should be considered as a “user” config
+    // file, one that a user would reasonably expect to be a config file
+    // for general use. This excludes game-specific config files, for
+    // example, while considering various possibilities for config
+    // files, such as $HOME/.garglkrc or $HOME/.config/garglk.ini.
+    bool user;
+};
+
 std::string winopenfile(const char *prompt, enum FILEFILTERS filter);
 std::string winsavefile(const char *prompt, enum FILEFILTERS filter);
 void winabort(const std::string &msg);
 std::string downcase(const std::string &string);
 void fontreplace(const std::string &font, int type);
-std::vector<std::string> configs(const std::string &exedir, const std::string &gamepath);
+std::vector<ConfigFile> configs(const std::string &exedir, const std::string &gamepath);
 void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, std::function<void(const std::string &cmd, const std::string &arg)> callback);
+std::string user_config();
 void set_lcdfilter(const std::string &filter);
 std::string winfontpath(const std::string &filename);
 

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -2,19 +2,17 @@
 # Gargoyle Glk configuration
 #-------------------------------------------------------------------------------
 #
-# Copy this file to "garglk.ini" in the same directory as your
-# gargoyle interpreter if you are running windows.
-# On unix systems, copy it to "~/.garglkrc".
-#
 # Gargoyle will look for configuration files and load them in this
 # order, with later settings overriding earlier settings:
 #
 #   1: same directory as the executable: garglk.ini (windows)
 #   2: /etc/garglk.ini (unix)
-#   3: user home directory: .garglkrc
-#   4: user home directory: garglk.ini
+#   3: $HOME/.garglkrc
+#   4: ${XDG_CONFIG_HOME:-$HOME/.config}/garglk.ini
 #   5: current working directory: garglk.ini
-#   6: name-of-game-file.ini (so for hell.gam it would read hell.ini)
+#   6: %APPDATA%/Gargoyle/garglk.ini (windows)
+#   7: game directory: garglk.ini
+#   8: name-of-game-file.ini (so for hell.gam it would read hell.ini)
 #
 # Sections of the config file can be turned on or off by matching
 # either the interpreter or game file being run. See the bottom

--- a/garglk/launcher.cpp
+++ b/garglk/launcher.cpp
@@ -227,7 +227,7 @@ static void configterp(const std::string &exedir, const std::string &gamepath, s
 
     for (const auto &config : garglk::configs(exedir, gamepath))
     {
-        if (findterp(config, story, interpreter) || findterp(config, ext, interpreter))
+        if (findterp(config.path, story, interpreter) || findterp(config.path, ext, interpreter))
             return;
     }
 }

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -26,6 +26,7 @@
 #include <QChar>
 #include <QClipboard>
 #include <QCursor>
+#include <QDesktopServices>
 #include <QElapsedTimer>
 #include <QFileDialog>
 #include <QGraphicsView>
@@ -249,6 +250,19 @@ void Window::start_timer(long ms)
     }
 }
 
+static void edit_config()
+{
+    try
+    {
+        auto config = garglk::user_config();
+        QDesktopServices::openUrl(QUrl::fromLocalFile(config.c_str()));
+    }
+    catch (std::runtime_error &e)
+    {
+        QMessageBox::warning(nullptr, "Warning", e.what());
+    }
+}
+
 void View::keyPressEvent(QKeyEvent *event)
 {
     Qt::KeyboardModifiers modmasked = event->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
@@ -267,6 +281,8 @@ void View::keyPressEvent(QKeyEvent *event)
         {{Qt::ControlModifier, Qt::Key_X},     []{ winclipsend(QClipboard::Clipboard); }},
         {{Qt::ControlModifier, Qt::Key_Left},  []{ gli_input_handle_key(keycode_SkipWordLeft); }},
         {{Qt::ControlModifier, Qt::Key_Right}, []{ gli_input_handle_key(keycode_SkipWordRight); }},
+
+        {{Qt::ControlModifier, Qt::Key_Comma}, edit_config},
 
         {{Qt::ShiftModifier, Qt::Key_Backspace}, []{ gli_input_handle_key(keycode_Delete); }},
 


### PR DESCRIPTION
macOS already supports this, and the old Windows code handled it as
well. It tries to figure out the proper location for a config file,
creating it first if necessary.

For Qt-based systems (i.e. all but Mac), control-, (control comma) will open a text editor with an appropriate location for a configuration file.  This restores, more or less, functionality that used to exist on Windows, so that users at least don't need to know _where_ their config file is, even if they still do need to know how to edit it.