### PR TITLE
Avoid passing around exedir

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -134,12 +134,13 @@ std::string winsavefile(const char *prompt, FileFilter filter);
 void winabort(const std::string &msg);
 std::string downcase(const std::string &string);
 void fontreplace(const std::string &font, FontType type);
-std::vector<ConfigFile> configs(const std::string &exedir, const std::string &gamepath);
+std::vector<ConfigFile> configs(const std::string &gamepath);
 void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, std::function<void(const std::string &cmd, const std::string &arg)> callback);
 std::string user_config();
 void set_lcdfilter(const std::string &filter);
 std::string winfontpath(const std::string &filename);
 std::vector<std::string> winappdata();
+std::string winappdir();
 
 namespace theme {
 void init();

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -114,9 +114,9 @@ static QString winbrowsefile()
     return QFileDialog::getOpenFileName(nullptr, AppName, "", filter_string, nullptr, options);
 }
 
-int garglk::winterp(const std::string &path, const std::string &exe, const std::string &flags, const std::string &game)
+int garglk::winterp(const std::string &interpreter_dir, const std::string &exe, const std::string &flags, const std::string &game)
 {
-    QString argv0 = QDir(path.c_str()).absoluteFilePath(exe.c_str());
+    QString argv0 = QDir(interpreter_dir.c_str()).absoluteFilePath(exe.c_str());
 
     QStringList args;
 
@@ -177,7 +177,7 @@ static QString parse_args(const QApplication &app)
     if (parser.isSet("p"))
     {
         std::cout << "Configuration file paths:\n\n";
-        for (const auto &path : garglk::configs("", ""))
+        for (const auto &path : garglk::configs(""))
             std::cout << path.path << std::endl;
 
         std::cout << "\nTheme paths:\n\n";
@@ -221,12 +221,12 @@ int main(int argc, char **argv)
     // of failing if there are no interpreters installed). If this is
     // set, the standard directory will *not* be used at all, even if no
     // interpreter is found.
-    QString dir = std::getenv("GARGLK_INTERPRETER_DIR");
-    if (dir.isNull())
+    QString interpreter_dir = std::getenv("GARGLK_INTERPRETER_DIR");
+    if (interpreter_dir.isNull())
 #ifdef GARGLK_CONFIG_INTERPRETER_DIR
-        dir = GARGLK_CONFIG_INTERPRETER_DIR;
+        interpreter_dir = GARGLK_CONFIG_INTERPRETER_DIR;
 #else
-        dir = QCoreApplication::applicationDirPath();
+        interpreter_dir = QCoreApplication::applicationDirPath();
 #endif
 
     auto story = parse_args(app);
@@ -238,5 +238,5 @@ int main(int argc, char **argv)
         return 1;
 
     /* run story file */
-    return garglk::rungame(dir.toStdString(), story.toStdString());
+    return garglk::rungame(interpreter_dir.toStdString(), story.toStdString());
 }

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -790,6 +790,12 @@ std::vector<std::string> garglk::winappdata()
     return paths;
 }
 
+std::string garglk::winappdir()
+{
+    // This is only used on Windows.
+    return "";
+}
+
 void gli_select(event_t *event, bool polled)
 {
     NSAutoreleasePool * pool = [[NSAutoreleasePool alloc] init];

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -669,6 +669,11 @@ std::vector<std::string> garglk::winappdata()
     return paths;
 }
 
+std::string garglk::winappdir()
+{
+    return QCoreApplication::applicationDirPath().toStdString();
+}
+
 void gli_tick()
 {
     if (last_tick.elapsed() > TICK_PERIOD_MILLIS)


### PR DESCRIPTION
exedir was/is used to find garglk.ini on Windows. Due to historical reasons, garglk.ini from the install directory (e.g. C:\Program Files\Gargoyle) exists as a user config file. Modern Gargoyle releases use a more appropriate location, but this is still loaded for backward compatibility.

Till now, all platforms were calculating exedir, the location of the Gargoyle main binary, and passing it around, though it is only _used_ when building for Windows.

This change removes that passing around, instead calling for the exedir only where it's required. This pushes the "find application dir" logic to the sys* files. It's implemented on Mac even though it doesn't need to be (since it won't ever be called there), just for completeness.

At the same time, rename the entirely-without-information variable "path" to "interpreter_dir". There was a conflation of the interpreter dir and the binary dir, because all platforms need the interpreter dir, to actually find the interpreters, and Windows was kind of abusing this by "knowing" that this was also the executable path, as well. On Unix platforms, for example, these two are generally different (e.g. /usr/bin and /usr/libexec/gargoyle), so exedir was actually getting passed the interpreter dir, but in the end it's not _used_ on Unix, so it didn't matter. But it's confusing, so hopefully this makes things a bit more clear.