### PR TITLE
Check more than style_Preformatted for monospace

### DIFF
--- a/garglk/wintext.cpp
+++ b/garglk/wintext.cpp
@@ -970,7 +970,13 @@ void win_textbuffer_putchar_uni(window_t *win, glui32 ch)
         }
     }
 
-    if (gli_conf_dashes && win->attr.style != style_Preformatted)
+    // This tracks whether the font "should" be monospace, not whether
+    // the font file itself is actually monospace: if the font is monor,
+    // monob, monoi, or monoz, then this will be true, regardless of
+    // what font the user actually set as the monospace font.
+    bool monospace = gli_tstyles[win->attr.style].font.monospace;
+
+    if (gli_conf_dashes && !monospace)
     {
         if (ch == '-')
         {
@@ -994,7 +1000,7 @@ void win_textbuffer_putchar_uni(window_t *win, glui32 ch)
             dwin->dashed = 0;
     }
 
-    if (gli_conf_spaces && win->attr.style != style_Preformatted
+    if (gli_conf_spaces && !monospace
         && dwin->styles[win->attr.style].bg == color
         && !dwin->styles[win->attr.style].reverse)
     {


### PR DESCRIPTION
The Agility interpreter uses styles User1 and User2 for monospace, but
Gargoyle only considered style_Preformatted, meaning that Gargoyle
assumed user styles were _not_ monospace, and translated hyphens into
em- and en-dashes.

Since Gargoyle knows which font type a style maps to, use that
information instead of checking the style directly. This will work if
interpreters use User styles, or if they change the appearance of other
styles via hints.

As noted in the comment, this assumes the user has properly set a
monospace font. If a proportional font is set as the monospace font,
Gargoyle will still assume it's monospace, because it's "supposed" to
be. This is at odds with how ligatures are done: there, the font file
itself is examined and if it's monospace, ligatures are disabled.

I think these differing approaches make sense: Here, with dashes, if a
user sets a proportional font as the monospace font, it hardly matters
whether the hyphens become em- and en-dashes, given that the width of
the glyphs is variable anyway (i.e. box drawing is hopelessly broken if
you set a proportional font, so changing hyphens is a drop in the
bucket). And if a monospace font is set as the proportional font, yes,
it'll get em- and en-dashes, but that's fine, since the width of the
characters, at that point, can't be expected to be fixed, given that it
_could_ be a proportional font. It will be a slightly degraded
experience since it won't be obvious it's a longer dash, but then, if
you're setting a monospace font everywhere, you can turn off dash
conversions.

As for ligatures, if the user sets a monospace font for the proportional
font (which is perfectly fine), the ligatures would look pretty silly,
especially the three-character ones. For example:

    Oﬀice
    Ofﬁce
    Oﬃce
    Ofﬂine
    Oﬄine