### PR TITLE
Don't redraw directly inside of paint events

### DIFF
--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -70,6 +70,8 @@ static Window *window;
 static QElapsedTimer last_tick;
 #define TICK_PERIOD_MILLIS 10
 
+static bool refresh_needed = true;
+
 static void handle_input(const QString &input)
 {
     for (const uint &c : input.toUcs4())
@@ -202,6 +204,7 @@ void Window::resizeEvent(QResizeEvent *event)
     gli_image_rgb = new unsigned char[gli_image_s * gli_image_h];
 
     gli_force_redraw = true;
+    refresh_needed = true;
 
     gli_windows_size_change();
 
@@ -229,13 +232,19 @@ void View::inputMethodEvent(QInputMethodEvent *event) {
     event->accept();
 }
 
-void View::paintEvent(QPaintEvent *event)
+void View::refresh()
 {
     if (!gli_drawselect)
         gli_windows_redraw();
     else
         gli_drawselect = false;
 
+    update();
+    refresh_needed = false;
+}
+
+void View::paintEvent(QPaintEvent *event)
+{
     QImage image(gli_image_rgb, gli_image_w, gli_image_h, QImage::Format_RGB32);
     QPainter painter(this);
     painter.drawImage(QPoint(0, 0), image);
@@ -271,6 +280,8 @@ static void edit_config()
 void View::keyPressEvent(QKeyEvent *event)
 {
     Qt::KeyboardModifiers modmasked = event->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+
+    refresh_needed = true;
 
     static const std::map<std::pair<decltype(modmasked), decltype(event->key())>, std::function<void()>> keys = {
         {{Qt::ControlModifier, Qt::Key_A},     []{ gli_input_handle_key(keycode_Home); }},
@@ -458,7 +469,7 @@ void wintitle()
 
 void winrepaint(int x0, int y0, int x1, int y1)
 {
-    window->update(x0, y0, x1 - x0, y1 - y0);
+    refresh_needed = true;
 }
 
 std::string garglk::winfontpath(const std::string &filename)
@@ -483,10 +494,16 @@ void gli_select(event_t *event, int polled)
 
     gli_dispatch_event(event, polled);
 
+    if (refresh_needed)
+        window->refresh();
+
     if (!polled)
     {
         while (event->type == evtype_None && !window->timed_out())
         {
+            if (refresh_needed)
+                window->refresh();
+
             app->processEvents(QEventLoop::WaitForMoreEvents);
             gli_dispatch_event(event, polled);
         }

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -23,6 +23,7 @@ public:
     }
 
     QVariant inputMethodQuery(Qt::InputMethodQuery query) const override;
+    void refresh();
 
 protected:
     void inputMethodEvent(QInputMethodEvent *event) override;
@@ -39,6 +40,8 @@ class Window : public QMainWindow {
 public:
     Window();
     ~Window();
+
+    void refresh() { m_view->refresh(); }
 
     void start_timer(long);
     bool timed_out() { return m_timed_out; }


### PR DESCRIPTION
When Glk ticks are enabled (required for the Qt sound backend), more
paint events could be generated, due to winrepaint() being called during
event processing in the tick handler. As a result, more redraw requests
were being made, leading to unwanted scrolling (past the more prompt) in
some cases.

Follow the macOS interface and delay redraws till something from the
user triggers them.