### PR TITLE
Add consistency in display of paths

### DIFF
--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -180,17 +180,27 @@ static QString parse_args(const QApplication &app)
         std::exit(0);
     }
 
+    // Convert to native separators and return absolute path.
+    auto canonicalize = [](const std::string &path) {
+        auto qpath = QString::fromStdString(path);
+        qpath = QDir(qpath).absolutePath();
+        return QDir::toNativeSeparators(qpath).toStdString();
+    };
+
     if (parser.isSet("p")) {
         std::cout << "Configuration file paths:\n\n";
-        for (const auto &path : garglk::configs(gamefile.toStdString())) {
-            std::cout << path.path << " " << path.format_type() << std::endl;
+        for (const auto &config : garglk::configs(gamefile.toStdString())) {
+            auto path = canonicalize(config.path);
+            auto type = QString::fromStdString(config.format_type());
+
+            std::cout << path << " " << type.toStdString() << std::endl;
         }
 
         std::cout << "\nTheme paths:\n\n";
         auto theme_paths = garglk::theme::paths();
         std::reverse(theme_paths.begin(), theme_paths.end());
         for (const auto &path : theme_paths) {
-            std::cout << path << std::endl;
+            std::cout << canonicalize(path) << std::endl;
         }
 
         std::exit(0);

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -349,10 +349,17 @@ void gli_edit_config()
 
 static void show_paths()
 {
+    // Convert to native separators and return absolute path.
+    auto canonicalize = [](const std::string &path) {
+        auto qpath = QString::fromStdString(path);
+        qpath = QDir(qpath).absolutePath();
+        return QDir::toNativeSeparators(qpath);
+    };
+
     QString text("<p>Configuration file paths:</p><pre>");
 
     for (const auto &config : garglk::all_configs) {
-        auto path = QDir::toNativeSeparators(QString::fromStdString(config.path));
+        auto path = canonicalize(config.path);
         auto type = QString::fromStdString(config.format_type());
 
         text += path + " " + type + "\n";
@@ -362,7 +369,7 @@ static void show_paths()
     auto theme_paths = garglk::theme::paths();
     std::reverse(theme_paths.begin(), theme_paths.end());
     for (const auto &path : theme_paths) {
-        text += QDir::toNativeSeparators(QString::fromStdString(path)) + "\n";
+        text += canonicalize(path) + "\n";
     }
     text += "</pre>";
 


### PR DESCRIPTION
Now all paths are given as absolute paths with native separators. Unfortunately there is duplication across launchqt and sysqt; eventually there may need to be a "qt utility" library or something; or, probably more likely, when the Cocoa interface is finally removed, Qt functionality will just be available everywhere, without needing to fence it off.