### PR TITLE
Clarify Glulxe licensing (MIT license)

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -12,11 +12,11 @@ Bocfel is copyright (c) Chris Spiegel. It is released under the terms of the GNU
 
 Git is copyright (c) Iain Merrick. It is released under the terms of the MIT License.
 
-Glulxe is copyright (c) Andrew Plotkin.
+Glulxe is copyright (c) Andrew Plotkin. It is released under the terms of the MIT License.
 
 Hugo is copyright (c) Kent Tessman. It is released with permission under the terms of the Simplified 2-Clause BSD license.
 
-JACL is copyright (c) Stuart Allen.  It is released under the terms of the GNU General Public License.
+JACL is copyright (c) Stuart Allen. It is released under the terms of the GNU General Public License.
 
 Level 9 is copyright (c) Glen Summers, David Kinder, Alan Staniforth, Simon Baldwin and Dieter Baron. It is released under the terms of the GNU General Public License.
 


### PR DESCRIPTION
Glulxe switched to the MIT license in 2016 with version 0.5.3, and the
currently bundled version 0.5.4 is also under the MIT license:

https://github.com/erkyrath/glulxe/commit/046949576c022da54c00ddc2e381b43161e5c08b

This was already made clear in `terps/glulxe/LICENSE` but not in
`Licenses.txt`.