### PR TITLE
Improve icons on Windows

### DIFF
--- a/garglk/icons.rc
+++ b/garglk/icons.rc
@@ -1,2 +1,1 @@
-IDI_GAPP ICON house.ico
-IDI_GDOC ICON docu2.ico
+IDI_ICON1 ICON house.ico

--- a/terps/CMakeLists.txt
+++ b/terps/CMakeLists.txt
@@ -24,6 +24,10 @@ function(terp target)
     target_include_directories(${target} PRIVATE "${PROJECT_SOURCE_DIR}/garglk" ${TERP_INCLUDE_DIRS})
     target_link_libraries(${target} PRIVATE garglkmain garglk ${TERP_LIBS})
 
+    if(MINGW)
+        target_sources(${target} PRIVATE "${PROJECT_SOURCE_DIR}/garglk/icons.rc")
+    endif()
+
     if(NOT TERP_CXXSTD)
         set(TERP_CXXSTD 98)
     endif()


### PR DESCRIPTION
This adds icon resources to all interpreters. In addition, Qt's
IDI_ICON1 is used so that the Gargoyle icon will be used in the taskbar.