### PR TITLE
Fix space removal at the end of lines

### DIFF
--- a/garglk/wintext.cpp
+++ b/garglk/wintext.cpp
@@ -366,8 +366,8 @@ void win_textbuffer_redraw(window_t *win)
         /* kill spaces at the end unless they're a different color*/
         Color color = gli_override_bg_set ? gli_window_color : win->bgcolor;
         while (i > 0 && linelen > 1 && ln.chars[linelen-1] == ' '
-            && dwin->styles[ln.attrs[linelen-1].style].bg == color
-            && !dwin->styles[ln.attrs[linelen-1].style].reverse)
+            && ln.attrs[linelen-1].bgcolor == color
+            && !ln.attrs[linelen-1].reverse)
                 linelen --;
 
         /* kill characters that would overwrite the scroll bar */
@@ -1038,8 +1038,8 @@ void win_textbuffer_putchar_uni(window_t *win, glui32 ch)
     /* kill spaces at the end for line width calculation */
     linelen = dwin->numchars;
     while (linelen > 1 && dwin->chars[linelen-1] == ' '
-        && dwin->styles[dwin->attrs[linelen-1].style].bg == color
-        && !dwin->styles[dwin->attrs[linelen-1].style].reverse)
+        && dwin->attrs[linelen-1].bgcolor == color
+        && !dwin->attrs[linelen-1].reverse)
         linelen --;
 
     if (calcwidth(dwin, dwin->chars, dwin->attrs, 0, linelen, -1) >= pw)


### PR DESCRIPTION
This was "broken" by the C++ conversion, although the original code was
broken, too.

The idea here is to remove trailing spaces if the background color of
the space is the same as the window background, as long as it doesn't
have reverse video turned on. A space colored this way is
indistinguishable from the background.

The original code did a check of the character background against the
window background, but these values were pointers that would never be
equal. Gargoyle thus thought the colors differed, so didn't kill spaces
at all. No space removal was done. This worked fine, since it's actually
the "correct" behavior: if a game prints spaces, it shouldn't be wrong
to print them. But it's not the intended Gargoyle behavior. You just
couldn't really tell unless you happened to select text in a game that
happened to have trailing whitespace.

The C++ code switched from using pointers for colors to using instances
of the class Color, which implements operator==, allowing colors to
properly be compared. This now killed off _all_ spaces, though not
directly because of the proper comparison. No, now the comparison fell
through to the next check, which was the reverse check (this was never
hit earlier because the window color check always failed). The test
against reverse video was checking whether the _style_ was reversed, not
whether the actual character itself. So if you're in style_Normal,
odds are you haven't got it set to be reversed, but the _character_ will
be reversed if you use garglk_set_reversevideo(). Thus _this_ test
passes (normal text isn't reversed!) and all spaces are killed.

It turns out the color of the style was being checked as well, which
isn't right either. So all tests now test what they think they're
testing, and the puzzle pieces in Jigsaw are visible again.