### PR TITLE
macOS: Stop sound channels when terminating game

### DIFF
--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -356,7 +356,16 @@ void winhandler(int signal)
     }
 
     if (signal == SIGUSR2)
+    {
         gli_window_alive = false;
+
+        /* Stop all sound channels */
+        for (channel_t *chan = glk_schannel_iterate(NULL, NULL); chan; chan = glk_schannel_iterate(chan, NULL))
+        {
+            glk_schannel_stop(chan);
+        }
+
+    }
 }
 
 void wininit(int *argc, char **argv)


### PR DESCRIPTION
This is a fix for #371. There might be a more elegant way to do it, but it seems to work.

When the interpreter process receives a termination signal, we stop any Glk sound channels.