### PR TITLE
SCOTT, PLUS, TAYLOR: Minor fixes

### DIFF
--- a/terps/plus/apple2detect.c
+++ b/terps/plus/apple2detect.c
@@ -252,7 +252,7 @@ int DetectApple2(uint8_t **sf, size_t *extent)
             free(new);
             new = MemAlloc(companionsize);
             offset = companionsize - 256;
-            for (int i = 0; i < companionsize && i < companionsize; i += 256) {
+            for (int i = 0; i < companionsize; i += 256) {
                 memcpy(new + offset, companionfile + i, 256);
                 offset -= 256;
             }

--- a/terps/plus/loaddatabase.c
+++ b/terps/plus/loaddatabase.c
@@ -164,7 +164,7 @@ static const char *ReadWholeLine(FILE *f)
         }
     } while (c != EOF && (isspace((unsigned char)c) || c == '\"')); // Strip first hyphen
     do {
-        if (c == '\n' || c == 10 || c == 13 || c == EOF)
+        if (c == 10 || c == 13 || c == EOF)
             break;
         /* Pass only ASCII to Glk; the other reasonable option
          * would be to pass Latin-1, but it's probably safe to

--- a/terps/plus/plusmain.c
+++ b/terps/plus/plusmain.c
@@ -428,8 +428,8 @@ static void FlushRoomDescription(char *buf,  int transcript)
         int line = 0;
         int index = 0;
         int i;
-        if (TopWidth > 2046)
-            TopWidth = 2046;
+        if (TopWidth > 2047)
+            TopWidth = 2047;
         char string[2048];
         for (line = 0; line < rows && index < length; line++) {
             for (i = 0; i < TopWidth; i++) {

--- a/terps/scott/detectgame.c
+++ b/terps/scott/detectgame.c
@@ -191,7 +191,7 @@ uint8_t *ReadDictionary(struct GameInfo info, uint8_t **pointer, int loud)
         }
         wordnum++;
 
-        if (c != 0 && c > 127)
+        if (c > 127)
             return ptr;
 
         charindex = 0;
@@ -597,7 +597,7 @@ int TryLoadingOld(struct GameInfo info, int dict_start)
             if (charindex > 255)
                 break;
         }
-        if (c != 0 && c > 127)
+        if (c > 127)
             return 0;
     } while (ct < nr + 1);
 
@@ -953,7 +953,7 @@ int TryLoading(struct GameInfo info, int dict_start, int loud)
                     if (charindex > 255)
                         break;
                 }
-                if (c != 0 && c > 127)
+                if (c > 127)
                     return 0;
             } while (ct < nr + 1);
         } else {

--- a/terps/scott/saga/ciderpress.c
+++ b/terps/scott/saga/ciderpress.c
@@ -163,7 +163,7 @@ typedef enum DIError {
     kDIErrNotSupported          = -105, // feature not currently supported
     kDIErrCancelled             = -106, // an operation was cancelled by user
 
-    kDIErrNufxLibInitFailed     = -110,
+    kDIErrNufxLibInitFailed     = -110
 } DIError;
 
 struct ringbuf_t {
@@ -188,7 +188,7 @@ enum {
     kNibbleAddrPrologLen = 3,       // d5 aa 96
     kNibbleAddrEpilogLen = 3,       // de aa eb
     kNibbleDataPrologLen = 3,       // d5 aa ad
-    kNibbleDataEpilogLen = 3,       // de aa eb
+    kNibbleDataEpilogLen = 3        // de aa eb
 };
 
 typedef struct {
@@ -369,7 +369,7 @@ const NibbleDescr *pNibbleDescr = &nibbleDescr;
  *
  * Returns the index start on success or -1 on failure.
  */
-static int  FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
+static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
                            int sector, int* pVol)
 {
     //DIError dierr;
@@ -464,7 +464,7 @@ static int  FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
 /*
  * Decode 6&2 encoding.
  */
-DIError DecodeNibbleData(ringbuf_handle_t ringbuffer, int idx,
+static DIError DecodeNibbleData(ringbuf_handle_t ringbuffer, int idx,
                          uint8_t* sctBuf)
 {
     uint8_t twos[kChunkSize62 * 3];   // 258
@@ -590,7 +590,7 @@ static DIError CalcSectorAndOffset(long track, int sector, size_t* pOffset, int*
  * tracks in TrackStar images.  A default implementation is provided and
  * used for everything but TrackStar.
  */
-int GetNibbleTrackLength(PhysicalFormat physical, int track)
+static int GetNibbleTrackLength(PhysicalFormat physical, int track)
 {
     if (physical == kPhysicalFormatNib525_6656)
         return kTrackLenNib525;
@@ -603,7 +603,7 @@ int GetNibbleTrackLength(PhysicalFormat physical, int track)
 /*
  * Load a nibble track into our track buffer.
  */
-DIError LoadNibbleTrack(long track, long* pTrackLen)
+static DIError LoadNibbleTrack(long track, long* pTrackLen)
 {
     DIError dierr = kDIErrNone;
     long offset;
@@ -644,31 +644,12 @@ DIError LoadNibbleTrack(long track, long* pTrackLen)
 }
 
 /*
- * Get the contents of the nibble track.
- *
- * "buf" must be able to hold kTrackAllocSize bytes.
- */
-DIError ReadNibbleTrack(long track, uint8_t* buf, long* pTrackLen)
-{
-    DIError dierr;
-
-    dierr = LoadNibbleTrack(track, pTrackLen);
-    if (dierr != kDIErrNone) {
-        debug_print("   DI ReadNibbleTrack: LoadNibbleTrack %ld failed", track);
-        return dierr;
-    }
-
-    memcpy(buf, fNibbleTrackBuf, *pTrackLen);
-    return kDIErrNone;
-}
-
-/*
  * Read a sector from a nibble image.
  *
  * While fNumTracks is valid, fNumSectPerTrack is a little flaky, because
  * in theory each track could be formatted differently.
  */
-DIError ReadNibbleSector(long track, int sector, uint8_t *buf)
+static DIError ReadNibbleSector(long track, int sector, uint8_t *buf)
 {
     if (pNibbleDescr == NULL) {
         /* disk has no recognizable sectors */

--- a/terps/scott/saga/saga.c
+++ b/terps/scott/saga/saga.c
@@ -114,7 +114,7 @@ uint8_t *ReadUSDictionary(uint8_t *ptr)
         }
         wordnum++;
 
-        if (c != 0 && c > 127)
+        if (c > 127)
             return ptr;
 
         charindex = 0;

--- a/terps/scott/scott.c
+++ b/terps/scott/scott.c
@@ -273,8 +273,8 @@ static void FlushRoomDescription(char *buf)
         int index = 0;
         int i;
         char string[2048];
-        if (TopWidth > 2046)
-            TopWidth = 2046;
+        if (TopWidth > 2047)
+            TopWidth = 2047;
         for (line = 0; line < rows && index < length; line++) {
             for (i = 0; i < TopWidth; i++) {
                 string[i] = text_with_breaks[index++];

--- a/terps/scott/scottdefines.h
+++ b/terps/scott/scottdefines.h
@@ -132,7 +132,7 @@ typedef enum {
 typedef enum {
     IMG_ROOM,
     IMG_ROOM_OBJ,
-    IMG_INV_OBJ,
+    IMG_INV_OBJ
 } USImageType;
 
 typedef enum {
@@ -233,7 +233,7 @@ typedef enum {
     SECRET_MISSION_VARIANT,
     SEAS_OF_BLOOD_VARIANT,
     US_VARIANT,
-    OLD_STYLE,
+    OLD_STYLE
 } GameType;
 
 typedef enum {

--- a/terps/taylor/c64decrunch.c
+++ b/terps/taylor/c64decrunch.c
@@ -63,7 +63,7 @@ static uint16_t checksum(uint8_t *sf, size_t extent)
     return c;
 }
 
-static int DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec entry);
+static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec entry);
 
 static uint8_t *get_largest_file(uint8_t *data, size_t length, size_t *newlength)
 {
@@ -184,10 +184,10 @@ static int terror_menu(uint8_t **sf, size_t *extent, int recindex)
     return 0;
 }
 
-int DetectC64(uint8_t **sf, size_t *extent)
+GameIDType DetectC64(uint8_t **sf, size_t *extent)
 {
     if (*extent > MAX_LENGTH || *extent < MIN_LENGTH)
-        return 0;
+        return UNKNOWN_GAME;
 
     uint16_t chksum = checksum(*sf, *extent);
 
@@ -220,7 +220,7 @@ int DetectC64(uint8_t **sf, size_t *extent)
             return DecrunchC64(sf, extent, c64_registry[i]);
         }
     }
-    return 0;
+    return UNKNOWN_GAME;
 }
 
 int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
@@ -228,7 +228,7 @@ int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
     return 0;
 }
 
-static int DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record)
+static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record)
 {
     size_t decompressed_length = *extent;
 

--- a/terps/taylor/c64decrunch.h
+++ b/terps/taylor/c64decrunch.h
@@ -9,6 +9,9 @@
 #define c64decrunch_h
 
 #include <stdio.h>
-int DetectC64(uint8_t **sf, size_t *extent);
+
+#include "taylor.h"
+
+GameIDType DetectC64(uint8_t **sf, size_t *extent);
 
 #endif /* c64decrunch_h */

--- a/terps/taylor/player.c
+++ b/terps/taylor/player.c
@@ -2484,7 +2484,7 @@ void glk_main(void)
 {
     /* The message analyser will look for version 0 games */
 
-    if (DetectC64(&FileImage, &FileImageLen)) {
+    if (DetectC64(&FileImage, &FileImageLen) != UNKNOWN_GAME) {
         EndOfData = FileImage + FileImageLen;
     }
 

--- a/terps/taylor/ui.c
+++ b/terps/taylor/ui.c
@@ -223,8 +223,8 @@ static void FlushRoomDescription(void)
     int i;
     int empty_lines = 0;
     char string[2048];
-    if (TopWidth > 2046)
-        TopWidth = 2046;
+    if (TopWidth > 2047)
+        TopWidth = 2047;
     for (line = 0; line < rows && index < length; line++) {
         for (i = 0; i < TopWidth; i++) {
             string[i] = text_with_breaks[index++];


### PR DESCRIPTION
Mostly cosmetic fixes found by the static analyzer.

Remove an unused function and make some other functions static.

Makes enum GameIDType usage consistent in TaylorMade as well, like #717 in ScottFree, though it is a little redundant here as the return value mostly isn't used by the caller.