### PR TITLE
Provide a new glkunix_fileref_get_filename API function

### DIFF
--- a/garglk/cheapglk/cgfref.cpp
+++ b/garglk/cheapglk/cgfref.cpp
@@ -542,3 +542,7 @@ void glkunix_set_base_file(char *filename)
 #endif
 }
 
+const char *glkunix_fileref_get_filename(fileref_t *fref)
+{
+    return fref->filename;
+}

--- a/garglk/cheapglk/glk.h
+++ b/garglk/cheapglk/glk.h
@@ -476,12 +476,6 @@ extern strid_t glk_stream_open_resource_uni(glui32 filenum, glui32 rock);
 
 #endif /* GLK_MODULE_RESOURCE_STREAM */
 
-/* "Unofficial official" Glk function (provided by remglk) as an
-    alternative name to garglk_fileref_get_name. */
-
-#define GLKUNIX_FILEREF_GET_FILENAME (1)
-extern const char *glkunix_fileref_get_filename(frefid_t fref);
-
 /* XXX non-official Glk functions that may or may not exist */
 
 #define GARGLK 1

--- a/garglk/cheapglk/glk.h
+++ b/garglk/cheapglk/glk.h
@@ -476,10 +476,19 @@ extern strid_t glk_stream_open_resource_uni(glui32 filenum, glui32 rock);
 
 #endif /* GLK_MODULE_RESOURCE_STREAM */
 
+/* "Unofficial official" Glk function (provided by remglk) as an
+    alternative name to garglk_fileref_get_name. */
+
+#define GLKUNIX_FILEREF_GET_FILENAME (1)
+extern const char *glkunix_fileref_get_filename(frefid_t fref);
+
 /* XXX non-official Glk functions that may or may not exist */
 
 #define GARGLK 1
 
+#ifdef __GNUC__
+__attribute__((__deprecated__("Use glkunix_fileref_get_filename instead")))
+#endif
 extern const char *garglk_fileref_get_name(frefid_t fref);
 
 extern void garglk_set_program_name(const char *name);

--- a/garglk/glkstart.h
+++ b/garglk/glkstart.h
@@ -61,9 +61,14 @@ extern glkunix_argumentlist_t glkunix_arguments[];
 
 extern int glkunix_startup_code(glkunix_startup_t *data);
 
+#define GLKUNIX_FILEREF_GET_FILENAME (1)
+
 extern void glkunix_set_base_file(char *filename);
 extern strid_t glkunix_stream_open_pathname(char *pathname, glui32 textmode,
     glui32 rock);
+#ifdef GLKUNIX_FILEREF_GET_FILENAME
+extern const char *glkunix_fileref_get_filename(frefid_t fref);
+#endif
 
 #ifdef __cplusplus
 }

--- a/terps/agility/os_glk.c
+++ b/terps/agility/os_glk.c
@@ -5788,9 +5788,9 @@ gagt_confirm (const char *prompt)
  * It may also work for you, but if it doesn't, or if your system lacks
  * things like dup or fdopen, define GLK_ANSI_ONLY and use the safe version.
  *
- * If GARGLK is used, non-ansi version calls garglk_fileref_get_name()
- * instead, and opens a file the highly portable way, but still with a
- * Glkily nice prompt dialog.
+ * If GLKUNIX_FILEREF_GET_FILENAME is defined, non-ansi version calls
+ * glkunix_fileref_get_filename() instead, and opens a file the highly
+ * portable way, but still with a Glkily nice prompt dialog.
  */
 #ifdef GLK_ANSI_ONLY
 static genfile
@@ -5922,8 +5922,8 @@ gagt_get_user_file (glui32 usage, glui32 fmode, const char *fdtype)
    * underlying file descriptor or FILE* from a Glk stream either. :-(
    */
 
-#ifdef GLK_MODULE_FILEREF_GET_NAME
-  retfile = fopen(garglk_fileref_get_name(fileref), fdtype);
+#ifdef GLKUNIX_FILEREF_GET_FILENAME
+  retfile = fopen(glkunix_fileref_get_filename(fileref), fdtype);
 #else
 
   /* So, start by dup()'ing the first file descriptor we can, ... */

--- a/terps/alan2/exe.c
+++ b/terps/alan2/exe.c
@@ -1526,13 +1526,13 @@ void save()
   char str[256];
   AtrElem *atr;
 
-#ifdef GLK_MODULE_FILEREF_GET_NAME
+#ifdef GLKUNIX_FILEREF_GET_FILENAME
 
   frefid_t fref;
   fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Write, 0);
   if (fref == NULL)
     error(M_SAVEFAILED);
-  strcpy(str, garglk_fileref_get_name(fref));
+  strcpy(str, glkunix_fileref_get_filename(fref));
   glk_fileref_destroy(fref);
 
 #else
@@ -1628,13 +1628,13 @@ void restore()
   char savedVersion[4];
   char savedName[256];
 
