### PR TITLE
Build Glulxe with link-time optimization

### DIFF
--- a/terps/CMakeLists.txt
+++ b/terps/CMakeLists.txt
@@ -208,7 +208,8 @@ if(WITH_GLULXE)
         glulxe/float.c
         MACROS ${GLULXE_MACROS}
         MATH
-        POSIX)
+        POSIX
+        LTO)
 endif()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This substantially speeds up at least some operations: benchmarking the
King of Shreds and Patches, from startup to the first prompt, the LTO
version is around 80% faster. It still pales in comparison to Git, but
for anybody using Glulxe, this is a big win.