### PR TITLE
Ensure function declarations are prototypes

### DIFF
--- a/terps/advsys/advprs.c
+++ b/terps/advsys/advprs.c
@@ -16,7 +16,7 @@ static int actor,action,dobject,ndobjects,iobject;
 static int flag;
 
 /* external routines */
-extern char *trm_get();
+extern char *trm_get(char *line);
 
 /* external variables */
 extern char line[];	/* line buffer */

--- a/terps/advsys/advtrm.c
+++ b/terps/advsys/advtrm.c
@@ -24,7 +24,7 @@ static char word[WORDMAX+1],*wptr;
 static FILE *logfp = NULL;
 
 /* forward declarations */
-char *trm_line();
+char *trm_line(char *line);
 
 /* trm_init - initialize the terminal module */
 void trm_init(int rows, int cols, char *name)

--- a/terps/alan2/args.h
+++ b/terps/alan2/args.h
@@ -29,6 +29,13 @@ extern BPTR cd;
 #define PROGNAME "alan2"
 #endif
 
+// _PROTOTYPES_ (which is a reserved identifier, but oh well) is defined in
+// sysdep.h, so theoretically that file should be included here; but that
+// causes, eventually, a conflicting definition of printf, as Alan defines
+// printf as a macro to a function that's _not_ compatible with the actual
+// printf(). Instead of fixing that, just define _PROTOTYPES_ here.
+#define _PROTOTYPES_
+
 #ifdef _PROTOTYPES_
 extern void args(int argc, char *argv[]);
 #else


### PR DESCRIPTION
Clang 15 introduces a warning regarding non-prototype declarations (i.e. those with empty parentheses) in advance of C2X finally ditching K&R declarations. There are a few interpreters which still have K&R declarations, so fix those. These are still built with C11, so K&R declarations are valid, if awful, but it's still good practice to use proper prototypes.

JACL still has a _lot_ of K&R declarations, but I'm not changing those because upstream already has this fixed, so next upstream update will fix these issues.