### PR TITLE
SCOTT: Clean up enum GameIDType usage

### DIFF
--- a/terps/scott/ai_uk/c64decrunch.c
+++ b/terps/scott/ai_uk/c64decrunch.c
@@ -233,7 +233,7 @@ int save_island_appendix_1_length = 0;
 uint8_t *save_island_appendix_2 = NULL;
 int save_island_appendix_2_length = 0;
 
-static int savage_island_menu(uint8_t **sf, size_t *extent, int recindex)
+static GameIDType savage_island_menu(uint8_t **sf, size_t *extent, int recindex)
 {
     Output("This disk image contains two games. Select one.\n\n1. Savage Island "
            "part I\n2. Savage Island part II");
@@ -283,7 +283,7 @@ static int savage_island_menu(uint8_t **sf, size_t *extent, int recindex)
         return DecrunchC64(sf, extent, rec);
     } else {
         fprintf(stderr, "SCOTT: DetectC64() Failed loading file %s\n", rec.appendfile);
-        return 0;
+        return UNKNOWN_GAME;
     }
 }
 
@@ -309,7 +309,7 @@ static void appendSIfiles(uint8_t **sf, size_t *extent)
     memcpy(*sf, megabuf, *extent);
 }
 
-static int mysterious_menu(uint8_t **sf, size_t *extent, int recindex)
+static GameIDType mysterious_menu(uint8_t **sf, size_t *extent, int recindex)
 {
     recindex = 0;
 
@@ -368,11 +368,11 @@ static int mysterious_menu(uint8_t **sf, size_t *extent, int recindex)
         return DecrunchC64(sf, extent, rec);
     } else {
         fprintf(stderr, "SCOTT: DetectC64() Failed loading file %s\n", filename);
-        return 0;
+        return UNKNOWN_GAME;
     }
 }
 
-static int mysterious_menu2(uint8_t **sf, size_t *extent, int recindex)
+static GameIDType mysterious_menu2(uint8_t **sf, size_t *extent, int recindex)
 {
     recindex = 6;
 
@@ -428,7 +428,7 @@ static int mysterious_menu2(uint8_t **sf, size_t *extent, int recindex)
         return DecrunchC64(sf, extent, rec);
     } else {
         fprintf(stderr, "Failed loading file %s\n", filename);
-        return 0;
+        return UNKNOWN_GAME;
     }
 }
 
