### PR TITLE
Add optional KDE support for better text editing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        feature: ["-DWITH_SDL=OFF", "-DWITH_TTS=OFF", "-DWITH_BABEL=OFF", "-DSOUND=QT"]
+        feature: ["-DWITH_SDL=OFF", "-DWITH_TTS=OFF", "-DWITH_BABEL=OFF", "-DSOUND=QT", "-DWITH_KDE=ON"]
 
     runs-on: ubuntu-20.04
     container:
@@ -30,10 +30,13 @@ jobs:
         run: DEBIAN_FRONTEND=noninteractive apt install -y
           build-essential
           cmake
+          extra-cmake-modules
           git
           libfontconfig1-dev
           libfreetype-dev
           libjpeg-dev
+          libkf5kio-dev
+          libkf5service-dev
           libmpg123-dev
           libopenmpt-dev
           libsdl2-mixer-dev

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,19 @@ If you want text-to-speech support on Unix, you will need
 speech-dispatcher. Windows and macOS natively provide text-to-speech
 APIs which are used on those platforms.
 
+For Qt builds, KDE Frameworks can optionally be used. They are used in
+one place at the moment: discovery of the user's preferred text editor.
+Qt cannot determine a user's text editor, so for editing the config
+file, Gargoyle instructs Qt to open the file, hoping that the user's
+environment will launch it in a text editor. If KDE Frameworks are used,
+the user's preferred text editor will be discovered and used directly to
+open the config file. KDE Frameworks are only available with Qt5. The
+following KDE Frameworks modules are required:
+
+- extra-cmake-modules
+- kio
+- kservice
+
 On Unix, Gargoyle can be built like any standard CMake project.
 Something like:
 
@@ -58,6 +71,8 @@ In addition, Gargoyle supports the following options:
 - `WITH_FREEDESKTOP`: If true (the default), install
   freedesktop.org-compliant desktop, application, and MIME files. This
   is available only on non-Apple Unix platforms.
+
+- `WITH_KDE`: If true, KDE Frameworks will be used.
 
 - `WITH_TTS`: Takes one of four values: "ON", "OFF", "AUTO", or "DYNAMIC".
 

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -134,6 +134,7 @@ elseif(UNIX OR MINGW)
         set(QT_VERSION "6")
     else()
         set(QT_VERSION "5")
+        option(WITH_KDE "Use KDE Frameworks (improves discovery of a text editor for config file editing)" OFF)
     endif()
 
     find_package(Qt${QT_VERSION} COMPONENTS Widgets REQUIRED CONFIG)
@@ -148,6 +149,26 @@ elseif(UNIX OR MINGW)
             target_compile_definitions(garglk PRIVATE GARGLK_HAS_DBUS)
             target_link_libraries(garglk PRIVATE Qt${QT_VERSION}::DBus)
         endif()
+    endif()
+
+    if (WITH_KDE)
+        if (WITH_QT6)
+            message(FATAL_ERROR "KDE support requires Qt5")
+        endif()
+
+        find_package(ECM 1.0.0 REQUIRED NO_MODULE)
+        set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+
+        # This may trigger a warning about setting a more recent required CMake
+        # version. Such a warning can be safely ignored. The newest KF5 versions
+        # require a more recent version of CMake than Gargoyle does, but older
+        # versions do not. If Gargoyle were to require the CMake version that
+        # corresponds to the most recent KF5 version, systems with older
+        # combinations of CMake and KF5 would be excluded, even though they work
+        # just fine.
+        find_package(KF5 REQUIRED COMPONENTS KIO Service)
+        target_link_libraries(garglk PRIVATE KF5::KIOWidgets KF5::Service)
+        set_property(SOURCE sysqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLK_KDE)
     endif()
 
     if(WITH_LAUNCHER)


### PR DESCRIPTION
This optional feature allows the user's preferred text editor to be
discovered and used to edit the config file. Qt's support assumes that
the operating system will be able to open whatever config file is thrown
at it (typically .garglkrc or garglk.ini), but that's not necessarily
going to be correct. KDE allows the user's preferred handler for
text/plain to be directly discovered and run, regardless of what the
desktop thinks it ought to use to open the file. This mimics the Mac
behavior (which uses "open -t").