### PR TITLE
Rename config macros set by the build system

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -42,7 +42,7 @@ if(INTERFACE STREQUAL "QT")
     set_property(SOURCE garglkini.cxx PROPERTY SKIP_AUTOMOC ON)
 
     if(NOT WITH_NATIVE_FILE_DIALOGS)
-        set_property(SOURCE sysqt.cpp launchqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLK_NO_NATIVE_FILE_DIALOGS)
+        set_property(SOURCE sysqt.cpp launchqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS)
     endif()
 endif()
 
@@ -97,13 +97,13 @@ if(WITH_LAUNCHER)
         target_sources(gargoyle PRIVATE launchqt.cpp)
 
         # For AppImage, interpreters are installed in the same directory as the
-        # launcher, so don't provide GARGLK_INTERPRETER_DIR: in its absence, the
-        # directory of the "gargoyle" binary is searched.
+        # launcher, so don't provide GARGLK_CONFIG_INTERPRETER_DIR: in its
+        # absence, the directory of the "gargoyle" binary is searched.
         #
         # For Apple, when doing a dist install, the same holds: it expects to
         # find interpreters in the same directory as the gargoyle binary.
         if(UNIX AND NOT APPIMAGE AND NOT DIST_INSTALL)
-            target_compile_definitions(gargoyle PRIVATE "GARGLK_INTERPRETER_DIR=\"${INTERPRETER_INSTALL_DIR}\"")
+            target_compile_definitions(gargoyle PRIVATE "GARGLK_CONFIG_INTERPRETER_DIR=\"${INTERPRETER_INSTALL_DIR}\"")
         endif()
     endif()
 endif()
@@ -147,7 +147,7 @@ elseif(UNIX OR MINGW)
     if(UNIX)
         find_package(Qt${QT_VERSION} COMPONENTS DBus CONFIG)
         if(Qt${QT_VERSION}DBus_FOUND)
-            target_compile_definitions(garglk PRIVATE GARGLK_HAS_DBUS)
+            target_compile_definitions(garglk PRIVATE GARGLK_CONFIG_HAS_QDBUS)
             target_link_libraries(garglk PRIVATE Qt${QT_VERSION}::DBus)
         endif()
     endif()
@@ -169,7 +169,7 @@ elseif(UNIX OR MINGW)
         # just fine.
         find_package(KF5 REQUIRED COMPONENTS KIO Service)
         target_link_libraries(garglk PRIVATE KF5::KIOWidgets KF5::Service)
-        set_property(SOURCE sysqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLK_KDE)
+        set_property(SOURCE sysqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLK_CONFIG_KDE)
     endif()
 
     if(WITH_LAUNCHER)
@@ -185,14 +185,13 @@ if("${SOUND}" STREQUAL "QT")
     pkg_check_modules(SOUND REQUIRED IMPORTED_TARGET sndfile libmpg123 libopenmpt)
     target_link_libraries(garglk PRIVATE Qt${QT_VERSION}::Multimedia PkgConfig::SOUND)
     target_sources(garglk PRIVATE sndqt.cpp)
-    target_compile_definitions(garglk PRIVATE GARGLK_TICK)
+    target_compile_definitions(garglk PRIVATE GARGLK_CONFIG_TICK)
     set(GARGLK_NEEDS_TICK TRUE CACHE INTERNAL "")
 elseif("${SOUND}" STREQUAL "SDL")
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(SDL2 REQUIRED IMPORTED_TARGET sdl2 SDL2_mixer)
     target_link_libraries(garglk PRIVATE PkgConfig::SDL2)
     target_sources(garglk PRIVATE sndsdl.cpp)
-    target_compile_definitions(garglk PRIVATE GARGLK_USESDL)
 else()
     target_sources(garglk PRIVATE sndnull.cpp)
 endif()
@@ -219,7 +218,7 @@ if(WITH_TTS)
         if(WITH_TTS STREQUAL "DYNAMIC")
             target_sources(garglk PRIVATE ttsspeechd.cpp)
             target_link_libraries(garglk PRIVATE ${CMAKE_DL_LIBS})
-            target_compile_definitions(garglk PRIVATE "GARGLK_DLOPEN_LIBSPEECHD")
+            target_compile_definitions(garglk PRIVATE "GARGLK_CONFIG_DLOPEN_LIBSPEECHD")
         elseif(SPEECH_DISPATCHER_FOUND)
             target_sources(garglk PRIVATE ttsspeechd.cpp)
             target_link_libraries(garglk PRIVATE PkgConfig::SPEECH_DISPATCHER)
@@ -285,7 +284,7 @@ elseif(UNIX)
         set(FONT_DIRECTORY "${CMAKE_INSTALL_BINDIR}")
     else()
         set(FONT_DIRECTORY "${CMAKE_INSTALL_DATADIR}/fonts/gargoyle")
