### PR TITLE
Flush FILE streams on write

### DIFF
--- a/garglk/cheapglk/cgstream.c
+++ b/garglk/cheapglk/cgstream.c
@@ -741,6 +741,7 @@ static void gli_put_char(stream_t *str, unsigned char ch)
                     putc(ch, str->file);
                 }
             }
+            fflush(str->file);
             break;
         case strtype_Resource:
             /* resource streams are never writable */
@@ -830,6 +831,7 @@ static void gli_put_char_uni(stream_t *str, glui32 ch)
                     putc( (ch        & 0xFF), str->file);
                 }
             }
+            fflush(str->file);
             break;
         case strtype_Resource:
             /* resource streams are never writable */
@@ -951,6 +953,7 @@ static void gli_put_buffer(stream_t *str, char *buf, glui32 len)
                     }
                 }
             }
+            fflush(str->file);
             break;
         case strtype_Resource:
             /* resource streams are never writable */


### PR DESCRIPTION
When upstream cheapglk was brought in, some fflush() calls got lost,
resulting in (among other things, probably) transcripts not getting
written until the buffer filled up, or the file was closed, whichever
came first.

fflush() is now called whenever a character or buffer is written. This
is less efficient than it ought to be, since glk_put_buffer_uni() is now
implemented in terms of gli_put_char_uni(). That means that when writing
a buffer, fflush() is called for each and every character. Accept this
for now, since it's never going to be a huge bottleneck, and only TADS
is actually making use of glk_put_buffer_uni(). But at some point I'd
like to find a solution that doesn't cause the code to deviate too much
from upstream cheapglk, to keep future updates as painless as possible.