### PR TITLE
Always read the entire line when parsing a config entry

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -438,21 +438,7 @@ void garglk::config_entries(const std::string &fname, bool accept_bare, const st
         if (linestream >> cmd)
         {
             std::string arg;
-            std::set<std::string> singlearg = {
-                "tcolor", "gcolor",
-                "tfont", "gfont",
-                "monofont", "propfont",
-                "monor", "monob", "monoi", "monoz",
-                "propr", "propb", "propi", "propz",
-                "lcdweights",
-                "moreprompt",
-                "terp",
-            };
-
-            if (std::any_of(singlearg.begin(), singlearg.end(), [&cmd](const std::string &key) { return key == cmd; }))
-                std::getline(linestream >> std::ws, arg);
-            else
-                linestream >> arg;
+            std::getline(linestream >> std::ws, arg);
 
             if (linestream)
                 callback(cmd, arg);


### PR DESCRIPTION
Earlier, except for specific functions, this would stop reading at the
first whitespace; but that doesn't really make sense: if the user's
providing extra data, why just ignore it?

Realistically speaking this won't change much: a lot of config entries
use strtol() or similar, which will bail at the first
invalid/non-numeric value anyway. It'll only change something like
lcdfilter, which takes a string argument. If the user tacked something
onto the end of it, then it'll no longer be valid. But nobody should do
that, and if they did, it's fair to say it was undefined behavior
anyway.

But the reason for this change isn't really to tighten up the parser.
Rather, it's because it gets rid of a lot of code that was pointless.