### PR TITLE
Reintroduce IDI_GDOC

### DIFF
--- a/garglk/icons.rc
+++ b/garglk/icons.rc
@@ -1,1 +1,2 @@
+IDI_GDOC ICON docu2.ico
 IDI_ICON1 ICON house.ico

--- a/installer.nsi
+++ b/installer.nsi
@@ -144,7 +144,7 @@ Section "DoInstall"
     WriteRegStr HKCR ".saga" "" "Gargoyle.Story"
 
     WriteRegStr HKCR "Gargoyle.Story" "" "Interactive Fiction Story File"
-    WriteRegStr HKCR "Gargoyle.Story\DefaultIcon" "" "$INSTDIR\gargoyle.exe,1"
+    WriteRegStr HKCR "Gargoyle.Story\DefaultIcon" "" "$INSTDIR\gargoyle.exe,0"
     WriteRegStr HKCR "Gargoyle.Story\shell" "" "open"
     WriteRegStr HKCR "Gargoyle.Story\shell\open" "" "Play"
     WriteRegStr HKCR "Gargoyle.Story\shell\open\command" "" "$INSTDIR\gargoyle.exe $\"%1$\""


### PR DESCRIPTION
This icon isn't used by name, but is used by number in the registry in
order to provide a document type icon for the various story files.
Documentation on this isn't exactly good, but it seems that the icons
are ordered by name, so now that IDI_GDOC and IDI_ICON1 are the only
ones, IDI_GDOC has the number 0, and IDI_ICON1 the number 1. Qt uses
IDI_ICON1 by name, so that's OK, but the installer uses the index, so
make sure it's in line with what actually exists.