### PR TITLE
Don't set _XOPEN_SOURCE

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -78,14 +78,10 @@ else()
     target_sources(garglk PRIVATE sysqt.cpp)
 endif()
 
-target_compile_definitions(garglk PRIVATE $<$<COMPILE_LANGUAGE:C>:_XOPEN_SOURCE=600>)
-
 if(WITH_LAUNCHER)
     add_executable(gargoyle WIN32 launcher.cpp)
     target_include_directories(gargoyle PRIVATE cheapglk)
     target_link_libraries(gargoyle PRIVATE garglk)
-    target_compile_definitions(garglk PRIVATE $<$<COMPILE_LANGUAGE:C>:_XOPEN_SOURCE=600>)
-    c_standard(gargoyle 11)
     cxx_standard(gargoyle ${CXX_VERSION})
     warnings(gargoyle)
 

--- a/garglk/cheapglk/cgdate.cpp
+++ b/garglk/cheapglk/cgdate.cpp
@@ -46,10 +46,9 @@
 */
 #define NO_TIMEGM_AVAIL
 
-/* ... but due to the mess that is C/C++ dependencies, give it a
-   different name, in case a dependency forces the name to be exposed
-   anyway, even though Gargoyle specifically requests a POSIX
-   environment, without extensions.
+/* ... but due to the mess that is C++ and POSIX, give it a
+   different name, since Unix environments tend to expose everything to
+   C++, standard or otherwise, unconditionally.
  */
 #define timegm cg_timegm
 


### PR DESCRIPTION
Now that everything (more or less) is C++, _XOPEN_SOURCE is pretty
pointless, since it was set for C files anyway. There are a few C files
in cheapglk still, but those don't expect POSIX, so there's no point in
this.

The launcher is all C++ and I botched the change way back when anyway,
setting _XOPEN_SOURCE for garglk twice, instead of garglk and gargoyle.