### PR TITLE
Properly look up config file location on Haiku

### DIFF
--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -7,12 +7,14 @@
 #
 #   1: same directory as the executable: garglk.ini (windows)
 #   2: /etc/garglk.ini (unix)
-#   3: $HOME/.garglkrc
-#   4: ${XDG_CONFIG_HOME:-$HOME/.config}/garglk.ini
-#   5: current working directory: garglk.ini
-#   6: %APPDATA%/Gargoyle/garglk.ini (windows)
-#   7: game directory: garglk.ini
-#   8: name-of-game-file.ini (so for hell.gam it would read hell.ini)
+#   3: Platform-specific locations:
+#          $HOME/.garglkrc (unix)
+#          ${XDG_CONFIG_HOME:-$HOME/.config}/garglk.ini (unix)
+#          <user settings directory>/Gargoyle (haiku)
+#          %APPDATA%/Gargoyle/garglk.ini (windows)
+#          current working directory: garglk.ini (windows)
+#   4: game directory: garglk.ini
+#   5: name-of-game-file.ini (so for hell.gam it would read hell.ini)
 #
 # Sections of the config file can be turned on or off by matching
 # either the interpreter or game file being run. See the bottom


### PR DESCRIPTION
This includes a couple other changes:

• garglk.ini is no longer searched for in the current working directory
  except on Windows (where this was the old "default" location for the
  config file). If you need to configure Gargoyle, there are better
  locations than random directories.
• $XDG_CONFIG_HOME and $HOME lookups are only used on Unix platforms, or
  at least are not used on Haiku and Windows. Since Haiku and Windows
  have specific places to place configuration, there's no need at all to
  use Unix-style methods there.