-#ifdef GLK_MODULE_FILEREF_GET_NAME
+#ifdef GLKUNIX_FILEREF_GET_FILENAME
 
   frefid_t fref;
   fref = glk_fileref_create_by_prompt(fileusage_SavedGame, filemode_Read, 0);
   if (fref == NULL)
     error(M_SAVEFAILED);
-  strcpy(str, garglk_fileref_get_name(fref));
+  strcpy(str, glkunix_fileref_get_filename(fref));
   glk_fileref_destroy(fref);
 
 #else

--- a/terps/bocfel/glkstart.cpp
+++ b/terps/bocfel/glkstart.cpp
@@ -26,6 +26,19 @@ extern "C" {
 #include <glk.h>
 }
 
+#ifdef ZTERP_GLK_BLORB
+extern "C" {
+#include <gi_blorb.h>
+}
+#endif
+
+#ifdef ZTERP_GLK_UNIX
+extern "C" {
+#include <glkstart.h>
+}
+
+static void load_resources();
+
 // The “standard” function (provided by remglk as an extension) for
 // getting a filename from a fileref is glkunix_fileref_get_filename;
 // Gargoyle has always had the function garglk_fileref_get_name for this
@@ -36,19 +49,6 @@ extern "C" {
 #if defined(GARGLK) && !defined(GLKUNIX_FILEREF_GET_FILENAME)
 #define glkunix_fileref_get_filename garglk_fileref_get_name
 #endif
-
-#ifdef ZTERP_GLK_BLORB
-extern "C" {
-#include <gi_blorb.h>
-}
-#endif
-
-static void load_resources();
-
-#ifdef ZTERP_GLK_UNIX
-extern "C" {
-#include <glkstart.h>
-}
 
 glkunix_argumentlist_t glkunix_arguments[] =
 {

--- a/terps/bocfel/glkstart.cpp
+++ b/terps/bocfel/glkstart.cpp
@@ -26,6 +26,17 @@ extern "C" {
 #include <glk.h>
 }
 
+// The “standard” function (provided by remglk as an extension) for
+// getting a filename from a fileref is glkunix_fileref_get_filename;
+// Gargoyle has always had the function garglk_fileref_get_name for this
+// purpose, but has now adopted the remglk name for greater
+// compatibility. If building under garglk, and the newer name is not
+// available, fall back to the known-to-exist original name. Otherwise,
+// use the new name.
+#if defined(GARGLK) && !defined(GLKUNIX_FILEREF_GET_FILENAME)
+#define glkunix_fileref_get_filename garglk_fileref_get_name
+#endif
+
 #ifdef ZTERP_GLK_BLORB
 extern "C" {
 #include <gi_blorb.h>
@@ -80,7 +91,7 @@ int glkunix_startup_code(glkunix_startup_t *data)
 
         ref = glk_fileref_create_by_prompt(fileusage_Data | fileusage_BinaryMode, filemode_Read, 0);
         if (ref != nullptr) {
-            const char *filename = garglk_fileref_get_name(ref);
+            const char *filename = glkunix_fileref_get_filename(ref);
             if (filename != nullptr) {
                 game_file = filename;
             }

--- a/terps/tads/glk/osgarglk.h
+++ b/terps/tads/glk/osgarglk.h
@@ -89,18 +89,6 @@ unsigned char *os_fill_buffer (unsigned char *buf, size_t len);
 
 int os_vasprintf(char **bufptr, const char *fmt, va_list ap);
 
-// Patch Remglk's fileref_get_filename function
-#include "glk.h"
-#include "glkstart.h"
-#ifdef GLKUNIX_FILEREF_GET_FILENAME
-
-#include "remglk.h"
-#define GLK_MODULE_FILEREF_GET_NAME
-extern char *glkunix_fileref_get_filename(frefid_t fref);
-#define garglk_fileref_get_name glkunix_fileref_get_filename
-
-#endif /* GLKUNIX_FILEREF_GET_FILENAME */
-
 #ifdef __cplusplus
 }
 #endif

--- a/terps/tads/glk/osglk.c
+++ b/terps/tads/glk/osglk.c
@@ -540,8 +540,8 @@ int os_askfile(const char *prompt, char *fname_buf, int fname_buf_len,
     if (fileref == NULL)
         return OS_AFE_CANCEL;
 
-#ifdef GARGLK
-    strcpy(fname_buf, garglk_fileref_get_name(fileref));
+#ifdef GLKUNIX_FILEREF_GET_FILENAME
+    strcpy(fname_buf, glkunix_fileref_get_filename(fileref));
 #endif
 
     glk_fileref_destroy(fileref);


### PR DESCRIPTION
This is identical to the existing garglk_fileref_get_name function, but
for compatibility with remglk, the new name is used (and preferred).

The original function is marked as deprecated, but will remain in the
library for the foreseeable future.