### PR TITLE
Improve coverage of readline-style keyboard shortcuts

### DIFF
--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -37,9 +37,18 @@
 #define NSKEY_DOWN      0x7d
 #define NSKEY_UP        0x7e
 
-#define NSKEY_X         0x07
+#define NSKEY_A         0x00
+#define NSKEY_B         0x0b
 #define NSKEY_C         0x08
+#define NSKEY_D         0x02
+#define NSKEY_E         0x0e
+#define NSKEY_F         0x03
+#define NSKEY_H         0x04
+#define NSKEY_N         0x2d
+#define NSKEY_P         0x23
+#define NSKEY_U         0x20
 #define NSKEY_V         0x09
+#define NSKEY_X         0x07
 
 #define NSKEY_PGUP      0x74
 #define NSKEY_PGDN      0x79

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -477,6 +477,17 @@ void winkey(NSEvent *evt)
         {{NSEventModifierFlagCommand, NSKEY_C}, []{ winclipsend(); }},
         {{NSEventModifierFlagCommand, NSKEY_V}, []{ winclipreceive(); }},
 
+        /* readline/emacs-style controls */
+        {{NSEventModifierFlagControl, NSKEY_A}, []{ gli_input_handle_key(keycode_Home); }},
+        {{NSEventModifierFlagControl, NSKEY_B}, []{ gli_input_handle_key(keycode_Left); }},
+        {{NSEventModifierFlagControl, NSKEY_D}, []{ gli_input_handle_key(keycode_Erase); }},
+        {{NSEventModifierFlagControl, NSKEY_E}, []{ gli_input_handle_key(keycode_End); }},
+        {{NSEventModifierFlagControl, NSKEY_F}, []{ gli_input_handle_key(keycode_Right); }},
+        {{NSEventModifierFlagControl, NSKEY_H}, []{ gli_input_handle_key(keycode_Delete); }},
+        {{NSEventModifierFlagControl, NSKEY_N}, []{ gli_input_handle_key(keycode_Down); }},
+        {{NSEventModifierFlagControl, NSKEY_P}, []{ gli_input_handle_key(keycode_Up); }},
+        {{NSEventModifierFlagControl, NSKEY_U}, []{ gli_input_handle_key(keycode_Escape); }},
+
         /* unmodified key for line editing */
         {{0, NSKEY_LEFT},  []{ gli_input_handle_key(keycode_Left); }},
         {{0, NSKEY_RIGHT}, []{ gli_input_handle_key(keycode_Right); }},

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -278,6 +278,7 @@ void View::keyPressEvent(QKeyEvent *event)
         {{Qt::ControlModifier, Qt::Key_D},     []{ gli_input_handle_key(keycode_Erase); }},
         {{Qt::ControlModifier, Qt::Key_E},     []{ gli_input_handle_key(keycode_End); }},
         {{Qt::ControlModifier, Qt::Key_F},     []{ gli_input_handle_key(keycode_Right); }},
+        {{Qt::ControlModifier, Qt::Key_H},     []{ gli_input_handle_key(keycode_Delete); }},
         {{Qt::ControlModifier, Qt::Key_N},     []{ gli_input_handle_key(keycode_Down); }},
         {{Qt::ControlModifier, Qt::Key_P},     []{ gli_input_handle_key(keycode_Up); }},
         {{Qt::ControlModifier, Qt::Key_U},     []{ gli_input_handle_key(keycode_Escape); }},


### PR DESCRIPTION
macOS now has the same level of support as Windows/Linux, and
Windows/Linux can now use C-h as a synonym for backspace.