### PR TITLE
Remove overrides which serve no functional purpose

### DIFF
--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -224,37 +224,11 @@ speak            0           # 1=enable TTS, 0=disable TTS
                              # for synthesis, as described by RFC 1766. Currently
                              # supported on OS X, and Unix with speech-dispatcher.
 
+
 #===============================================================================
 # You can add sections here to over-ride settings. List all the executables to
 # be affected in the [ selector list ]. The name of game file can also be used
 #-------------------------------------------------------------------------------
-
-[ Git Glulxe ]
-cols          80              # longer lines for Glulx games
-rows          25              # same number of rows
-
-[ Hugo ]
-# Hugo has ugly status bars with no padding.
-# Hugo also uses grid windows for arbitrarily placed text.
-# Add a thin border line between windows.
-wborderx      1               # border line width between windows
-wbordery      1               # border line width between windows
-
-[ Magnetic ]
-cols          68
-
-# [ Agility ]
-# monoaspect  0.8             # squeeze mono font
-# cols        80
-# rows        25
-
-[ curses.z5 ]
-monoaspect    0.9             # squeeze to compensate for more columns
-cols          65
-
-[ photo201.blb ]
-cols          80
-rows          24
 
 [ trinity.z5 ]
 mincols       62              # Trinity requires at least 62 columns


### PR DESCRIPTION
The Trinity override is completely necessary since it fails to start
with fewer columns.

The Winter Wonderland override is necessary to make the ASCII art come
out right. More subjective, but probably OK to have.

Git & Glulxe at 80x25 is arbitrary. Why just Glulx games?

Hugo: The border under the status bar is different than other
interpreters; it's more jarring to have it in Hugo than not.

Magnetic: These games work fine with the defaults.

Agility: This was commented out already anyway.

Curses: The game works fine with the defaults.

Photopia: The game works fine with the defaults.

It's actually possible that some parts of the listed games do fail at
the defaults; I tested the first parts to see if there were problems as
in Trinity. But I think if there are problems with the default 60x25, it
should be changed rather than trying to override it. 80x25 is a
reasonable default, given that so many games were written with that size
in mind, but for now, that'd be a pretty big change. This will have some
effect on existing users (assuming they have the default garglk.ini
installed), but I think it's best to not make subjective choices about
specific games.