### PR TITLE
Unix: Install garglk.ini to `CMAKE_INSTALL_SYSCONFDIR`

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -7,7 +7,10 @@ option(BUILD_SHARED_LIBS "Build a shared libgarglk instead of a static library" 
 
 if(UNIX AND NOT APPLE)
     option(WITH_FREEDESKTOP "Install freedesktop.org application, icon, and MIME files" ON)
-    set(GARGLKINI "/etc/garglk.ini" CACHE STRING "Full path for garglk.ini")
+    set(GARGLKINI "${CMAKE_INSTALL_FULL_SYSCONFDIR}/garglk.ini")
+    if(NOT APPIMAGE)
+        option(INSTALL_GARGLKINI "Install an example config file to ${GARGLKINI}" OFF)
+    endif()
 endif()
 
 if(APPLE)
@@ -219,6 +222,10 @@ elseif(UNIX)
     install(FILES cheapglk/gi_blorb.h cheapglk/glk.h glkstart.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/garglk")
     configure_file("garglk.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/garglk.pc" @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/garglk.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+
+    if(INSTALL_GARGLKINI)
+        install(FILES "garglk.ini" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
+    endif()
 
     if(WITH_FREEDESKTOP)
         install(FILES "gargoyle.desktop" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -6,7 +6,7 @@
 # order, with later settings overriding earlier settings:
 #
 #   1: same directory as the executable: garglk.ini (windows)
-#   2: /etc/garglk.ini (unix)
+#   2: /etc/garglk.ini (or other location set at build time, Unix only)
 #   3: Platform-specific locations:
 #          $HOME/.garglkrc (unix)
 #          ${XDG_CONFIG_HOME:-$HOME/.config}/garglk.ini (unix)


### PR DESCRIPTION
There might have been a good reason not to do so, so feel free to close this PR if it's not wanted.

Installing `garglk.ini` to `/etc/garglk.ini` seems to be the main path where Gargoyle expects to find it on Unix (at least on Linux), and what I used to do manually in my distro packaging of gargoyle (for Mageia).

I'm not sure how it works on macOS, nor whether it should also be done for the Linux AppImage distribution. I can amend the commit as needed.