### PR TITLE
Tweak the Alan MIME types

### DIFF
--- a/garglk/gargoyle.desktop
+++ b/garglk/gargoyle.desktop
@@ -7,4 +7,4 @@ Comment=Interactive Fiction multi-interpreter that supports all major IF formats
 Icon=gargoyle-house
 Exec=gargoyle %f
 Categories=Game;
-MimeType=application/x-adrift;application/x-advsys;application/x-agt;application/x-alan;application/x-blorb;application/x-glulx;application/x-hugo;application/x-level9;application/x-magscroll;application/x-tads;application/x-t3vm-image;application/x-zmachine;
+MimeType=application/x-adrift;application/x-advsys;application/x-agt;application/x-alan-adventure-game;application/x-alan3-adventure-game;application/x-blorb;application/x-glulx;application/x-hugo;application/x-level9;application/x-magscroll;application/x-tads;application/x-t3vm-image;application/x-zmachine;

--- a/garglk/interactive-fiction.xml
+++ b/garglk/interactive-fiction.xml
@@ -24,10 +24,14 @@
     <glob pattern="*.d$$"/>
   </mime-type>
 
-  <mime-type type="application/x-alan">
+  <mime-type type="application/x-alan-adventure-game">
     <comment>Alan game data</comment>
-    <glob pattern="*.a3c"/>
     <glob pattern="*.acd"/>
+  </mime-type>
+
+  <mime-type type="application/x-alan3-adventure-game">
+    <comment>Alan 3 game data</comment>
+    <glob pattern="*.a3c"/>
     <magic priority="50">
       <match type="string" offset="0" value="ALAN\x03"/>
     </magic>


### PR DESCRIPTION
There are two things here:

1. There's some precedent for the Alan MIME type to be
   application/x-alan-adventure-game. See
   https://github.com/jjh42/countdr/blob/master/magic.py,
   https://wiki.tcl-lang.org/page/mime+type+discriminator, etc.
   Since there's precedent, use it.
2. Alan2 and Alan3 are different interpreters. Earlier these were lumped
   into one MIME type, at odds with the same situation in TADS, which
   has two MIME types for its two major versions. Add
   application/x-alan3-adventure-game to differentiate between the two.