### PR TITLE
Have default themes (dark/light) be files, not hard-coded C++ structures

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -36,6 +36,22 @@ vtk_encode_string(
 
 set_property(SOURCE config.cpp launchqt.cpp PROPERTY COMPILE_DEFINITIONS GARGLKINI_H="${GARGLKINI_H}")
 
+vtk_encode_string(
+    INPUT ../themes/dark.json
+    NAME theme_dark
+    HEADER_OUTPUT THEME_DARK_H
+    SOURCE_OUTPUT THEME_DARK_CXX
+)
+
+vtk_encode_string(
+    INPUT ../themes/light.json
+    NAME theme_light
+    HEADER_OUTPUT THEME_LIGHT_H
+    SOURCE_OUTPUT THEME_LIGHT_CXX
+)
+
+set_property(SOURCE theme.cpp PROPERTY COMPILE_DEFINITIONS THEME_DARK_H="${THEME_DARK_H}" THEME_LIGHT_H="${THEME_LIGHT_H}")
+
 if(INTERFACE STREQUAL "QT")
     set(CMAKE_AUTOMOC ON)
     set_property(SOURCE garglkini.cxx PROPERTY SKIP_AUTOMOC ON)
@@ -48,7 +64,7 @@ endif()
 add_library(garglk babeldata.cpp style.cpp config.cpp draw.cpp event.cpp
     garglk.cpp imgload.cpp imgscale.cpp theme.cpp winblank.cpp window.cpp
     wingfx.cpp wingrid.cpp winmask.cpp winpair.cpp wintext.cpp zbleep.cpp
-    ${GARGLKINI_CXX}
+    ${GARGLKINI_CXX} ${THEME_DARK_CXX} ${THEME_LIGHT_CXX}
 
     # These can't be a library in cheapglk/ because they contain
     # references to code in garglk, and garglk contains references to
@@ -310,6 +326,8 @@ elseif(UNIX)
         "${PROJECT_SOURCE_DIR}/themes/Lectrote Slate.json"
         "${PROJECT_SOURCE_DIR}/themes/Pencil.json"
         "${PROJECT_SOURCE_DIR}/themes/Zoom.json"
+        "${PROJECT_SOURCE_DIR}/themes/dark.json"
+        "${PROJECT_SOURCE_DIR}/themes/light.json"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/io.github.garglk/Gargoyle/themes")
 
 endif()

--- a/gargoyle-buildrpm.sh
+++ b/gargoyle-buildrpm.sh
@@ -106,6 +106,8 @@ cp -v garglk.ini "%{buildroot}%{_sysconfdir}/"
 "%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Slate.json"
 %{_datarootdir}/io.github.garglk/Gargoyle/themes/Pencil.json
 %{_datarootdir}/io.github.garglk/Gargoyle/themes/Zoom.json
+%{_datarootdir}/io.github.garglk/Gargoyle/themes/dark.json
+%{_datarootdir}/io.github.garglk/Gargoyle/themes/light.json
 %{_datarootdir}/icons/io.github.garglk.Gargoyle.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-adrift.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-advsys.png

--- a/themes/dark.json
+++ b/themes/dark.json
@@ -1,0 +1,14 @@
+{
+    "name": "dark",
+    "window": "#31363b",
+    "border": "#000000",
+    "caret": "#e7e8e9",
+    "link": "#1d99f3",
+    "more": "#00cc00",
+    "text_buffer": {
+        "default": {"fg": "#e7e8e9", "bg": "#31363b"}
+    },
+    "text_grid": {
+        "default": {"fg": "#e7e8e9", "bg": "#31363b"}
+    }
+}

--- a/themes/light.json
+++ b/themes/light.json
@@ -1,0 +1,14 @@
+{
+    "name": "light",
+    "window": "#ffffff",
+    "border": "#000000",
+    "caret": "#000000",
+    "link": "#000060",
+    "more": "#006000",
+    "text_buffer": {
+        "default": {"fg": "#000000", "bg": "#ffffff"}
+    },
+    "text_grid": {
+        "default": {"fg": "#000000", "bg": "#ffffff"}
+    }
+}


### PR DESCRIPTION
This has a big advantage: modifying the system themes (in the source code) is a lot easier. These are still built in to the Gargoyle binary, so that Gargoyle will continue to work regardless of whether the theme files exist, but they are built in based on the JSON files. They're also installed, now, so that users have a template to work from if they just want to tweak the dark/light themes.

One disadvantage: invalid dark/light themes will not be caught at compile-time, as they have to be parsed as JSON. This is probably fine, given that we control the contents of these files.