@@ -460,7 +460,6 @@ void LoadC64USImages(uint8_t *data, size_t length) {
 
     DiskImage *d64 = di_create_from_data(data, length);
     if (d64) {
-
         char **filenames = get_all_file_names(d64, &numfiles);
         unsigned char rawname[1024];
         if (filenames) {
@@ -479,9 +478,7 @@ void LoadC64USImages(uint8_t *data, size_t length) {
 
             if (imgindex) {
                 USImages = new_image();
-
                 struct USImage *image = USImages;
-
                 for (int i = 0; i < imgindex; i++) {
                     const char *shortname = imagefiles[i];
                     di_rawname_from_name(rawname, shortname);
@@ -512,7 +509,6 @@ void LoadC64USImages(uint8_t *data, size_t length) {
                     free(USImages);
                     USImages = NULL;
                 }
-
             }
         }
     }
@@ -590,7 +586,7 @@ GameIDType DetectC64(uint8_t **sf, size_t *extent)
                 uint8_t *database_file = get_file_named(*sf, *extent, &newlength, c64_registry[i].appendfile);
                 if (database_file == NULL) {
                     fprintf(stderr, "SCOTT: DetectC64() Could not find database in D64\n");
-                    return 0;
+                    return UNKNOWN_GAME;
                 }
 
                 if (c64_registry[i].decompress_iterations) {
@@ -626,7 +622,7 @@ GameIDType DetectC64(uint8_t **sf, size_t *extent)
             return DecrunchC64(sf, extent, c64_registry[i]);
         }
     }
-    return 0;
+    return UNKNOWN_GAME;
 }
 
 int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
@@ -684,7 +680,7 @@ static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record
 
     if (record.type == TYPE_US) {
         *extent = length;
-        return 1;
+        return record.id;
     }
 
     for (int i = 0; games[i].Title != NULL; i++) {

--- a/terps/scott/detectgame.c
+++ b/terps/scott/detectgame.c
@@ -1320,7 +1320,7 @@ GameIDType DetectGame(const char *file_name)
     if (file_length > MAX_GAMEFILE_SIZE) {
         debug_print("File too large to be a vaild game file (%zu bytes, max is %d)\n",
             file_length, MAX_GAMEFILE_SIZE);
-        return 0;
+        return UNKNOWN_GAME;
     }
 
     Game = (struct GameInfo *)MemAlloc(sizeof(struct GameInfo));
@@ -1329,7 +1329,7 @@ GameIDType DetectGame(const char *file_name)
     // Check if the original ScottFree LoadDatabase() function can read the file.
     GameIDType detectedGame = LoadDatabase(f, Options & DEBUGGING);
 
-    if (!detectedGame) { /* Not a ScottFree game, check if TI99/4A */
+    if (detectedGame == UNKNOWN_GAME) { /* Not a ScottFree game, check if TI99/4A */
         entire_file = MemAlloc(file_length);
         fseek(f, 0, SEEK_SET);
         size_t result = fread(entire_file, 1, file_length, f);
@@ -1339,27 +1339,23 @@ GameIDType DetectGame(const char *file_name)
 
         detectedGame = DetectTI994A();
 
-        if (!detectedGame) /* Not a TI99/4A game, check if C64 */
+        if (detectedGame == UNKNOWN_GAME) /* Not a TI99/4A game, check if C64 */
             detectedGame = DetectC64(&entire_file, &file_length);
 
-        if (!detectedGame) { /* Not a C64 game, check if Atari */
-            result = DetectAtari8(&entire_file, &file_length);
-            if (result)
-                detectedGame = CurrentGame;
+        if (detectedGame == UNKNOWN_GAME) { /* Not a C64 game, check if Atari */
+            detectedGame = DetectAtari8(&entire_file, &file_length);
         }
 
-        if (!detectedGame) { /* Not an Atari game, check if Apple 2 */
-            result = DetectApple2(&entire_file, &file_length);
-            if (result)
-                detectedGame = CurrentGame;
+        if (detectedGame == UNKNOWN_GAME) { /* Not an Atari game, check if Apple 2 */
+            detectedGame = DetectApple2(&entire_file, &file_length);
         }
 
-        if (!detectedGame) { /* Not an Apple 2 game, check if ZX Spectrum */
+        if (detectedGame == UNKNOWN_GAME) { /* Not an Apple 2 game, check if ZX Spectrum */
             detectedGame = DetectZXSpectrum();
         }
 
-        if (Game == NULL)
-            return 0;
+        if (detectedGame == UNKNOWN_GAME)
+            return UNKNOWN_GAME;
     }
 
     if (detectedGame == HULK_US) {

--- a/terps/scott/saga/apple2detect.c
+++ b/terps/scott/saga/apple2detect.c
@@ -670,10 +670,10 @@ static const imglist a2listVoodoo[] = {
 static uint8_t *GetApple2CompanionFile(size_t *size, int *isnib);
 static int ExtractImagesFromApple2CompanionFile(uint8_t *data, size_t datasize, int isnib);
 
-int DetectApple2(uint8_t **sf, size_t *extent)
+GameIDType DetectApple2(uint8_t **sf, size_t *extent)
 {
     if (*extent > MAX_LENGTH || *extent < kDiskImageSize)
-        return 0;
+        return UNKNOWN_GAME;
 
     if ((*sf)[0] == 'W' && (*sf)[1] == 'O' && (*sf)[2] == 'Z') {
         uint8_t *result = woz2nib(*sf, extent);
@@ -731,7 +731,6 @@ int DetectApple2(uint8_t **sf, size_t *extent)
     uint8_t *database = NULL;
     size_t newlength = 0;
 
-
     if (datafile) {
         size_t data_start = 0x135;
 
@@ -746,20 +745,20 @@ int DetectApple2(uint8_t **sf, size_t *extent)
         memcpy(database, datafile + data_start, newlength);
     } else {
         debug_print("Failed loading database\n");
-        return 0;
+        return UNKNOWN_GAME;
     }
 
     if (database) {
-        int result = LoadBinaryDatabase(database, newlength, *Game, 0);
-        if (!result && newlength > 0x3d00) {
+        GameIDType result = LoadBinaryDatabase(database, newlength, *Game, 0);
+        if (result == UNKNOWN_GAME && newlength > 0x3d00) {
             result = LoadBinaryDatabase(database + 0x3d00, newlength - 0x3d00, *Game, 0);
         }
 
-        if (!result && newlength > 0x3803) {
+        if (result == UNKNOWN_GAME && newlength > 0x3803) {
             result = LoadBinaryDatabase(database + 0x3803, newlength - 0x3803, *Game, 0);
         }
 
-        if (result) {
+        if (result != UNKNOWN_GAME) {
             CurrentSys = SYS_APPLE2;
 
             ImageWidth = 280;
@@ -791,7 +790,7 @@ int DetectApple2(uint8_t **sf, size_t *extent)
     } else {
         free (datafile);
         debug_print("Failed loading database\n");
-        return 0;
+        return UNKNOWN_GAME;
     }
 }
 

--- a/terps/scott/saga/apple2detect.h
+++ b/terps/scott/saga/apple2detect.h
@@ -10,6 +10,8 @@
 
 #include <stdio.h>
 
-int DetectApple2(uint8_t **sf, size_t *extent);
+#include "scottdefines.h"
+
+GameIDType DetectApple2(uint8_t **sf, size_t *extent);
 
 #endif /* apple2detect_h */

--- a/terps/scott/saga/atari8detect.h
+++ b/terps/scott/saga/atari8detect.h
@@ -9,5 +9,9 @@
 #define detectatari8_h
 
 #include <stdio.h>
-int DetectAtari8(uint8_t **sf, size_t *extent);
+
+#include "scottdefines.h"
+
+GameIDType DetectAtari8(uint8_t **sf, size_t *extent);
+
 #endif /* atari8detect_h */

--- a/terps/scott/saga/saga.c
+++ b/terps/scott/saga/saga.c
@@ -298,7 +298,7 @@ uint8_t *Skip(uint8_t *ptr, int count, uint8_t *eof) {
     return  ptr + count;
 }
 
-int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int dict_start)
+GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int dict_start)
 {
     int ni, na, nw, nr, mc, pr, tr, wl, lt, mn, trm;
     int ct;
@@ -350,7 +350,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
     }
 
     if (ptr == NULL)
-        return 0;
+        return UNKNOWN_GAME;
 
     ptr = ReadHeader(ptr);
 
@@ -360,7 +360,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
     PrintHeaderInfo(header, ni, na, nw, nr, mc, pr, tr, wl, lt, mn, trm);
 
     if (!SanityCheckScottFreeHeader(ni, na, nw, nr, mc))
-        return 0;
+        return UNKNOWN_GAME;
 
     GameHeader.NumItems = ni;
     Items = (Item *)MemAlloc(sizeof(Item) * (ni + 1));
@@ -385,7 +385,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
     if (dict_start) {
         if (header[0] != info.word_length || header[1] != info.number_of_words || header[2] != info.number_of_actions || header[3] != info.number_of_items || header[4] != info.number_of_messages || header[5] != info.number_of_rooms || header[6] != info.max_carried) {
             //    debug_print("Non-matching header\n");
-            return 0;
+            return UNKNOWN_GAME;
         }
     }
 
@@ -395,7 +395,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
         ptr++;
 
     if (ptr - data >= length - 2)
-        return 0;
+        return UNKNOWN_GAME;
 
     ptr = ReadUSDictionary(ptr);
 
@@ -559,7 +559,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
     // Return if not reading UK Hulk
     if (!dict_start) {
         ptr = Skip(ptr, 0xe4, data + length);
-        return 1;
+        return CurrentGame;
     }
 
 #pragma mark room images
@@ -579,7 +579,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
 #pragma mark item images
 
     if (SeekIfNeeded(info.start_of_item_image_list, &offset, &ptr) == 0)
-        return 0;
+        return UNKNOWN_GAME;
 
     ip = Items;
 
@@ -604,7 +604,7 @@ int LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info, int d
         hulk_image_offset = -0x7ff;
     }
 
-    return 1;
+    return CurrentGame;
 }
 
 

--- a/terps/scott/scott.c
+++ b/terps/scott/scott.c
@@ -706,7 +706,7 @@ void FreeDatabase(void)
     free(Messages);
 }
 
-int LoadDatabase(FILE *f, int loud)
+GameIDType LoadDatabase(FILE *f, int loud)
 {
     int ni, na, nw, nr, mc, pr, tr, wl, lt, mn, trm;
     int ct;
@@ -723,7 +723,7 @@ int LoadDatabase(FILE *f, int loud)
         < 10) {
         if (loud)
             debug_print("Invalid database(bad header)\n");
-        return 0;
+        return UNKNOWN_GAME;
     }
     GameHeader.NumItems = ni;
     Items = (Item *)MemAlloc(sizeof(Item) * (ni + 1));
@@ -777,7 +777,7 @@ int LoadDatabase(FILE *f, int loud)
             != 8) {
             fprintf(stderr, "Bad action line (%d)\n", ct);
             FreeDatabase();
-            return 0;
+            return UNKNOWN_GAME;
         }
 
         if (loud) {
@@ -821,7 +821,7 @@ int LoadDatabase(FILE *f, int loud)
             != 6) {
             debug_print("Bad room line (%d)\n", ct);
             FreeDatabase();
-            return 0;
+            return UNKNOWN_GAME;
         }
 
         rp->Text = ReadString(f);
@@ -866,7 +866,7 @@ int LoadDatabase(FILE *f, int loud)
         if (fscanf(f, "%hd", &lo) != 1) {
             debug_print("Bad item line (%d)\n", ct);
             FreeDatabase();
-            return 0;
+            return UNKNOWN_GAME;
         }
         ip->Location = (unsigned char)lo;
         if (loud)
@@ -884,14 +884,14 @@ int LoadDatabase(FILE *f, int loud)
     if (fscanf(f, "%d", &ct) != 1) {
         debug_print("Cannot read version\n");
         FreeDatabase();
-        return 0;
+        return UNKNOWN_GAME;
     }
     if (loud)
         debug_print("Version %d.%02d of Adventure ", ct / 100, ct % 100);
     if (fscanf(f, "%d", &ct) != 1) {
         debug_print("Cannot read adventure number\n");
         FreeDatabase();
-        return 0;
+        return UNKNOWN_GAME;
     }
     if (loud)
         debug_print("%d.\nLoad Complete.\n\n", ct);
@@ -2483,7 +2483,7 @@ void glk_main(void)
 
     GameIDType game_type = DetectGame(game_file);
 
-    if (!game_type)
+    if (game_type == UNKNOWN_GAME)
 		Fatal("Unsupported game!");
 
     if (game_type != SCOTTFREE && game_type != TI994A) {

--- a/terps/scott/scott.h
+++ b/terps/scott/scott.h
@@ -120,7 +120,7 @@ void DrawImage(int image);
 void OpenGraphicsWindow(void);
 size_t GetFileLength(FILE *in);
 void *MemAlloc(int size);
-int LoadDatabase(FILE *f, int loud);
+GameIDType LoadDatabase(FILE *f, int loud);
 void CloseGraphicsWindow(void);
 void Updates(event_t ev);
 int PerformExtraCommand(int extra_stop_time);

--- a/terps/scott/ti994a/load_ti99_4a.c
+++ b/terps/scott/ti994a/load_ti99_4a.c
@@ -118,7 +118,7 @@ static void GetMaxTI99Items(struct DATAHEADER dh)
 //    debug_print("Unknown: %d\n", header.strange);
 //}
 
-static int TryLoadingTI994A(struct DATAHEADER dh, int loud);
+static GameIDType TryLoadingTI994A(struct DATAHEADER dh, int loud);
 
 GameIDType DetectTI994A()
 {
@@ -375,7 +375,7 @@ static uint8_t *LoadTitleScreen(void)
     return result;
 }
 
-static int TryLoadingTI994A(struct DATAHEADER dh, int loud)
+static GameIDType TryLoadingTI994A(struct DATAHEADER dh, int loud)
 {
     int ni, nw, nr, mc, pr, tr, wl, lt, mn, trm;
     int ct;
@@ -477,7 +477,7 @@ static int TryLoadingTI994A(struct DATAHEADER dh, int loud)
 #pragma mark room connections
 #endif
     if (SeekIfNeeded(FixAddress(FixWord(dh.p_room_exit)), &offset, &ptr) == 0)
-        return 0;
+        return UNKNOWN_GAME;
 
     ct = 0;
     rp = Rooms;
@@ -494,7 +494,7 @@ static int TryLoadingTI994A(struct DATAHEADER dh, int loud)
 #pragma mark item locations
 #endif
     if (SeekIfNeeded(FixAddress(FixWord(dh.p_orig_items)), &offset, &ptr) == 0)
-        return 0;
+        return UNKNOWN_GAME;
 
     ct = 0;
     ip = Items;
@@ -535,7 +535,7 @@ static int TryLoadingTI994A(struct DATAHEADER dh, int loud)
     int objectlinks[1024];
 
     if (SeekIfNeeded(FixAddress(FixWord(dh.p_obj_link)), &offset, &ptr) == 0)
-        return 0;
+        return UNKNOWN_GAME;
 
     do {
         objectlinks[ct] = *(ptr++ - file_baseline_offset);


### PR DESCRIPTION
Consistently return GameIDType from all detection functions. Hopefully this makes some of the detection code a tiny bit less confusing.