### PR TITLE
Sanitize config entries

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -119,6 +119,11 @@ find_package(PNG REQUIRED)
 target_include_directories(garglk PUBLIC cheapglk PRIVATE ${FREETYPE_INCLUDE_DIRS} ${JPEG_INCLUDE_DIRS} ${PNG_INCLUDE_DIRS})
 target_link_libraries(garglk PRIVATE ${FREETYPE_LIBRARIES} ${JPEG_LIBRARIES} ${PNG_LIBRARIES})
 
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+    target_link_libraries(garglk PRIVATE ${MATH_LIBRARY})
+endif()
+
 if(${INTERFACE} STREQUAL "COCOA")
     find_library(COCOA_LIBRARY Cocoa REQUIRED)
     find_package(OpenGL REQUIRED)

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -295,7 +295,6 @@ extern bool gli_conf_lockrows;
 extern unsigned char gli_scroll_bg[3];
 extern unsigned char gli_scroll_fg[3];
 extern int gli_scroll_width;
-extern int gli_scroll_width_save;
 
 extern int gli_baseline;
 extern int gli_leading;


### PR DESCRIPTION
Before this, there was no sanitization of config values, so the user
could set things like -50 columns, or a line spacing of -100. A lot of
these invalid values could lead to segfaults, while others caused
obvious graphics glitches.

All (hopefully) config entries are now checked to ensure they're at
least positive, where necessary. In addition, parsing of colors is more
correct: earlier, a value such as "-b-b-b" was allowed, and is not any
more.

It's possible that this causes behavior change, but only in config files
that were clearly wrong, so that's fine.