-        target_compile_definitions(garglk PRIVATE "GARGLK_FONT_PATH=\"${CMAKE_INSTALL_FULL_DATADIR}/fonts/gargoyle\"")
+        target_compile_definitions(garglk PRIVATE "GARGLK_CONFIG_FONT_PATH=\"${CMAKE_INSTALL_FULL_DATADIR}/fonts/gargoyle\"")
     endif()
 
     install(FILES

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -270,8 +270,8 @@ static std::string font_path_fallback_system(const std::string &, const std::str
         return "";
 
     return std::string(directory) + "\\" + fallback;
-#elif defined(GARGLK_FONT_PATH)
-    return std::string(GARGLK_FONT_PATH) + "/" + fallback;
+#elif defined(GARGLK_CONFIG_FONT_PATH)
+    return std::string(GARGLK_CONFIG_FONT_PATH) + "/" + fallback;
 #else
     return "";
 #endif

--- a/garglk/event.cpp
+++ b/garglk/event.cpp
@@ -98,7 +98,7 @@ void glk_select_poll(event_t *event)
 
 void glk_tick()
 {
-#ifdef GARGLK_TICK
+#ifdef GARGLK_CONFIG_TICK
     gli_tick();
 #endif
 }

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -935,7 +935,7 @@ void gli_draw_picture(picture_t *pic, int x, int y, int x0, int y0, int x1, int 
 void gli_startup(int argc, char *argv[]);
 
 extern void gli_select(event_t *event, bool polled);
-#ifdef GARGLK_TICK
+#ifdef GARGLK_CONFIG_TICK
 extern void gli_tick();
 #endif
 

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -105,7 +105,7 @@ static QString winbrowsefile()
     // the dialog ridiculously wide (Qt probably should cut it off, but
     // it doesn't, so try to compensate here).
     QFileDialog::Options options(QFileDialog::HideNameFilterDetails);
-#ifdef GARGLK_NO_NATIVE_FILE_DIALOGS
+#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
     options |= QFileDialog::DontUseNativeDialog;
 #endif
     return QFileDialog::getOpenFileName(nullptr, AppName, "", filter_string, nullptr, options);
@@ -146,8 +146,8 @@ int main(int argc, char **argv)
     QString story;
 
     // Find the directory that contains the interpreters. By default
-    // this is GARGLK_INTERPRETER_DIR but if that is not set, it is the
-    // containing directory of the gargoyle executable.
+    // this is GARGLK_CONFIG_INTERPRETER_DIR but if that is not set, it
+    // is the containing directory of the gargoyle executable.
     //
     // For development purposes, the environment variable
     // $GARGLK_INTERPRETER_DIR can be set to the interpreter build
@@ -158,8 +158,8 @@ int main(int argc, char **argv)
     // interpreter is found.
     QString dir = std::getenv("GARGLK_INTERPRETER_DIR");
     if (dir.isNull())
-#ifdef GARGLK_INTERPRETER_DIR
-        dir = GARGLK_INTERPRETER_DIR;
+#ifdef GARGLK_CONFIG_INTERPRETER_DIR
+        dir = GARGLK_CONFIG_INTERPRETER_DIR;
 #else
         dir = QCoreApplication::applicationDirPath();
 #endif

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -50,12 +50,12 @@
 #include <QWidget>
 #include <QtGlobal>
 
-#if GARGLK_HAS_DBUS
+#if GARGLK_CONFIG_HAS_QDBUS
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QDBusReply>
 #endif
 
-#ifdef GARGLK_KDE
+#ifdef GARGLK_CONFIG_KDE
 #include <kio_version.h>
 
 #if KIO_VERSION >= ((5 << 16) | (69 << 8))
@@ -145,7 +145,7 @@ static std::string winchoosefile(const QString &prompt, FileFilter filter, Actio
 {
     QString filename;
     QFileDialog::Options options;
-#ifdef GARGLK_NO_NATIVE_FILE_DIALOGS
+#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
     options |= QFileDialog::DontUseNativeDialog;
 #endif
 
@@ -323,7 +323,7 @@ static void edit_config()
         QStringList args;
         args << "-t" << config.c_str();
         proc.startDetached("open", args);
-#elif defined(GARGLK_KDE)
+#elif defined(GARGLK_CONFIG_KDE)
         // If KDE is available, it provides a way to query the user's
         // preferred text editor, allowing an approximation of the Mac
         // behavior. Fall back to QDesktopServices::openUrl otherwise.
@@ -609,7 +609,7 @@ void winrepaint(int x0, int y0, int x1, int y1)
 
 bool windark()
 {
-#if GARGLK_HAS_DBUS
+#if GARGLK_CONFIG_HAS_QDBUS
     // https://flatpak.github.io/xdg-desktop-portal/
     QDBusInterface interface("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Settings");
     QDBusReply<QVariant> reply = interface.call("Read", "org.freedesktop.appearance", "color-scheme");

--- a/garglk/ttsspeechd.cpp
+++ b/garglk/ttsspeechd.cpp
@@ -29,7 +29,7 @@
 #include "glk.h"
 #include "garglk.h"
 
-#ifdef GARGLK_DLOPEN_LIBSPEECHD
+#ifdef GARGLK_CONFIG_DLOPEN_LIBSPEECHD
 
 #include <dlfcn.h>
 #include <iostream>
@@ -92,7 +92,7 @@ void gli_initialize_tts()
 {
     if (gli_conf_speak)
     {
-#ifdef GARGLK_DLOPEN_LIBSPEECHD
+#ifdef GARGLK_CONFIG_DLOPEN_LIBSPEECHD
         void *libspeechd = dlopen("libspeechd.so.2", RTLD_LAZY | RTLD_LOCAL);
 
         if (libspeechd == nullptr)


### PR DESCRIPTION
When looking through the source, it's helpful to be able to know the
purpose of a macro. By prefixing all macros which introduce conditional
functionality with GARGLK_CONFIG, it makes it obvious where they come
frim (i.e., the build system).