### PR TITLE
Use fnmatch()/PathMatchSpec() to check filenames

### DIFF
--- a/garglk/launcher.cpp
+++ b/garglk/launcher.cpp
@@ -275,16 +275,9 @@ static void configterp(const std::string &exedir, const std::string &gamepath, s
     if (story.empty())
         return;
 
-    std::string ext = story;
-    auto dot = story.rfind('.');
-    if (dot != std::string::npos)
-        ext.replace(0, dot, "*");
-    else
-        ext = "*.*";
-
     for (const auto &config : garglk::configs(exedir, gamepath))
     {
-        if (findterp(config.path, story, interpreter) || findterp(config.path, ext, interpreter))
+        if (findterp(config.path, story, interpreter))
             return;
     }
 }


### PR DESCRIPTION
The previous code was very relaxed in determining whether an
interpreter/game matched a section: a simple string search was done, so
something like

    [*.z1 *.z2 *.z3]

would do the equivalent of

    strstr(selector, "*.z3") != NULL

Now fnmatch() (or PathMatchSpec() on Windows) is used to do matching per
the platform's expected shell matching behavior, and multiple patterns
are matched individually.

This definitely _can_ have different behavior than the original code,
but in all realistic cases shouldn't; and if the behavior is different,
the new behavior is more correct (which is to say more strict). There
shouldn't be accidental matches now, with the new code.