### PR TITLE
SCOTT, PLUS, TAYLOR: Don't use variable length arrays

### DIFF
--- a/terps/plus/plusmain.c
+++ b/terps/plus/plusmain.c
@@ -428,7 +428,9 @@ static void FlushRoomDescription(char *buf,  int transcript)
         int line = 0;
         int index = 0;
         int i;
-        char string[TopWidth + 1];
+        if (TopWidth > 2046)
+            TopWidth = 2046;
+        char string[2048];
         for (line = 0; line < rows && index < length; line++) {
             for (i = 0; i < TopWidth; i++) {
                 string[i] = text_with_breaks[index++];

--- a/terps/scott/ai_uk/c64decrunch.c
+++ b/terps/scott/ai_uk/c64decrunch.c
@@ -465,7 +465,9 @@ void LoadC64USImages(uint8_t *data, size_t length) {
         unsigned char rawname[1024];
         if (filenames) {
             int imgindex = 0;
-            char *imagefiles[numfiles];
+            if (numfiles > 1024)
+                numfiles = 1024;
+            char *imagefiles[1024];
             for (int i = 0; i < numfiles; i++) {
                 if (issagaimg(filenames[i])) {
                     imagefiles[imgindex++] = filenames[i];
@@ -550,7 +552,7 @@ GameIDType DetectC64(uint8_t **sf, size_t *extent)
                 if (buflen <= 0 || buflen > MAX_LENGTH)
                     return 0;
 
-                uint8_t megabuf[buflen];
+                uint8_t *megabuf = MemAlloc(buflen);
                 memcpy(megabuf, largest_file, newlength);
                 if (appendix != NULL) {
                     memcpy(megabuf + newlength + c64_registry[i].parameter, appendix + 2,
@@ -564,6 +566,7 @@ GameIDType DetectC64(uint8_t **sf, size_t *extent)
                     memcpy(*sf, megabuf, newlength);
                     *extent = newlength;
                 }
+                free(megabuf);
 
             } else if (c64_registry[i].type == TYPE_T64) {
                 uint8_t *file_records = *sf + 64;

--- a/terps/scott/detectgame.c
+++ b/terps/scott/detectgame.c
@@ -120,7 +120,9 @@ int SanityCheckHeader(void)
 uint8_t *ReadDictionary(struct GameInfo info, uint8_t **pointer, int loud)
 {
     uint8_t *ptr = *pointer;
-    char dictword[info.word_length + 2];
+    if (info.word_length + 2 > 1024)
+        Fatal("Bad word length");
+    char dictword[1024];
     char c = 0;
     int wordnum = 0;
     int charindex = 0;

--- a/terps/scott/parser.c
+++ b/terps/scott/parser.c
@@ -925,7 +925,9 @@ static struct Command *CommandFromStrings(int index, struct Command *previous)
 static int CreateAllCommands(struct Command *command)
 {
 
-    int exceptions[GameHeader.NumItems];
+    if (GameHeader.NumItems > 2048)
+        Fatal("Bad number of items");
+    int exceptions[2048];
     int exceptioncount = 0;
 
     int location = CARRIED;

--- a/terps/scott/saga/apple2detect.c
+++ b/terps/scott/saga/apple2detect.c
@@ -849,7 +849,7 @@ uint8_t *ReadA2DiskImageFile(const char *filename, size_t *filesize, int *isnib)
 
 uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize, int *isnib) {
 
-    char sideB[stringlen + 9];
+    char *sideB = MemAlloc(stringlen + 9);
     uint8_t *result = NULL;
 
     *isnib = 0;
@@ -895,8 +895,10 @@ uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t st
             size_t ppos = stringlen - 1;
             while(sideB[ppos] != '.' && ppos > 0)
                 ppos--;
-            if (ppos < 1)
+            if (ppos < 1) {
+                free(sideB);
                 return NULL;
+            }
             // Then we copy the extension to the new end position
             for (size_t i = ppos; i <= stringlen; i++) {
                 sideB[i + 7] = sideB[i];
@@ -912,7 +914,7 @@ uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t st
             result = ReadA2DiskImageFile(sideB, filesize, isnib);
         }
     }
-
+    free(sideB);
     return result;
 }
 

--- a/terps/scott/saga/atari8detect.c
+++ b/terps/scott/saga/atari8detect.c
@@ -423,7 +423,7 @@ static int StripBrackets(char sideB[], size_t length) {
 
 static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize) {
 
-    char sideB[stringlen + 10];
+    char *sideB = MemAlloc(stringlen + 10);
     uint8_t *result = NULL;
 
     memcpy(sideB, game_file, stringlen + 1);
@@ -467,8 +467,10 @@ static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type
             size_t ppos = stringlen - 1;
             while(sideB[ppos] != '.' && ppos > 0)
                 ppos--;
-            if (ppos < 1)
+            if (ppos < 1) {
+                free(sideB);
                 return NULL;
+            }
             // Then we copy the extension to the new end position
             for (size_t i = ppos; i <= stringlen; i++) {
                 sideB[i + 8] = sideB[i];
@@ -485,7 +487,7 @@ static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type
             result = ReadFileIfExists(sideB, filesize);
         }
     }
-
+    free(sideB);
     return result;
 }
 

--- a/terps/scott/scott.c
+++ b/terps/scott/scott.c
@@ -272,7 +272,9 @@ static void FlushRoomDescription(char *buf)
         int line = 0;
         int index = 0;
         int i;
-        char string[TopWidth + 1];
+        char string[2048];
+        if (TopWidth > 2046)
+            TopWidth = 2046;
         for (line = 0; line < rows && index < length; line++) {
             for (i = 0; i < TopWidth; i++) {
                 string[i] = text_with_breaks[index++];

--- a/terps/scott/ti994a/load_ti99_4a.c
+++ b/terps/scott/ti994a/load_ti99_4a.c
@@ -530,7 +530,9 @@ static int TryLoadingTI994A(struct DATAHEADER dh, int loud)
     ct = 0;
     ip = Items;
 
-    int objectlinks[ni + 1];
+    if (ni >= 1024)
+        Fatal("Bad number of items");
+    int objectlinks[1024];
 
     if (SeekIfNeeded(FixAddress(FixWord(dh.p_obj_link)), &offset, &ptr) == 0)
         return 0;

--- a/terps/taylor/ui.c
+++ b/terps/taylor/ui.c
@@ -222,7 +222,9 @@ static void FlushRoomDescription(void)
     int index = 0;
     int i;
     int empty_lines = 0;
-    char string[TopWidth + 1];
+    char string[2048];
+    if (TopWidth > 2046)
+        TopWidth = 2046;
     for (line = 0; line < rows && index < length; line++) {
         for (i = 0; i < TopWidth; i++) {
             string[i] = text_with_breaks[index++];


### PR DESCRIPTION
See discussion in #715.

Also replaced some raw uses of `malloc()` with the guarded version `MemAlloc()`.