### PR TITLE
Allow native file dialogs to be disabled with Qt

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -20,6 +20,10 @@ set(WITH_TTS "AUTO" CACHE STRING "Enable text-to-speech support (ON/OFF/AUTO)")
 set(GARGLKPRE "" CACHE STRING "Binary prefix")
 set(SOUND "SDL" CACHE STRING "Backend to use for sound (SDL, QT, or none)")
 
+if(INTERFACE STREQUAL "QT")
+    option(WITH_NATIVE_FILE_DIALOGS "Use native dialogs instead of Qt dialogs" ON)
+endif()
+
 vtk_encode_string(
     INPUT garglk.ini
     NAME garglkini
@@ -33,6 +37,10 @@ set_property(SOURCE config.cpp PROPERTY COMPILE_DEFINITIONS GARGLKINI_H="${GARGL
 if(INTERFACE STREQUAL "QT")
     set(CMAKE_AUTOMOC ON)
     set_property(SOURCE garglkini.cxx PROPERTY SKIP_AUTOMOC ON)
+
+    if(NOT WITH_NATIVE_FILE_DIALOGS)
+        set_property(SOURCE sysqt.cpp launchqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLK_NO_NATIVE_FILE_DIALOGS)
+    endif()
 endif()
 
 add_library(garglk babeldata.c style.c config.cpp draw.cpp

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -107,7 +107,11 @@ static QString winbrowsefile()
     // Hide filter details because the sheer number in "All Games" makes
     // the dialog ridiculously wide (Qt probably should cut it off, but
     // it doesn't, so try to compensate here).
-    return QFileDialog::getOpenFileName(nullptr, AppName, "", filter_string, nullptr, QFileDialog::HideNameFilterDetails);
+    QFileDialog::Options options(QFileDialog::HideNameFilterDetails);
+#ifdef GARGLK_NO_NATIVE_FILE_DIALOGS
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+    return QFileDialog::getOpenFileName(nullptr, AppName, "", filter_string, nullptr, options);
 }
 
 int garglk::winterp(const std::string &path, const std::string &exe, const std::string &flags, const std::string &game)

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -108,16 +108,20 @@ enum class Action { Open, Save };
 static std::string winchoosefile(const QString &prompt, FILEFILTERS filter, Action action)
 {
     QString filename;
+    QFileDialog::Options options;
+#ifdef GARGLK_NO_NATIVE_FILE_DIALOGS
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
 
     if (action == Action::Open)
     {
         QString filterstring = QString("%1;;All files (*)").arg(filters.at(filter).first);
-        filename = QFileDialog::getOpenFileName(window, prompt, "", filterstring);
+        filename = QFileDialog::getOpenFileName(window, prompt, "", filterstring, nullptr, options);
     }
     else
     {
         QString dir = QString("./Untitled.%1").arg(filters.at(filter).second);
-        filename = QFileDialog::getSaveFileName(window, prompt, dir, filters.at(filter).first);
+        filename = QFileDialog::getSaveFileName(window, prompt, dir, filters.at(filter).first, nullptr, options);
     }
 
     return filename.toStdString();


### PR DESCRIPTION
The primary reason for this is to support Flatpak. With native dialogs
(at least with Plasma), files aren't properly mapped to the Flatpak
sandbox. They can be selected, but the filename returned by QFileDialog
is a non-existent file. Using non-native file dialogs doesn't have this
problem.

This directly contradicts the advice at
https://docs.flatpak.org/en/latest/portals-qt.html. I don't know why.