### PR TITLE
Support fallback fonts on macOS

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -232,7 +232,7 @@ static void parsecolor(const std::string &str, unsigned char *rgb)
 //        %APPDATA%/Gargoyle/garglk.ini (Windows only)
 //        <current directory>/garglk.ini (Windows only)
 //        $HOME/garglk.ini (macOS only)
-// 4. $GARGLK_INI/garglk.ini (macOS only)
+// 4. $GARGLK_RESOURCES/garglk.ini (macOS only)
 // 5. /etc/garglk.ini (or other location set at build time, Unix only)
 // 6. <directory containing gargoyle executable>/garglk.ini (Windows only)
 //
@@ -310,9 +310,9 @@ std::vector<garglk::ConfigFile> garglk::configs(const std::string &exedir = "", 
 #endif
 
 #ifdef __APPLE__
-    // macOS sets $GARGLK_INI to the bundle directory containing a
+    // macOS sets $GARGLK_RESOURCES to the bundle directory containing a
     // default garglk.ini.
-    const char *garglkini = std::getenv("GARGLK_INI");
+    const char *garglkini = std::getenv("GARGLK_RESOURCES");
     if (garglkini != nullptr)
         configs.push_back(ConfigFile(std::string(garglkini) + "/garglk.ini", false));
 #endif

--- a/garglk/fontmac.mm
+++ b/garglk/fontmac.mm
@@ -237,8 +237,8 @@ void garglk::fontreplace(const std::string &font, int type)
 
 void fontload(void)
 {
-    // 'GARGLK_INI' should be the path to the Bundle's Resources directory
-    const char * env = getenv("GARGLK_INI");
+    // 'GARGLK_RESOURCES' should be the path to the Bundle's Resources directory
+    const char * env = getenv("GARGLK_RESOURCES");
     if (!env)
         return;
 

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -618,7 +618,7 @@ static BOOL isTextbufferEvent(NSEvent * evt)
 
     [nsResources getCString: etc maxLength: sizeof etc encoding: NSUTF8StringEncoding];
 
-    setenv("GARGLK_INI", etc, true);
+    setenv("GARGLK_RESOURCES", etc, true);
 
     /* set preference defaults */
     [[NSUserDefaults standardUserDefaults] registerDefaults:

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -688,9 +688,11 @@ void winpoll(void)
 
 std::string garglk::winfontpath(const std::string &filename)
 {
-    // There's no need to look up fonts in any special way on macOS: the
-    // bundle sets fonts up in such a way that they're found without
-    // needing a fallback.
+    char *resources = getenv("GARGLK_RESOURCES");
+
+    if (resources != nullptr)
+        return std::string(resources) + "/Fonts/" + filename;
+
     return "";
 }
 


### PR DESCRIPTION
Fallback fonts are still useful on macOS if the user specifies invalid
fonts in garglk.ini. This can accidentally happen with an older
garglk.ini from 2019.1 (or earlier) which uses fonts that are no longer
distributed with Gargoyle. Now macOS falls back to the bundled fonts.