### PR TITLE
Move non-standard functions out of cgmisc.c

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -46,8 +46,8 @@ if(INTERFACE STREQUAL "QT")
     endif()
 endif()
 
-add_library(garglk babeldata.c style.c config.cpp draw.cpp
-    event.cpp imgload.c imgscale.c winblank.c window.c wingfx.c
+add_library(garglk babeldata.c style.c config.cpp draw.cpp event.cpp
+    garglk.cpp imgload.c imgscale.c winblank.c window.c wingfx.c
     wingrid.c winmask.c winpair.c wintext.c ${GARGLKINI_CXX}
 
     # These can't be a library in cheapglk/ because they contain

--- a/garglk/cheapglk/cgmisc.c
+++ b/garglk/cheapglk/cgmisc.c
@@ -42,40 +42,6 @@ bool gli_terminated = false;
 static unsigned char char_tolower_table[256];
 static unsigned char char_toupper_table[256];
 
-#ifdef GARGLK
-char gli_program_name[256] = "Unknown";
-char gli_program_info[256] = "";
-char gli_story_name[256] = "";
-char gli_story_title[256] = "";
-
-void garglk_set_program_name(const char *name)
-{
-    strncpy(gli_program_name, name, sizeof gli_program_name);
-    gli_program_name[sizeof gli_program_name-1] = 0;
-    wintitle();
-}
-
-void garglk_set_program_info(const char *info)
-{
-    strncpy(gli_program_info, info, sizeof gli_program_info);
-    gli_program_info[sizeof gli_program_info-1] = 0;
-}
-
-void garglk_set_story_name(const char *name)
-{
-    strncpy(gli_story_name, name, sizeof gli_story_name);
-    gli_story_name[sizeof gli_story_name-1] = 0;
-    wintitle();
-}
-
-void garglk_set_story_title(const char *title)
-{
-    strncpy(gli_story_title, title, sizeof gli_story_title);
-    gli_story_title[sizeof gli_story_title-1] = 0;
-    wintitle();
-}
-#endif
-
 gidispatch_rock_t (*gli_register_obj)(void *obj, glui32 objclass) = NULL;
 void (*gli_unregister_obj)(void *obj, glui32 objclass, 
     gidispatch_rock_t objrock) = NULL;

--- a/garglk/garglk.cpp
+++ b/garglk/garglk.cpp
@@ -1,0 +1,31 @@
+#include <string>
+
+#include "garglk.h"
+
+std::string gli_program_name = "Unknown";
+std::string gli_program_info;
+std::string gli_story_name;
+std::string gli_story_title;
+
+void garglk_set_program_name(const char *name)
+{
+    gli_program_name = name;
+    wintitle();
+}
+
+void garglk_set_program_info(const char *info)
+{
+    gli_program_info = info;
+}
+
+void garglk_set_story_name(const char *name)
+{
+    gli_story_name = name;
+    wintitle();
+}
+
+void garglk_set_story_title(const char *title)
+{
+    gli_story_title = title;
+    wintitle();
+}

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -138,10 +138,13 @@ typedef struct window_graphics_s window_graphics_t;
 #define gli_zoom_int(x) ((x) * gli_zoom + 0.5)
 #define gli_unzoom_int(x) ((x) / gli_zoom + 0.5)
 
-extern char gli_program_name[256];
-extern char gli_program_info[256];
-extern char gli_story_name[256];
-extern char gli_story_title[256];
+#ifdef __cplusplus
+extern std::string gli_program_name;
+extern std::string gli_program_info;
+extern std::string gli_story_name;
+extern std::string gli_story_title;
+#endif
+
 extern bool gli_terminated;
 
 extern window_t *gli_rootwin;

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -281,9 +281,9 @@ void wintitle(void)
 {
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];
 
-    NSString * story_title = [NSString stringWithCString: gli_story_title encoding: NSUTF8StringEncoding];
-    NSString * story_name = [NSString stringWithCString: gli_story_name encoding: NSUTF8StringEncoding];
-    NSString * program_name = [NSString stringWithCString: gli_program_name encoding: NSUTF8StringEncoding];
+    NSString * story_title = [NSString stringWithCString: gli_story_title.c_str() encoding: NSUTF8StringEncoding];
+    NSString * story_name = [NSString stringWithCString: gli_story_name.c_str() encoding: NSUTF8StringEncoding];
+    NSString * program_name = [NSString stringWithCString: gli_program_name.c_str() encoding: NSUTF8StringEncoding];
 
     NSString * title = nil;
     if ([story_title length])

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -489,12 +489,12 @@ void wintitle()
 {
     QString title;
 
-    if (std::strlen(gli_story_title) != 0)
-        title = gli_story_title;
-    else if (std::strlen(gli_story_name) != 0)
-        title = QString("%1 - %2").arg(gli_story_name, gli_program_name);
+    if (!gli_story_title.empty())
+        title = QString::fromStdString(gli_story_title);
+    else if (!gli_story_name.empty())
+        title = QString("%1 - %2").arg(QString::fromStdString(gli_story_name), QString::fromStdString(gli_program_name));
     else
-        title = gli_program_name;
+        title = QString::fromStdString(gli_program_name);
 
     window->setWindowTitle(title);
 }


### PR DESCRIPTION
Once upon a time these functions lived in cgmisc.c, which came from
cheapglk. However, Gargoyle didn't merge any upstream changes from
cheapglk, so it didn't matter too much. Now cheapglk is upstreamed when
a new version comes out, and I'd rather keep it as unmodified as
possible, inserting Gargoyle-specific code only where necessary. These
extensions are _not_ required to be part of cheapglk, but there's no
other obvious home for them, so a new file called garglk.cpp was created
to hold them. It's pretty sparse at the moment, but any miscellaneous
Gargoyle functions can be added there.