### PR TITLE
Don't use the name timegm()

### DIFF
--- a/garglk/cheapglk/cgdate.c
+++ b/garglk/cheapglk/cgdate.c
@@ -46,6 +46,13 @@
 */
 #define NO_TIMEGM_AVAIL
 
+/* ... but due to the mess that is C/C++ dependencies, give it a
+   different name, in case a dependency forces the name to be exposed
+   anyway, even though Gargoyle specifically requests a POSIX
+   environment, without extensions.
+ */
+#define timegm cg_timegm
+
 /* bzero() is deprecated */
 #undef bzero
 #define bzero(s, n) memset((s), 0, (n))


### PR DESCRIPTION
It's perfectly valid to use this name, since it's not a standard
function (neither C nor POSIX). But due to how broken the C dependency
system is, it's possible that the name gets exposed anyway.

This is not just a theoretical problem: SDL2_mixer 2.6.0 has an updated
pkg-config file which, ultimately, results in ncurses being required,
which sets _DEFAULT_SOURCE. This causes timegm() to be exposed, clashing
with cheapglk's version of timegm() (a name which which, again, it's
allowed to use).

The fact that headers are simply pasted into your own source files makes
it impossible to have a clean separation between your code and any
libraries you may use. If a library's header requires a non-standard
environment, then that environment is forced on *your* code as well.
It's ridiculous that a version bump in SDL2_mixer, without changing the
API or ABI, can cause a build failure, but here we are.