### PR TITLE
SCOTT and TAYLOR: Reinstate Unp64

### DIFF
--- a/terps/CMakeLists.txt
+++ b/terps/CMakeLists.txt
@@ -64,6 +64,10 @@ if(WITH_PLUS OR WITH_SCOTT OR WITH_TAYLOR)
     add_subdirectory(c64diskimage)
 endif()
 
+if(WITH_SCOTT OR WITH_TAYLOR)
+    add_subdirectory(unp64)
+endif()
+
 
 # ------------------------------------------------------------------------------
 #
@@ -369,7 +373,7 @@ if(WITH_SCOTT)
         scott/saga/sagagraphics.c scott/saga/woz2nib.c scott/titleimage.c
         scott/ai_uk/seasofblood.c scott/ti994a/ti99_4a_terp.c
         INCLUDE_DIRS ${SCOTT_INCLUDE_DIRS}
-        LIBS c64diskimage)
+        LIBS c64diskimage unp64)
 endif()
 
 # ------------------------------------------------------------------------------
@@ -385,5 +389,5 @@ if(WITH_TAYLOR)
         taylor/layouttext.c taylor/loadtotpicture.c taylor/parseinput.c taylor/player.c
         taylor/restorestate.c taylor/sagadraw.c taylor/ui.c taylor/utility.c
         INCLUDE_DIRS ${TAYLOR_INCLUDE_DIRS}
-        LIBS c64diskimage)
+        LIBS c64diskimage unp64)
 endif()

--- a/terps/scott/ai_uk/c64decrunch.c
+++ b/terps/scott/ai_uk/c64decrunch.c
@@ -170,7 +170,7 @@ uint16_t checksum(uint8_t *sf, uint32_t extent)
     return c;
 }
 
-static int DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec entry);
+static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec entry);
 
 size_t writeToFile(const char *name, uint8_t *data, size_t size)
 {
@@ -514,10 +514,10 @@ void LoadC64USImages(uint8_t *data, size_t length) {
     }
 }
 
-int DetectC64(uint8_t **sf, size_t *extent)
+GameIDType DetectC64(uint8_t **sf, size_t *extent)
 {
     if (*extent > MAX_LENGTH || *extent < MIN_LENGTH)
-        return 0;
+        return UNKNOWN_GAME;
 
     uint16_t chksum = checksum(*sf, *extent);
 
@@ -546,7 +546,7 @@ int DetectC64(uint8_t **sf, size_t *extent)
 
                 size_t buflen = newlength + appendixlen;
                 if (buflen <= 0 || buflen > MAX_LENGTH)
-                    return 0;
+                    return UNKNOWN_GAME;
 
                 uint8_t *megabuf = MemAlloc(buflen);
                 memcpy(megabuf, largest_file, newlength);

--- a/terps/scott/ai_uk/c64decrunch.c
+++ b/terps/scott/ai_uk/c64decrunch.c
@@ -22,7 +22,7 @@
 
 #include "hulk.h"
 
-//#include "unp64_interface.h"
+#include "unp64_interface.h"
 
 typedef enum {
     UNKNOWN_FILE_TYPE,
@@ -170,7 +170,7 @@ uint16_t checksum(uint8_t *sf, uint32_t extent)
     return c;
 }
 
-static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec entry);
+static int DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec entry);
 
 size_t writeToFile(const char *name, uint8_t *data, size_t size)
 {
@@ -514,7 +514,7 @@ void LoadC64USImages(uint8_t *data, size_t length) {
     }
 }
 
-GameIDType DetectC64(uint8_t **sf, size_t *extent)
+int DetectC64(uint8_t **sf, size_t *extent)
 {
     if (*extent > MAX_LENGTH || *extent < MIN_LENGTH)
         return 0;
@@ -625,11 +625,6 @@ GameIDType DetectC64(uint8_t **sf, size_t *extent)
     return UNKNOWN_GAME;
 }
 
-int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
-          size_t *final_length, char *settings[], int numsettings) {
-    return 0;
-}
-
 static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record)
 {
     size_t length = *extent;
@@ -651,9 +646,6 @@ static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record
 
     size_t result = 0;
 
-    if (record.decompress_iterations > 0) {
-        Fatal("Unsupported game");
-    }
     for (int i = 1; i <= record.decompress_iterations; i++) {
         /* We only send switches on the iteration specified by parameter */
         if (i == record.parameter && record.switches != NULL) {

--- a/terps/scott/ai_uk/c64decrunch.h
+++ b/terps/scott/ai_uk/c64decrunch.h
@@ -9,6 +9,9 @@
 #define c64decrunch_h
 
 #include <stdio.h>
-int DetectC64(uint8_t **sf, size_t *extent);
+
+#include "scottdefines.h"
+
+GameIDType DetectC64(uint8_t **sf, size_t *extent);
 
 #endif /* c64decrunch_h */

--- a/terps/scott/ai_uk/c64decrunch.h
+++ b/terps/scott/ai_uk/c64decrunch.h
@@ -9,9 +9,6 @@
 #define c64decrunch_h
 
 #include <stdio.h>
-
-#include "scottdefines.h"
-
-GameIDType DetectC64(uint8_t **sf, size_t *extent);
+int DetectC64(uint8_t **sf, size_t *extent);
 
 #endif /* c64decrunch_h */

--- a/terps/taylor/c64decrunch.c
+++ b/terps/taylor/c64decrunch.c
@@ -105,7 +105,7 @@ static uint8_t *GetFileFromT64(int filenum, int number_of_records, uint8_t **sf,
     return file;
 }
 
-static int terror_menu(uint8_t **sf, size_t *extent, int recindex)
+static GameIDType terror_menu(uint8_t **sf, size_t *extent, int recindex)
 {
     OpenBottomWindow();
     Display(Bottom, "This datasette image contains one version of Temple of Terror with pictures, and one with without pictures but slightly more text.\n\nPlease select one:\n1. Graphics version\n2. Text-only version\n3. Use pictures from file 1 and text from file 2");
@@ -120,7 +120,7 @@ static int terror_menu(uint8_t **sf, size_t *extent, int recindex)
 
     if (file1 == NULL || file2 == NULL) {
         fprintf(stderr, "TAYLOR: terror_menu() Failed loading file!\n");
-        return 0;
+        return UNKNOWN_GAME;
     }
     glk_request_char_event(Bottom);
 
@@ -178,10 +178,8 @@ static int terror_menu(uint8_t **sf, size_t *extent, int recindex)
         }
         default:
             fprintf(stderr, "TAYLOR: invalid switch case!\n");
-            return 0;
-
     }
-    return 0;
+    return UNKNOWN_GAME;
 }
 
 GameIDType DetectC64(uint8_t **sf, size_t *extent)

--- a/terps/taylor/c64decrunch.c
+++ b/terps/taylor/c64decrunch.c
@@ -16,7 +16,7 @@
 #include "c64decrunch.h"
 #include "c64diskimage.h"
 
-//#include "unp64_interface.h"
+#include "unp64_interface.h"
 
 #define MAX_LENGTH 300000
 #define MIN_LENGTH 24
@@ -223,11 +223,6 @@ GameIDType DetectC64(uint8_t **sf, size_t *extent)
     return UNKNOWN_GAME;
 }
 
-int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
-          size_t *final_length, char *settings[], int numsettings) {
-    return 0;
-}
-
 static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record)
 {
     size_t decompressed_length = *extent;
@@ -248,9 +243,6 @@ static GameIDType DecrunchC64(uint8_t **sf, size_t *extent, struct c64rec record
 
     size_t result = 0;
 
-    if (record.decompress_iterations > 0) {
-        Fatal("Unsupported game");
-    }
     for (int i = 1; i <= record.decompress_iterations; i++) {
         /* We only send switches on the iteration specified by parameter */
         if (i == record.parameter && record.switches != NULL) {

--- a/terps/unp64/6502emu.c
+++ b/terps/unp64/6502emu.c
@@ -1,6 +1,33 @@
+/* Code from Exomizer distributed under the zlib License
+ * by kind permission of the original authors
+ * Magnus Lind and iAN CooG.
+ */
+
+/*
+ * Copyright (c) 2002 - 2023 Magnus Lind.
+ *
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
 /*
 Original: Magnus Lind
-Modifications for UNP64: iAN CooG
+Modifications for UNP64: iAN CooG and Petter Sjölund
 */
 #include "6502emu.h"
 #include "log.h"

--- a/terps/unp64/6502emu.c
+++ b/terps/unp64/6502emu.c
@@ -1,0 +1,1462 @@
+/*
+Original: Magnus Lind
+Modifications for UNP64: iAN CooG
+*/
+#include "6502emu.h"
+#include "log.h"
+#include <stdlib.h>
+
+#define FLAG_N 128
+#define FLAG_V 64
+#define FLAG_D 8
+#define FLAG_I 4
+#define FLAG_Z 2
+#define FLAG_C 1
+
+extern int debugprint;
+
+struct arg_ea {
+    u16 value;
+};
+struct arg_relative {
+    i8 value;
+};
+struct arg_immediate {
+    u8 value;
+};
+
+union inst_arg {
+    struct arg_ea ea;
+    struct arg_relative rel;
+    struct arg_immediate imm;
+};
+
+typedef void op_f(struct cpu_ctx *r, int mode, union inst_arg *arg);
+typedef int mode_f(struct cpu_ctx *r, union inst_arg *arg);
+
+struct op_info {
+    op_f *f;
+    char *fmt;
+};
+
+struct mode_info {
+    mode_f *f;
+    char *fmt;
+};
+
+struct inst_info {
+    struct op_info *op;
+    struct mode_info *mode;
+    u8 cycles;
+};
+
+#define MODE_IMMEDIATE 0
+#define MODE_ZERO_PAGE 1
+#define MODE_ZERO_PAGE_X 2
+#define MODE_ZERO_PAGE_Y 3
+#define MODE_ABSOLUTE 4
+#define MODE_ABSOLUTE_X 5
+#define MODE_ABSOLUTE_Y 6
+#define MODE_INDIRECT 7
+#define MODE_INDIRECT_X 8
+#define MODE_INDIRECT_Y 9
+#define MODE_RELATIVE 10
+#define MODE_ACCUMULATOR 11
+#define MODE_IMPLIED 12
+
+static int mode_imm(struct cpu_ctx *r, union inst_arg *arg)
+{
+    arg->imm.value = r->mem[r->pc + 1];
+    r->pc += 2;
+    return MODE_IMMEDIATE;
+}
+static int mode_zp(struct cpu_ctx *r, union inst_arg *arg)
+{
+    arg->ea.value = r->mem[r->pc + 1];
+    r->pc += 2;
+    return MODE_ZERO_PAGE;
+}
+static int mode_zpx(struct cpu_ctx *r,
+    union inst_arg *arg)
+{ /* iAN: ldx #1 lda $ff,x should fetch
+                                              from $00 and not $100 */
+    u8 lsbLo = (r->mem[r->pc + 1] + r->x) & 0xff;
+    arg->ea.value = lsbLo;
+    r->pc += 2;
+    return MODE_ZERO_PAGE_X;
+}
+static int mode_zpy(struct cpu_ctx *r,
+    union inst_arg *arg)
+{ /* iAN: ldy #1 ldx $ff,y should fetch
+                                              from $00 and not $100 */
+    u8 lsbLo = (r->mem[r->pc + 1] + r->y) & 0xff;
+    arg->ea.value = lsbLo;
+    r->pc += 2;
+    return MODE_ZERO_PAGE_Y;
+}
+static int mode_abs(struct cpu_ctx *r, union inst_arg *arg)
+{
+    u16 offset = r->mem[r->pc + 1];
+    u16 base = r->mem[r->pc + 2] << 8;
+    arg->ea.value = base + offset;
+    r->pc += 3;
+    return MODE_ABSOLUTE;
+}
+static int mode_absx(struct cpu_ctx *r, union inst_arg *arg)
+{
+    u16 offset = r->mem[r->pc + 1] + r->x;
+    u16 base = r->mem[r->pc + 2] << 8;
+    arg->ea.value = base + offset;
+    r->pc += 3;
+    r->cycles += (offset > 255);
+    return MODE_ABSOLUTE_X;
+}
+static int mode_absy(struct cpu_ctx *r, union inst_arg *arg)
+{
+    u16 offset = r->mem[r->pc + 1] + r->y;
+    u16 base = r->mem[r->pc + 2] << 8;
+    arg->ea.value = base + offset;
+    r->pc += 3;
+    r->cycles += (offset > 255);
+    return MODE_ABSOLUTE_Y;
+}
+static int mode_ind(struct cpu_ctx *r, union inst_arg *arg)
+{
+    /* iAN: Wrong calcs, for example I have a jmp ($0512), at $0512 there's
+     $0b $08 $00 $ff, this returns $0800 instead of $80b
+     Also, the wraparound bug is not handled as it should:
+     JMP ($12FF) should fetch lobyte from $12FF & hibyte from $1200
+     */
+
+    /* wrong
+     u8 lsbLo = r->mem[r->pc + 1];
+     u8 msbLo = lsbLo + 1;
+     u16 base = r->mem[msbLo + (r->mem[r->pc + 2] << 8)] << 8;
+     u16 offset = r->mem[lsbLo];
+     arg->ea.value = base + offset;
+     */
+
+    /* correction */
+    int lsbLo = r->mem[r->pc + 1];
+    int msbLo = r->mem[r->pc + 2];
+    int offsetlo = lsbLo | msbLo << 8;
+    int offsethi = ((lsbLo + 1) & 0xff) | msbLo << 8;
+    arg->ea.value = r->mem[offsetlo] | r->mem[offsethi] << 8;
+
+    r->pc += 3;
+    return MODE_INDIRECT;
+}
+static int mode_indx(struct cpu_ctx *r, union inst_arg *arg)
+{
+    u8 lsbLo = r->mem[r->pc + 1] + r->x;
+    u8 msbLo = lsbLo + 1;
+    u16 base = r->mem[msbLo] << 8;
+    u16 offset = r->mem[lsbLo];
+    arg->ea.value = base + offset;
+    r->pc += 2;
+    return MODE_INDIRECT_X;
+}
+static int mode_indy(struct cpu_ctx *r, union inst_arg *arg)
+{
+    u8 lsbLo = r->mem[r->pc + 1];
+    u8 msbLo = lsbLo + 1;
+    u16 base = r->mem[msbLo] << 8;
+    u16 offset = r->mem[lsbLo] + r->y;
+    arg->ea.value = base + offset;
+    r->pc += 2;
+    r->cycles += (offset > 255);
+    return MODE_INDIRECT_Y;
+}
+static int mode_rel(struct cpu_ctx *r, union inst_arg *arg)
+{
+    arg->rel.value = r->mem[r->pc + 1];
+    r->pc += 2;
+    return MODE_RELATIVE;
+}
+static int mode_acc(struct cpu_ctx *r, union inst_arg *arg)
+{
+    r->pc++;
+    return MODE_ACCUMULATOR;
+}
+static int mode_imp(struct cpu_ctx *r, union inst_arg *arg)
+{
+    r->pc++;
+    return MODE_IMPLIED;
+}
+
+static struct mode_info mode_imm_o = { &mode_imm, "#$%02x" };
+static struct mode_info mode_zp_o = { &mode_zp, "$%02x" };
+static struct mode_info mode_zpx_o = { &mode_zpx, "$%02x,x" };
+static struct mode_info mode_zpy_o = { &mode_zpy, "$%02x,y" };
+static struct mode_info mode_abs_o = { &mode_abs, "$%04x" };
+static struct mode_info mode_absx_o = { &mode_absx, "$%04x,x" };
+static struct mode_info mode_absy_o = { &mode_absy, "$%04x,y" };
+static struct mode_info mode_ind_o = { &mode_ind, "($%04x)" };
+static struct mode_info mode_indx_o = { &mode_indx, "($%02x,x)" };
+static struct mode_info mode_indy_o = { &mode_indy, "($%02x),y" };
+static struct mode_info mode_rel_o = { &mode_rel, "$%02x" };
+static struct mode_info mode_acc_o = { &mode_acc, "a" };
+static struct mode_info mode_imp_o = { &mode_imp, NULL };
+
+static void update_flags_nz(struct cpu_ctx *r, u8 value)
+{
+    r->flags &= ~(FLAG_Z | FLAG_N);
+    r->flags |= (value == 0 ? FLAG_Z : 0) | (value & FLAG_N);
+}
+
+static void update_carry(struct cpu_ctx *r, int bool)
+{
+    r->flags = (r->flags & ~FLAG_C) | (bool != 0 ? FLAG_C : 0);
+}
+
+static void update_overflow(struct cpu_ctx *r, int bool)
+{
+    r->flags = (r->flags & ~FLAG_V) | (bool != 0 ? FLAG_V : 0);
+}
+
+static void op_adc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    u16 result;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    result = r->a + value + (r->flags & FLAG_C);
+    update_carry(r, result & 256);
+    update_overflow(r, !((r->a & 0x80) ^ (value & 0x80)) && ((r->a & 0x80) ^ (result & 0x80)));
+    r->a = result & 0xff;
+    update_flags_nz(r, r->a);
+}
+
+static void op_and(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->a &= value;
+    update_flags_nz(r, r->a);
+}
+
+static void op_asl(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 *valuep;
+    switch (mode) {
+    case MODE_ACCUMULATOR:
+        valuep = &r->a;
+        break;
+    default:
+        valuep = &r->mem[arg->ea.value];
+        break;
+    }
+    update_carry(r, *valuep & 128);
+    *valuep <<= 1;
+    update_flags_nz(r, *valuep);
+}
+
+static void branch(struct cpu_ctx *r, union inst_arg *arg)
+{
+    u16 target = r->pc + arg->rel.value;
+    r->cycles += 1 + ((target & ~255) != (r->pc & ~255));
+    r->pc = target;
+}
+
+static void op_bcc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (!(r->flags & FLAG_C)) {
+        branch(r, arg);
+    }
+}
+
+static void op_bcs(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (r->flags & FLAG_C) {
+        branch(r, arg);
+    }
+}
+
+static void op_beq(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (r->flags & FLAG_Z) {
+        branch(r, arg);
+    }
+}
+
+static void op_bit(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags &= ~(FLAG_N | FLAG_V | FLAG_Z);
+    r->flags |= (r->mem[arg->ea.value] & FLAG_N) != 0 ? FLAG_N : 0;
+    r->flags |= (r->mem[arg->ea.value] & FLAG_V) != 0 ? FLAG_V : 0;
+    r->flags |= (r->mem[arg->ea.value] & r->a) == 0 ? FLAG_Z : 0;
+}
+
+static void op_bmi(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (r->flags & FLAG_N) {
+        branch(r, arg);
+    }
+}
+
+static void op_bne(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (!(r->flags & FLAG_Z)) {
+        branch(r, arg);
+    }
+}
+
+static void op_bpl(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (!(r->flags & FLAG_N)) {
+        branch(r, arg);
+    }
+}
+
+static void op_brk(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[0x100 + r->sp--] = (r->pc + 1) >> 8;
+    r->mem[0x100 + r->sp--] = r->pc + 1;
+    r->mem[0x100 + r->sp--] = r->flags | 0x10;
+}
+
+static void op_bvc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if (!(r->flags & FLAG_V)) {
+        branch(r, arg);
+    }
+}
+
+static void op_bvs(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    if ((r->flags & FLAG_V)) {
+        branch(r, arg);
+    }
+}
+
+static void op_clc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags &= ~FLAG_C;
+}
+
+static void op_cld(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags &= ~FLAG_D;
+}
+
+static void op_cli(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags &= ~FLAG_I;
+}
+
+static void op_clv(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags &= ~FLAG_V;
+}
+
+static u16 subtract(struct cpu_ctx *r, int carry, u8 val1, u8 value)
+{
+    u16 target = val1 - value - (1 - !!carry);
+    update_carry(r, !(target & 256));
+    update_flags_nz(r, target & 255);
+    return target;
+}
+
+static void op_cmp(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    subtract(r, 1, r->a, value);
+}
+
+static void op_cpx(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    subtract(r, 1, r->x, value);
+}
+
+static void op_cpy(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    subtract(r, 1, r->y, value);
+}
+
+static void op_dec(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[arg->ea.value]--;
+    update_flags_nz(r, r->mem[arg->ea.value]);
+}
+
+static void op_dex(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->x--;
+    update_flags_nz(r, r->x);
+}
+
+static void op_dey(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->y--;
+    update_flags_nz(r, r->y);
+}
+
+static void op_eor(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->a ^= value;
+    update_flags_nz(r, r->a);
+}
+
+static void op_inc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[arg->ea.value]++;
+    update_flags_nz(r, r->mem[arg->ea.value]);
+}
+
+static void op_inx(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->x++;
+    update_flags_nz(r, r->x);
+}
+
+static void op_iny(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->y++;
+    update_flags_nz(r, r->y);
+}
+
+static void op_jmp(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->pc = arg->ea.value;
+}
+
+static void op_jsr(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->pc--;
+    r->mem[0x100 + r->sp--] = r->pc >> 8;
+    r->mem[0x100 + r->sp--] = r->pc & 0xff;
+    r->pc = arg->ea.value;
+}
+
+static void op_lda(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->a = value;
+    update_flags_nz(r, r->a);
+}
+
+static void op_ldx(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->x = value;
+    update_flags_nz(r, r->x);
+}
+
+static void op_ldy(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->y = value;
+    update_flags_nz(r, r->y);
+}
+
+static void op_lsr(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 *valuep;
+    switch (mode) {
+    case MODE_ACCUMULATOR:
+        valuep = &r->a;
+        break;
+    default:
+        valuep = &r->mem[arg->ea.value];
+        break;
+    }
+    update_carry(r, *valuep & 1);
+    *valuep >>= 1;
+    update_flags_nz(r, *valuep);
+}
+
+static void op_nop(struct cpu_ctx *r, int mode, union inst_arg *arg) { }
+
+static void op_ora(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->a |= value;
+    update_flags_nz(r, r->a);
+}
+
+static void op_pha(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[0x100 + r->sp--] = r->a;
+}
+
+static void op_php(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[0x100 + r->sp--] = r->flags & ~0x10;
+}
+
+static void op_pla(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->a = r->mem[0x100 + ++r->sp];
+    update_flags_nz(r, r->a);
+}
+
+static void op_plp(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags = r->mem[0x100 + ++r->sp];
+}
+
+static void op_rol(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 *valuep;
+    u8 old_flags;
+    switch (mode) {
+    case MODE_ACCUMULATOR:
+        valuep = &r->a;
+        break;
+    default:
+        valuep = &r->mem[arg->ea.value];
+        break;
+    }
+    old_flags = r->flags;
+    update_carry(r, *valuep & 128);
+    *valuep <<= 1;
+    *valuep |= (old_flags & FLAG_C) != 0 ? 1 : 0;
+    update_flags_nz(r, *valuep);
+}
+
+static void op_ror(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 *valuep;
+    u8 old_flags;
+    switch (mode) {
+    case MODE_ACCUMULATOR:
+        valuep = &r->a;
+        break;
+    default:
+        valuep = &r->mem[arg->ea.value];
+        break;
+    }
+    old_flags = r->flags;
+    update_carry(r, *valuep & 1);
+    *valuep >>= 1;
+    *valuep |= (old_flags & FLAG_C) != 0 ? 128 : 0;
+    update_flags_nz(r, *valuep);
+}
+
+static void op_rti(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags = r->mem[0x100 + ++r->sp];
+    r->pc = r->mem[0x100 + ++r->sp];
+    r->pc |= r->mem[0x100 + ++r->sp] << 8;
+}
+
+static void op_rts(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->pc = r->mem[0x100 + ++r->sp];
+    r->pc |= r->mem[0x100 + ++r->sp] << 8;
+    r->pc++;
+}
+
+static void op_sbc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    u16 result;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    result = subtract(r, r->flags & FLAG_C, r->a, value);
+    update_overflow(r, !((r->a & 0x80) ^ (value & 0x80)) && ((r->a & 0x80) ^ (result & 0x80)));
+    r->a = result & 0xff;
+    update_flags_nz(r, r->a);
+}
+
+static void op_sec(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags |= FLAG_C;
+}
+
+static void op_sed(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags |= FLAG_D;
+}
+
+static void op_sei(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->flags |= FLAG_I;
+}
+
+static void op_sta(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[arg->ea.value] = r->a;
+}
+
+static void op_stx(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[arg->ea.value] = r->x;
+}
+
+static void op_sty(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->mem[arg->ea.value] = r->y;
+}
+
+static void op_tax(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->x = r->a;
+    update_flags_nz(r, r->x);
+}
+
+static void op_tay(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->y = r->a;
+    update_flags_nz(r, r->y);
+}
+
+static void op_tsx(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->x = r->sp;
+    update_flags_nz(r, r->x);
+}
+
+static void op_txa(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->a = r->x;
+    update_flags_nz(r, r->a);
+}
+
+static void op_txs(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->sp = r->x;
+}
+
+static void op_tya(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->a = r->y;
+    update_flags_nz(r, r->a);
+}
+
+/* iAN */
+static void op_anc(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    u8 value;
+    switch (mode) {
+    case MODE_IMMEDIATE:
+        value = arg->imm.value;
+        break;
+    default:
+        value = r->mem[arg->ea.value];
+        break;
+    }
+    r->a &= value;
+    if (r->a & 0x80)
+        r->flags |= FLAG_C;
+    update_flags_nz(r, r->a);
+}
+
+/* iAN */
+static void op_lax(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_lda(r, mode, arg);
+    r->x = r->a;
+    update_flags_nz(r, r->x);
+}
+/* iAN */
+static void op_lae(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_lda(r, mode, arg);
+    r->x = r->a;
+    r->sp = r->a;
+    update_flags_nz(r, r->a);
+}
+
+/* iAN */
+static void op_dcp(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_dec(r, mode, arg);
+    op_cmp(r, mode, arg);
+}
+
+/* iAN */
+static void op_sax(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->a &= r->x;
+    op_sta(r, mode, arg);
+}
+
+/* iAN */
+static void op_rla(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_rol(r, mode, arg);
+    op_and(r, mode, arg);
+}
+
+/* iAN */
+static void op_rra(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_rol(r, mode, arg);
+    op_adc(r, mode, arg);
+}
+
+/* iAN */
+static void op_isb(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_inc(r, mode, arg);
+    op_sbc(r, mode, arg);
+}
+
+/* iAN */
+static void op_slo(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_asl(r, mode, arg);
+    op_ora(r, mode, arg);
+}
+
+/* iAN */
+static void op_sbx(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    /* immediate mode only: sbx #$ff */
+    r->x &= r->a;
+    r->flags = (r->flags & 0xfe) | (r->x >= arg->imm.value ? 1 : 0); /* fixed: Carry IS set by SBX but
+                                                  not used during subtraction */
+    r->x -= arg->imm.value;
+    update_flags_nz(r, r->x);
+}
+
+/* iAN */
+static void op_sre(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    op_lsr(r, mode, arg);
+    op_eor(r, mode, arg);
+}
+/* iAN */
+static void
+op_asr(struct cpu_ctx *r, int mode,
+    union inst_arg *arg)
+{ /* first A AND #immediate, then LSR A */
+    op_and(r, MODE_IMMEDIATE, arg);
+    op_lsr(r, MODE_ACCUMULATOR, arg);
+}
+/* iAN */
+static void op_ane(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->a |= 0xee;
+    r->a &= r->x;
+    op_and(r, MODE_IMMEDIATE, arg);
+}
+/* iAN */
+static void op_lxa(struct cpu_ctx *r, int mode, union inst_arg *arg)
+{
+    r->a |= 0xee;
+    op_and(r, MODE_IMMEDIATE, arg);
+    r->x = r->a;
+}
+
+static struct op_info op_adc_o = { &op_adc, "adc" };
+static struct op_info op_anc_o = { &op_anc, "anc" };
+static struct op_info op_and_o = { &op_and, "and" };
+static struct op_info op_ane_o = { &op_ane, "ane" };
+static struct op_info op_asl_o = { &op_asl, "asl" };
+static struct op_info op_asr_o = { &op_asr, "asr" };
+static struct op_info op_bcc_o = { &op_bcc, "bcc" };
+static struct op_info op_bcs_o = { &op_bcs, "bcs" };
+static struct op_info op_beq_o = { &op_beq, "beq" };
+static struct op_info op_bit_o = { &op_bit, "bit" };
+static struct op_info op_bmi_o = { &op_bmi, "bmi" };
+static struct op_info op_bne_o = { &op_bne, "bne" };
+static struct op_info op_bpl_o = { &op_bpl, "bpl" };
+static struct op_info op_brk_o = { &op_brk, "brk" };
+static struct op_info op_bvc_o = { &op_bvc, "bvc" };
+static struct op_info op_bvs_o = { &op_bvs, "bvs" };
+static struct op_info op_clc_o = { &op_clc, "clc" };
+
+static struct op_info op_cld_o = { &op_cld, "cld" };
+static struct op_info op_cli_o = { &op_cli, "cli" };
+static struct op_info op_clv_o = { &op_clv, "clv" };
+static struct op_info op_cmp_o = { &op_cmp, "cmp" };
+static struct op_info op_cpx_o = { &op_cpx, "cpx" };
+static struct op_info op_cpy_o = { &op_cpy, "cpy" };
+static struct op_info op_dcp_o = { &op_dcp, "dcp" };
+static struct op_info op_dec_o = { &op_dec, "dec" };
+static struct op_info op_dex_o = { &op_dex, "dex" };
+static struct op_info op_dey_o = { &op_dey, "dey" };
+static struct op_info op_eor_o = { &op_eor, "eor" };
+static struct op_info op_inc_o = { &op_inc, "inc" };
+static struct op_info op_isb_o = { &op_isb, "isb" };
+static struct op_info op_inx_o = { &op_inx, "inx" };
+static struct op_info op_iny_o = { &op_iny, "iny" };
+static struct op_info op_jmp_o = { &op_jmp, "jmp" };
+
+static struct op_info op_jsr_o = { &op_jsr, "jsr" };
+static struct op_info op_lda_o = { &op_lda, "lda" };
+static struct op_info op_ldx_o = { &op_ldx, "ldx" };
+static struct op_info op_ldy_o = { &op_ldy, "ldy" };
+static struct op_info op_lsr_o = { &op_lsr, "lsr" };
+static struct op_info op_nop_o = { &op_nop, "nop" };
+static struct op_info op_ora_o = { &op_ora, "ora" };
+static struct op_info op_pha_o = { &op_pha, "pha" };
+static struct op_info op_php_o = { &op_php, "php" };
+static struct op_info op_pla_o = { &op_pla, "pla" };
+static struct op_info op_plp_o = { &op_plp, "plp" };
+static struct op_info op_rol_o = { &op_rol, "rol" };
+static struct op_info op_rla_o = { &op_rla, "rla" };
+static struct op_info op_ror_o = { &op_ror, "ror" };
+static struct op_info op_rti_o = { &op_rti, "rti" };
+static struct op_info op_rra_o = { &op_rra, "rra" };
+
+static struct op_info op_rts_o = { &op_rts, "rts" };
+static struct op_info op_sbc_o = { &op_sbc, "sbc" };
+static struct op_info op_sbx_o = { &op_sbx, "sbx" };
+static struct op_info op_sec_o = { &op_sec, "sec" };
+static struct op_info op_sed_o = { &op_sed, "sed" };
+static struct op_info op_sei_o = { &op_sei, "sei" };
+static struct op_info op_slo_o = { &op_slo, "slo" };
+static struct op_info op_sta_o = { &op_sta, "sta" };
+static struct op_info op_stx_o = { &op_stx, "stx" };
+static struct op_info op_sty_o = { &op_sty, "sty" };
+static struct op_info op_lax_o = { &op_lax, "lax" };
+static struct op_info op_lae_o = { &op_lae, "lae" };
+static struct op_info op_lxa_o = { &op_lxa, "lxa" };
+static struct op_info op_tax_o = { &op_tax, "tax" };
+static struct op_info op_sax_o = { &op_sax, "sax" };
+static struct op_info op_sre_o = { &op_sre, "sre" };
+static struct op_info op_tay_o = { &op_tay, "tay" };
+static struct op_info op_tsx_o = { &op_tsx, "tsx" };
+static struct op_info op_txa_o = { &op_txa, "txa" };
+static struct op_info op_txs_o = { &op_txs, "txs" };
+static struct op_info op_tya_o = { &op_tya, "tya" };
+
+#define NULL_OP       \
+    {                 \
+        NULL, NULL, 0 \
+    }
+
+static int retfire = 0xff;
+static int retspace = 0xff;
+int flipfire(void)
+{
+    retfire ^= 0x90;
+    return retfire;
+}
+int flipspace(void)
+{
+    retspace ^= 0x10;
+    return retspace;
+}
+
+/* http://www.obelisk.demon.co.uk/6502/reference.html is a nice reference */
+static struct inst_info ops[256] = {
+    /* 0x00 */
+    { &op_brk_o, &mode_imp_o, 7 },
+    { &op_ora_o, &mode_indx_o, 6 },
+    NULL_OP,
+    NULL_OP,
+    { &op_nop_o, &mode_zp_o, 3 }, /* $04 nop $ff */
+    { &op_ora_o, &mode_zp_o, 3 },
+    { &op_asl_o, &mode_zp_o, 5 },
+    { &op_slo_o, &mode_zp_o, 5 }, /* $07 slo $ff */
+    { &op_php_o, &mode_imp_o, 3 },
+    { &op_ora_o, &mode_imm_o, 2 },
+    { &op_asl_o, &mode_acc_o, 2 },
+    { &op_anc_o, &mode_imm_o, 2 }, /* $0b anc #$ff */
+    { &op_nop_o, &mode_abs_o, 4 }, /* $0c nop $ffff */
+    { &op_ora_o, &mode_abs_o, 4 },
+    { &op_asl_o, &mode_abs_o, 6 },
+    { &op_slo_o, &mode_abs_o, 6 }, /* $0f slo $ffff */
+    /* 0x10 */
+    { &op_bpl_o, &mode_rel_o, 2 },
+    { &op_ora_o, &mode_indy_o, 5 },
+    NULL_OP,
+    NULL_OP,
+    { &op_nop_o, &mode_zpx_o, 4 }, /* $14 nop $ff,x */
+    { &op_ora_o, &mode_zpx_o, 4 },
+    { &op_asl_o, &mode_zpx_o, 6 },
+    NULL_OP,
+    { &op_clc_o, &mode_imp_o, 2 },
+    { &op_ora_o, &mode_absy_o, 4 },
+    { &op_nop_o, &mode_imp_o, 2 }, /* $1a nop */
+    { &op_slo_o, &mode_absy_o, 4 }, /* $1b slo $ffff,y */
+    { &op_nop_o, &mode_absx_o, 4 }, /* $1c nop $ffff,x */
+    { &op_ora_o, &mode_absx_o, 4 },
+    { &op_asl_o, &mode_absx_o, 7 },
+    { &op_slo_o, &mode_absx_o, 7 }, /* $1f slo $ffff,x */
+    /* 0x20 */
+    { &op_jsr_o, &mode_abs_o, 6 },
+    { &op_and_o, &mode_indx_o, 6 },
+    NULL_OP,
+    { &op_rla_o, &mode_indx_o, 8 }, /* $23 rla ($ff,x) */
+    { &op_bit_o, &mode_zp_o, 3 },
+    { &op_and_o, &mode_zp_o, 3 },
+    { &op_rol_o, &mode_zp_o, 5 },
+    { &op_rla_o, &mode_zp_o, 5 }, /* $27 rla $ff */
+    { &op_plp_o, &mode_imp_o, 4 },
+    { &op_and_o, &mode_imm_o, 2 },
+    { &op_rol_o, &mode_acc_o, 2 },
+    { &op_anc_o, &mode_imm_o, 2 }, /* $2b anc #$ff */
+    { &op_bit_o, &mode_abs_o, 4 },
+    { &op_and_o, &mode_abs_o, 4 },
+    { &op_rol_o, &mode_abs_o, 6 },
+    { &op_rla_o, &mode_abs_o, 6 }, /* $2f rla $ffff */
+    /* 0x30 */
+    { &op_bmi_o, &mode_rel_o, 2 },
+    { &op_and_o, &mode_indy_o, 5 },
+    NULL_OP,
+    { &op_rla_o, &mode_indy_o, 8 }, /* $33 rla ($ff),y  */
+    { &op_nop_o, &mode_zpx_o, 4 }, /* $34 nop $ff,x */
+    { &op_and_o, &mode_zpx_o, 4 },
+    { &op_rol_o, &mode_zpx_o, 6 },
+    { &op_rla_o, &mode_zpx_o, 6 }, /* $37 rla $ff,x */
+    { &op_sec_o, &mode_imp_o, 2 },
+    { &op_and_o, &mode_absy_o, 4 },
+    { &op_nop_o, &mode_imp_o, 2 }, /* $3a nop */
+    { &op_rla_o, &mode_absy_o, 7 }, /* $3b rla $ffff,y */
+    { &op_nop_o, &mode_absx_o, 7 }, /* $3c nop $ffff,x */
+    { &op_and_o, &mode_absx_o, 4 },
+    { &op_rol_o, &mode_absx_o, 7 },
+    { &op_rla_o, &mode_absx_o, 7 }, /* $3f rla $ffff,x */
+    /* 0x40 */
+    { &op_rti_o, &mode_imp_o, 6 },
+    { &op_eor_o, &mode_indx_o, 6 },
+    NULL_OP,
+    { &op_sre_o, &mode_indx_o, 6 }, /* $43 sre ($ff,x) */
+    { &op_nop_o, &mode_zp_o, 3 }, /* $44 nop $ff */
+    { &op_eor_o, &mode_zp_o, 3 },
+    { &op_lsr_o, &mode_zp_o, 5 },
+    { &op_sre_o, &mode_zp_o, 5 }, /* $47 sre $ff */
+    { &op_pha_o, &mode_imp_o, 3 },
+    { &op_eor_o, &mode_imm_o, 2 },
+    { &op_lsr_o, &mode_acc_o, 2 },
+    { &op_asr_o, &mode_imm_o, 2 }, /* $4b asr #$ff */
+    { &op_jmp_o, &mode_abs_o, 3 },
+    { &op_eor_o, &mode_abs_o, 4 },
+    { &op_lsr_o, &mode_abs_o, 6 },
+    { &op_sre_o, &mode_abs_o, 6 }, /* $4f sre $ffff */
+    /* 0x50 */
+    { &op_bvc_o, &mode_rel_o, 2 },
+    { &op_eor_o, &mode_indy_o, 5 },
+    NULL_OP,
+    NULL_OP,
+    { &op_nop_o, &mode_zpx_o, 4 }, /* $54 nop $ff,x */
+    { &op_eor_o, &mode_zpx_o, 4 }, /* fix: eor $ff,x takes 4 cycles*/
+    { &op_lsr_o, &mode_zpx_o, 6 },
+    { &op_sre_o, &mode_zpx_o, 6 }, /* $57 sre $ff,x */
+    { &op_cli_o, &mode_imp_o, 2 },
+    { &op_eor_o, &mode_absy_o, 4 },
+    { &op_nop_o, &mode_imp_o, 2 }, /* $5a nop */
+    { &op_sre_o, &mode_absy_o, 7 }, /* $5b sre $ffff,y */
+    { &op_nop_o, &mode_absx_o, 4 }, /* $5c nop $ffff,x */
+    { &op_eor_o, &mode_absx_o, 4 },
+    { &op_lsr_o, &mode_absx_o, 7 },
+    { &op_sre_o, &mode_absx_o, 7 }, /* $5f sre $ffff,x */
+    /* 0x60 */
+    { &op_rts_o, &mode_imp_o, 6 },
+    { &op_adc_o, &mode_indx_o, 6 },
+    NULL_OP,
+    { &op_rra_o, &mode_indx_o, 8 }, /* $63 rra ($ff,x) */
+    { &op_nop_o, &mode_zp_o, 3 }, /* $64 nop $ff */
+    { &op_adc_o, &mode_zp_o, 3 },
+    { &op_ror_o, &mode_zp_o, 5 },
+    { &op_rra_o, &mode_zp_o, 5 }, /* $67 rra $ff */
+    { &op_pla_o, &mode_imp_o, 4 },
+    { &op_adc_o, &mode_imm_o, 2 },
+    { &op_ror_o, &mode_acc_o, 2 },
+    NULL_OP, /* fix: $6b ARR (todo?) */
+    { &op_jmp_o, &mode_ind_o, 5 }, /* fix: $6c JMP ($FFFF) */
+    { &op_adc_o, &mode_abs_o, 4 },
+    { &op_ror_o, &mode_abs_o, 6 },
+    { &op_rra_o, &mode_abs_o, 6 }, /* $6f rra $ffff */
+    /* 0x70 */
+    { &op_bvs_o, &mode_rel_o, 2 },
+    { &op_adc_o, &mode_indy_o, 5 },
+    NULL_OP,
+    { &op_rra_o, &mode_indy_o, 8 }, /* $73 rra ($ff),y */
+    { &op_nop_o, &mode_zpx_o, 4 }, /* $74 nop $ff,x */
+    { &op_adc_o, &mode_zpx_o, 4 },
+    { &op_ror_o, &mode_zpx_o, 6 },
+    { &op_rra_o, &mode_zpx_o, 6 }, /* $77 rra $ff,x */
+    { &op_sei_o, &mode_imp_o, 2 },
+    { &op_adc_o, &mode_absy_o, 4 },
+    { &op_nop_o, &mode_imp_o, 2 }, /* $7a nop */
+    { &op_rra_o, &mode_absy_o, 7 }, /* $7b rra $ffff,y */
+    { &op_nop_o, &mode_absx_o, 4 }, /* $7c nop $ffff,x */
+    { &op_adc_o, &mode_absx_o, 4 },
+    { &op_ror_o, &mode_absx_o, 7 },
+    { &op_rra_o, &mode_absx_o, 7 }, /* $7f rra $ffff,x */
+    /* 0x80 */
+    { &op_nop_o, &mode_imm_o, 2 }, /* $80 nop #$ff */
+    { &op_sta_o, &mode_indx_o, 6 },
+    { &op_nop_o, &mode_imm_o, 2 }, /* $82 nop #$ff */
+    { &op_sax_o, &mode_indx_o, 6 }, /* $83 sax ($ff,x) */
+    { &op_sty_o, &mode_zp_o, 3 },
+    { &op_sta_o, &mode_zp_o, 3 },
+    { &op_stx_o, &mode_zp_o, 3 },
+    { &op_sax_o, &mode_zp_o, 3 }, /* $87 sax $ff */
+    { &op_dey_o, &mode_imp_o, 2 },
+    { &op_nop_o, &mode_imm_o, 2 }, /* $89 nop #$ff */
+    { &op_txa_o, &mode_imp_o, 2 },
+    { &op_ane_o, &mode_imm_o, 2 }, /* $8b ane #$ff */
+    { &op_sty_o, &mode_abs_o, 4 },
+    { &op_sta_o, &mode_abs_o, 4 },
+    { &op_stx_o, &mode_abs_o, 4 },
+    { &op_sax_o, &mode_abs_o, 4 }, /* $8f sax $ffff */
+    /* 0x90 */
+    { &op_bcc_o, &mode_rel_o, 2 },
+    { &op_sta_o, &mode_indy_o, 6 },
+    NULL_OP,
+    NULL_OP,
+    { &op_sty_o, &mode_zpx_o, 4 },
+    { &op_sta_o, &mode_zpx_o, 4 },
+    { &op_stx_o, &mode_zpy_o, 4 },
+    { &op_sax_o, &mode_zpy_o, 4 }, /* $97 sax $ff,y */
+    { &op_tya_o, &mode_imp_o, 2 },
+    { &op_sta_o, &mode_absy_o, 5 },
+    { &op_txs_o, &mode_imp_o, 2 },
+    NULL_OP,
+    NULL_OP,
+    { &op_sta_o, &mode_absx_o, 5 },
+    NULL_OP,
+    NULL_OP,
+    /* 0xa0 */
+    { &op_ldy_o, &mode_imm_o, 2 },
+    { &op_lda_o, &mode_indx_o, 6 },
+    { &op_ldx_o, &mode_imm_o, 2 },
+    { &op_lax_o, &mode_indx_o, 6 }, /* $a3 lax ($ff,x) */
+    { &op_ldy_o, &mode_zp_o, 3 },
+    { &op_lda_o, &mode_zp_o, 3 },
+    { &op_ldx_o, &mode_zp_o, 3 },
+    { &op_lax_o, &mode_zp_o, 3 }, /* $a7 lax $ff */
+    { &op_tay_o, &mode_imp_o, 2 },
+    { &op_lda_o, &mode_imm_o, 2 },
+    { &op_tax_o, &mode_imp_o, 2 },
+    { &op_lxa_o, &mode_imm_o, 2 }, /* $ab lxa #$ff */
+    { &op_ldy_o, &mode_abs_o, 4 },
+    { &op_lda_o, &mode_abs_o, 4 },
+    { &op_ldx_o, &mode_abs_o, 4 },
+    { &op_lax_o, &mode_abs_o, 4 }, /* $af lax $ffff */
+    /* 0xb0 */
+    { &op_bcs_o, &mode_rel_o, 2 },
+    { &op_lda_o, &mode_indy_o, 5 },
+    NULL_OP,
+    { &op_lax_o, &mode_indy_o, 5 }, /* $b3 lax ($ff),y */
+    { &op_ldy_o, &mode_zpx_o, 4 },
+    { &op_lda_o, &mode_zpx_o, 4 },
+    { &op_ldx_o, &mode_zpy_o, 4 },
+    { &op_lax_o, &mode_zpy_o, 4 }, /* $b7 lax $ff,y */
+    { &op_clv_o, &mode_imp_o, 2 },
+    { &op_lda_o, &mode_absy_o, 4 },
+    { &op_tsx_o, &mode_imp_o, 2 },
+    { &op_lae_o, &mode_absy_o, 4 }, /* $bb lae $ffff,y */
+    { &op_ldy_o, &mode_absx_o, 4 },
+    { &op_lda_o, &mode_absx_o, 4 },
+    { &op_ldx_o, &mode_absy_o, 4 },
+    { &op_lax_o, &mode_absy_o, 4 }, /* $bf lax $ffff,y */
+    /* 0xc0 */
+    { &op_cpy_o, &mode_imm_o, 2 },
+    { &op_cmp_o, &mode_indx_o, 6 },
+    { &op_nop_o, &mode_imm_o, 2 }, /* $c2 nop #$ff */
+    { &op_dcp_o, &mode_indx_o, 8 }, /* $c3 dcp ($ff,x) */
+    { &op_cpy_o, &mode_zp_o, 3 },
+    { &op_cmp_o, &mode_zp_o, 3 },
+    { &op_dec_o, &mode_zp_o, 5 },
+    { &op_dcp_o, &mode_zp_o, 5 }, /* $c7 dcp $FF */
+    { &op_iny_o, &mode_imp_o, 2 },
+    { &op_cmp_o, &mode_imm_o, 2 },
+    { &op_dex_o, &mode_imp_o, 2 },
+    { &op_sbx_o, &mode_imm_o, 2 }, /* $cb sbx #$ff */
+    { &op_cpy_o, &mode_abs_o, 4 },
+    { &op_cmp_o, &mode_abs_o, 4 },
+    { &op_dec_o, &mode_abs_o, 6 },
+    { &op_dcp_o, &mode_abs_o, 6 }, /* $cf dcp $ffff */
+    /* 0xd0 */
+    { &op_bne_o, &mode_rel_o, 2 },
+    { &op_cmp_o, &mode_indy_o, 5 },
+    NULL_OP,
+    { &op_dcp_o, &mode_indy_o, 8 }, /* $d3 dcp ($ff),y */
+    { &op_nop_o, &mode_zpx_o, 4 }, /* $d4 nop $ff,x */
+    { &op_cmp_o, &mode_zpx_o, 4 },
+    { &op_dec_o, &mode_zpx_o, 6 },
+    { &op_dcp_o, &mode_zpx_o, 6 }, /* $d7 dcp $ff,x */
+    { &op_cld_o, &mode_imp_o, 2 },
+    { &op_cmp_o, &mode_absy_o, 4 },
+    { &op_nop_o, &mode_imp_o, 2 }, /* $da nop */
+    { &op_dcp_o, &mode_absy_o, 7 }, /* $db dcp $ffff,y */
+    { &op_nop_o, &mode_absx_o, 4 }, /* $dc nop $ffff,x */
+    { &op_cmp_o, &mode_absx_o, 4 },
+    { &op_dec_o, &mode_absx_o, 7 },
+    { &op_dcp_o, &mode_absx_o, 7 }, /* $df dcp $ffff,x */
+    /* 0xe0 */
+    { &op_cpx_o, &mode_imm_o, 2 },
+    { &op_sbc_o, &mode_indx_o, 6 },
+    { &op_nop_o, &mode_imm_o, 2 }, /* $e2 nop #$ff */
+    { &op_isb_o, &mode_indx_o, 8 }, /* $e3 isb ($ff,x) */
+    { &op_cpx_o, &mode_zp_o, 3 },
+    { &op_sbc_o, &mode_zp_o, 3 },
+    { &op_inc_o, &mode_zp_o, 5 },
+    { &op_isb_o, &mode_zp_o, 5 }, /* $e7 isb $ff */
+    { &op_inx_o, &mode_imp_o, 2 },
+    { &op_sbc_o, &mode_imm_o, 2 },
+    { &op_nop_o, &mode_imp_o, 2 },
+    { &op_sbc_o, &mode_imm_o, 2 }, /* $eb sbc #$ff */
+    { &op_cpx_o, &mode_abs_o, 4 },
+    { &op_sbc_o, &mode_abs_o, 4 },
+    { &op_inc_o, &mode_abs_o, 6 },
+    { &op_isb_o, &mode_abs_o, 6 }, /* $ef isb $ffff */
+    /* 0xf0 */
+    { &op_beq_o, &mode_rel_o, 2 },
+    { &op_sbc_o, &mode_indy_o, 5 },
+    NULL_OP,
+    { &op_isb_o, &mode_indy_o, 8 }, /* $f3 isb ($ff),y */
+    { &op_nop_o, &mode_zpx_o, 4 }, /* $f4 nop $ff,x */
+    { &op_sbc_o, &mode_zpx_o, 4 },
+    { &op_inc_o, &mode_zpx_o, 6 },
+    { &op_isb_o, &mode_zpx_o, 6 }, /* $f7 isb $ff,x */
+    { &op_sed_o, &mode_imp_o, 2 },
+    { &op_sbc_o, &mode_absy_o, 4 },
+    { &op_nop_o, &mode_imp_o, 2 }, /* $fa nop */
+    { &op_isb_o, &mode_absy_o, 7 }, /* $fb isb $ffff,y */
+    { &op_nop_o, &mode_absx_o, 7 }, /* $fc nop $ffff,x */
+    { &op_sbc_o, &mode_absx_o, 4 },
+    { &op_inc_o, &mode_absx_o, 7 },
+    { &op_isb_o, &mode_absx_o, 7 }, /* $ff isb $ffff,x */
+};
+
+int byted011[2] = { 0, 0 };
+int next_inst(struct cpu_ctx *r)
+{
+    union inst_arg arg[1];
+    int oldpc = r->pc;
+    int op_code = r->mem[r->pc];
+    struct inst_info *info = ops + op_code;
+    int mode, WriteToIO = 0;
+    int bt = 0, br;
+    if (info->op == NULL) {
+        fprintf(stderr, "unimplemented opcode $%02X @ $%04X\n", op_code, r->pc);
+        return 1;
+        //        exit(1);
+    }
+    //    LOG(LOG_DUMP, ("%02x %02x %02x %02x %02x: ", r->a, r->x, r->y,
+    //    r->sp,r->flags));
+    mode = info->mode->f(r, arg);
+
+    /* iAN: only if RAM is not visible there! */
+    if (((r->mem[1] & 0x7) >= 0x5) && ((r->mem[1] & 0x07) <= 0x7)) {
+        if (arg->ea.value >= 0xd000 && arg->ea.value < 0xe000) {
+            /* is this an absolute sta, stx or sty to the IO-area? */
+            /* iAN: added all possible writing opcodes */
+            if (op_code == 0x0E || /*ASL $ffff  */
+                op_code == 0x1E || /*ASL $ffff,X*/
+                op_code == 0xCE || /*DEC $ffff  */
+                op_code == 0xDE || /*DEC $ffff,X*/
+                op_code == 0xEE || /*INC $ffff  */
+                op_code == 0xFE || /*INC $ffff,X*/
+                op_code == 0x4E || /*LSR $ffff  */
+                op_code == 0x5E || /*LSR $ffff,X*/
+                op_code == 0x2E || /*ROL $ffff  */
+                op_code == 0x3E || /*ROL $ffff,X*/
+                op_code == 0x6E || /*ROR $ffff  */
+                op_code == 0x7E || /*ROR $ffff,X*/
+                op_code == 0x8D || /*STA $ffff  */
+                op_code == 0x9D || /*STA $ffff,X*/
+                op_code == 0x99 || /*STA $ffff,Y*/
+                op_code == 0x91 || /*STA ($ff),Y*/
+                op_code == 0x8E || /*STX $ffff  */
+                op_code == 0x8C /*STY $ffff  */
+            ) {
+                r->cycles += ops[op_code].cycles;
+                /* ignore it, its probably an effect */
+                /* try to keep updated at least a copy of $d011 */
+                if (arg->ea.value == 0xd011) {
+                    switch (op_code) {
+                    case 0x8D:
+                        byted011[0] = r->a & 0x7f;
+                        break;
+                    case 0x8E:
+                        byted011[0] = r->x & 0x7f;
+                        break;
+                    case 0x8C:
+                        byted011[0] = r->y & 0x7f;
+                        break;
+                    default:
+                        break;
+                    }
+                }
+                WriteToIO = 1;
+            } else {
+                byted011[1] = (r->cycles / 0x3f) % 0x157;
+                byted011[0] = (byted011[0] & 0x7f) | ((byted011[1] & 0x100) >> 1);
+                byted011[1] &= 0xff;
+                switch (op_code) {
+                case 0xad:
+                case 0xaf: /* lda $ffff / lax $ffff */
+
+                    if ((arg->ea.value == 0xd011) || (arg->ea.value == 0xd012)) {
+                        r->cycles += ops[op_code].cycles;
+                        r->a = byted011[arg->ea.value - 0xd011];
+                        if (op_code == 0xaf)
+                            r->x = r->a;
+                        update_flags_nz(r, r->a);
+                        WriteToIO = 5;
+                        break;
+                    }
+
+                    /* intros: simulate space */
+                    if (arg->ea.value == 0xdc00 || arg->ea.value == 0xdc01) {
+                        r->cycles += ops[op_code].cycles;
+                        if (arg->ea.value == 0xdc00)
+                            r->a = flipfire();
+                        else
+                            r->a = flipspace();
+                        if (op_code == 0xaf)
+                            r->x = r->a;
+                        update_flags_nz(r, r->a);
+                        WriteToIO = 6;
+                        break;
+                    }
+
+                    if (arg->ea.value >= 0xdd01 && arg->ea.value <= 0xdd0f) {
+                        r->cycles += ops[op_code].cycles;
+                        r->a = 0xff;
+                        if (op_code == 0xaf)
+                            r->x = r->a;
+                        update_flags_nz(r, r->a);
+                        WriteToIO = 2;
+                        break;
+                    }
+                    break;
+                case 0x2d: /* and $ffff */
+
+                    /* intros: simulate space */
+                    if (arg->ea.value == 0xdc00 || arg->ea.value == 0xdc01) {
+                        r->cycles += ops[op_code].cycles;
+                        if (arg->ea.value == 0xdc00)
+                            r->a &= flipfire();
+                        else
+                            r->a &= flipspace();
+
+                        update_flags_nz(r, r->a);
+                        WriteToIO = 6;
+                        break;
+                    }
+                    break;
+                case 0xae: /* ldx $ffff */
+
+                    if ((arg->ea.value == 0xd011) || (arg->ea.value == 0xd012)) {
+                        r->cycles += ops[op_code].cycles;
+                        r->x = byted011[arg->ea.value - 0xd011];
+                        update_flags_nz(r, r->x);
+                        WriteToIO = 5;
+                        break;
+                    }
+                    if (arg->ea.value == 0xdc00 || arg->ea.value == 0xdc01) {
+                        r->cycles += ops[op_code].cycles;
+                        if (arg->ea.value == 0xdc00)
+                            r->x = flipfire();
+                        else
+                            r->x = flipspace();
+                        update_flags_nz(r, r->x);
+                        WriteToIO = 6;
+                        break;
+                    }
+                    break;
+                case 0xac: /* ldy $ffff */
+
+                    if ((arg->ea.value == 0xd011) || (arg->ea.value == 0xd012)) {
+                        r->cycles += ops[op_code].cycles;
+                        r->y = byted011[arg->ea.value - 0xd011];
+                        update_flags_nz(r, r->y);
+                        WriteToIO = 5;
+                        break;
+                    }
+                    if (arg->ea.value == 0xdc00 || arg->ea.value == 0xdc01) {
+                        r->cycles += ops[op_code].cycles;
+                        if (arg->ea.value == 0xdc00)
+                            r->y = flipfire();
+                        else
+                            r->y = flipspace();
+                        update_flags_nz(r, r->y);
+                        WriteToIO = 6;
+                        break;
+                    }
+                    break;
+
+                case 0x2c: /* bit $d011 */
+
+                    if ((arg->ea.value == 0xd011) || (arg->ea.value == 0xd012)) {
+                        r->cycles += ops[op_code].cycles;
+                        bt = byted011[arg->ea.value - 0xd011];
+                        r->flags &= ~(FLAG_N | FLAG_V | FLAG_Z);
+                        r->flags |= (bt & FLAG_N) != 0 ? FLAG_N : 0;
+                        r->flags |= (bt & FLAG_V) != 0 ? FLAG_V : 0;
+                        r->flags |= (bt & r->a) == 0 ? FLAG_Z : 0;
+                        WriteToIO = 3;
+                    }
+                    break;
+
+                case 0xcd: /* cmp $ffff */
+                case 0xec: /* cpx $ffff */
+                case 0xcc: /* cpy $ffff */
+                    if ((arg->ea.value == 0xd011) || (arg->ea.value == 0xd012)) {
+                        r->cycles += ops[op_code].cycles;
+                        bt = byted011[arg->ea.value - 0xd011];
+                        br = r->a;
+                        if (op_code == 0xec)
+                            br = r->x;
+                        if (op_code == 0xcc)
+                            br = r->y;
+                        subtract(r, 1, br, bt);
+                        WriteToIO = 4;
+                        break;
+                    }
+                    /* intros: simulate space */
+                    if (arg->ea.value == 0xdc00 || arg->ea.value == 0xdc01) {
+                        r->cycles += ops[op_code].cycles;
+                        br = r->a;
+                        if (op_code == 0xec)
+                            br = r->x;
+                        if (op_code == 0xcc)
+                            br = r->y;
+                        if (arg->ea.value == 0xdc00)
+                            bt = flipfire();
+                        else
+                            bt = flipspace();
+                        subtract(r, 1, br, bt);
+                        WriteToIO = 6;
+                        break;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    if (IS_LOGGABLE(LOG_DUMP)) {
+        //        LOG(LOG_DUMP, ("%04x %s", oldpc, info->op->fmt));
+
+        if (info->mode->fmt != NULL) {
+            int value = 0;
+            int pc = r->pc;
+            while (--pc > oldpc) {
+                value <<= 8;
+                value |= r->mem[pc];
+            }
+            //            LOG(LOG_DUMP, (" "));
+            if (mode == MODE_RELATIVE) {
+                //                LOG(LOG_DUMP, ("$%04x", r->pc + arg->rel.value));
+            } else {
+                //                LOG(LOG_DUMP, (info->mode->fmt, value));
+            }
+            switch (mode) {
+            case MODE_RELATIVE:
+            case MODE_IMPLIED:
+            case MODE_ACCUMULATOR:
+            case MODE_IMMEDIATE:
+            case MODE_ABSOLUTE:
+                break;
+            default:
+                fprintf(stderr, " ($%04x)", arg->ea.value);
+            }
+        }
+        switch (WriteToIO) {
+        case 1:
+            //            LOG(LOG_DUMP, (" write to IO, skipped\n"));
+            break;
+        }
+        //        LOG(LOG_DUMP, ("\n"));
+    }
+    if (WriteToIO) {
+        if (debugprint) {
+            switch (WriteToIO) {
+            case 2:
+                fprintf(stderr, "\nLDA $%04X -> $ff forced\n", arg->ea.value);
+                break;
+            case 6:
+                fprintf(stderr, "\nLDA $DC01->space %s\n",
+                    (retspace == 0xef ? "pressed" : "released"));
+                break;
+            }
+        }
+        return 0;
+    }
+    info->op->f(r, mode, arg);
+    r->cycles += info->cycles;
+    if (op_code == 0) {
+        fprintf(stderr, "\nBRK reached @ $%04X\n", r->pc - 1);
+        //        exit(1);
+        return 1;
+    }
+    return 0;
+}

--- a/terps/unp64/6502emu.h
+++ b/terps/unp64/6502emu.h
@@ -1,0 +1,46 @@
+#ifndef ALREADY_INCLUDED_6502EMU
+#define ALREADY_INCLUDED_6502EMU
+
+/*
+ * Copyright (c) 2007 - 2008 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+#include "int.h"
+
+struct cpu_ctx {
+  u32 cycles;
+  u16 pc;
+  u8 *mem;
+  u8 sp;
+  u8 flags;
+  u8 a;
+  u8 x;
+  u8 y;
+};
+
+int next_inst(struct cpu_ctx *r);
+
+#endif

--- a/terps/unp64/CMakeLists.txt
+++ b/terps/unp64/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(unp64 STATIC 6502emu.c exo_util.c log.c unp64.c
+    scanners/_Scanners.c scanners/1001card.c scanners/AbuzeCrunch.c
+    scanners/ActionPacker.c scanners/ByteBoiler.c scanners/Caution.c
+    scanners/CCS.c scanners/Cruel.c scanners/ECA.c scanners/Exomizer.c
+    scanners/Expert.c scanners/FinalSuperComp.c scanners/Intros.c
+    scanners/MasterCompressor.c scanners/Megabyte.c scanners/MrCross.c
+    scanners/MrZ.c scanners/PuCrunch.c scanners/Section8.c
+    scanners/TBCMultiComp.c scanners/TCScrunch.c scanners/XTC.c)
+
+c_standard(unp64 11)
+warnings(unp64)
+
+target_include_directories(unp64 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/terps/unp64/exo_util.c
+++ b/terps/unp64/exo_util.c
@@ -1,27 +1,27 @@
+/* Code from Exomizer distributed under the zlib License
+ * by kind permission of the original author
+ * Magnus Lind.
+ */
+
 /*
- * Copyright (c) 2008 Magnus Lind.
+ * Copyright (c) 2008 - 2023 Magnus Lind.
  *
- * This software is provided 'as-is', without any express or implied warranty.
- * In no event will the authors be held liable for any damages arising from
- * the use of this software.
  *
- * Permission is granted to anyone to use this software, alter it and re-
- * distribute it freely for any non-commercial, non-profit purpose subject to
- * the following restrictions:
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
- *   1. The origin of this software must not be misrepresented; you must not
- *   claim that you wrote the original software. If you use this software in a
- *   product, an acknowledgment in the product documentation would be
- *   appreciated but is not required.
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
  *
- *   2. Altered source versions must be plainly marked as such, and must not
- *   be misrepresented as being the original software.
- *
- *   3. This notice may not be removed or altered from any distribution.
- *
- *   4. The names of this software and/or it's copyright holders may not be
- *   used to endorse or promote products derived from this software without
- *   specific prior written permission.
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
  *
  */
 

--- a/terps/unp64/exo_util.c
+++ b/terps/unp64/exo_util.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2008 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "exo_util.h"
+
+int find_sys(const unsigned char *buf, int target)
+{
+    int outstart = -1;
+    int state = 1;
+    int i = 0;
+    /* skip link and line number */
+    buf += 4;
+    /* iAN: workaround for hidden sysline (1001 cruncher, CFB, etc)*/
+    if (buf[0] == 0) {
+        for (i = 5; i < 32; i++)
+            if (buf[i] == 0x9e && (((buf[i + 1] & 0x30) == 0x30) || ((buf[i + 2] & 0x30) == 0x30)))
+                break;
+    }
+    /* exit loop at line end */
+    while (i < 1000 && buf[i] != '\0') {
+        unsigned char *sys_end;
+        int c = buf[i];
+        switch (state) {
+            /* look for and consume sys token */
+        case 1:
+            if ((target == -1 && (c == 0x9e /* cbm */ /* ||
+                             c == 0x8c*/
+                     /* apple 2*/ /* ||
+                        c == 0xbf*/
+                     /* oric 1*/))
+                || c == target) {
+                state = 2;
+            }
+            break;
+            /* skip spaces and left parenthesis, if any */
+        case 2:
+            if (strchr(" (", c) != NULL)
+                break;
+            /* convert string number to int */
+        case 3:
+            outstart = (int)strtol((const char *)(buf + i), (void *)&sys_end, 10);
+            if ((buf + i) == sys_end) {
+                /* we got nothing */
+                outstart = -1;
+            } else {
+                c = *sys_end;
+                if ((c >= 0xaa) && (c <= 0xae)) {
+                    i = (int)strtol((char *)(sys_end + 1), (void *)&sys_end, 10);
+                    switch (c) {
+                    case 0xaa:
+                        outstart += i;
+                        break;
+                    case 0xab:
+                        outstart -= i;
+                        break;
+                    case 0xac:
+                        outstart *= i;
+                        break;
+                    case 0xad:
+                        if (i > 0)
+                            outstart /= i;
+                        break;
+                    case 0xae:
+                        c = outstart;
+                        while (--i)
+                            outstart *= c;
+                        break;
+                    }
+                } else if (c == 'E') {
+                    i = (int)strtol((char *)(sys_end + 1), (void *)&sys_end, 10);
+                    i++;
+                    while (--i)
+                        outstart *= 10;
+                }
+            }
+            state = 4;
+            break;
+        case 4:
+            break;
+        }
+        ++i;
+    }
+
+    LOG(LOG_DEBUG, ("state when leaving: %d.\n", state));
+    return outstart;
+}
+
+static int get_byte(FILE *in)
+{
+    int byte = fgetc(in);
+    if (byte == EOF) {
+        // LOG(LOG_ERROR, ("Error: unexpected end of xex-file."));
+        fclose(in);
+        exit(-1);
+    }
+    return byte;
+}
+
+static int get_le_word(FILE *in)
+{
+    int word = get_byte(in);
+    word |= get_byte(in) << 8;
+    return word;
+}
+//#if 0
+// static int get_be_word(FILE *in)
+//{
+//    int word = get_byte(in) << 8;
+//    word |= get_byte(in);
+//    return word;
+//}
+//#endif
+
+static FILE *open_file(char *name, int *load_addr)
+{
+    FILE *in;
+    int is_plain = 0;
+    int is_relocated = 0;
+    int load = -3;
+
+    do {
+        char *load_str;
+        char *at_str;
+
+        in = fopen(name, "rb");
+        if (in != NULL) {
+            /* We have succeded in opening the file.
+       * There's no address suffix. */
+            break;
+        }
+
+        /* hmm, let's see if the user is trying to relocate it */
+        load_str = strrchr(name, ',');
+        at_str = strrchr(name, '@');
+        if (at_str != NULL && (load_str == NULL || at_str > load_str)) {
+            is_plain = 1;
+            load_str = at_str;
+        }
+
+        if (load_str == NULL) {
+            /* nope, */
+            break;
+        }
+
+        *load_str = '\0';
+        ++load_str;
+        is_relocated = 1;
+
+        /* relocation was requested */
+        if (str_to_int(load_str, &load) != 0) {
+            /* we fail */
+            LOG(LOG_FATAL, (" can't parse load address from \"%s\"\n", load_str));
+            exit(-1);
+        }
+
+        in = fopen(name, "rb");
+
+    } while (0);
+    if (in == NULL) {
+        LOG(LOG_FATAL, (" can't open file \"%s\" for input\n", name));
+        exit(-1);
+    }
+
+    if (!is_plain) {
+        /* read the prg load address */
+        int prg_load = get_le_word(in);
+        if (!is_relocated) {
+            load = prg_load;
+            //#if 0
+            //            /* unrelocated prg loading to $ffff is xex */
+            //            if(prg_load == 0xffff)
+            //            {
+            //                /* differentiate this from relocated $ffff files so it
+            //                is
+            //                 * possible to override the xex auto-detection. */
+            //                load = -1;
+            //            }
+            //            /* unrelocated prg loading to $1616 is Oric tap */
+            //            else if(prg_load == 0x1616)
+            //            {
+            //                load = -2;
+            //            }
+            //#endif
+        }
+    }
+
+    if (load_addr != NULL) {
+        *load_addr = load;
+    }
+    return in;
+}
+
+//#if 0
+// static void load_xex(unsigned char mem[65536], FILE *in,
+//                     struct load_info *info)
+//{
+//    int run = -1;
+//    int jsr = -1;
+//    int min = 65536, max = 0;
+//
+//    goto initial_state;
+//    for(;;)
+//    {
+//        int start, end, len;
+//
+//        start = fgetc(in);
+//        if(start == EOF) break;
+//        ungetc(start, in);
+//
+//        start = get_le_word(in);
+//        if(start == 0xffff)
+//        {
+//            /* allowed optional header */
+//        initial_state:
+//            start = get_le_word(in);
+//        }
+//        end = get_le_word(in);
+//        if(start > 0xffff || end > 0xffff || end < start)
+//        {
+//            LOG(LOG_ERROR, ("Error: corrupt data in xex-file."));
+//            fclose(in);
+//            exit(-1);
+//        }
+//        if(start == 0x2e2 && end == 0x2e3)
+//        {
+//            /* init vector */
+//            jsr = get_le_word(in);
+//            LOG(LOG_VERBOSE, ("Found xex initad $%04X.\n", jsr));
+//            continue;
+//        }
+//        if(start == 0x2e0 && end == 0x2e1)
+//        {
+//            /* run vector */
+//            run = get_le_word(in);
+//            LOG(LOG_VERBOSE, ("Found xex runad $%04X.\n", run));
+//            continue;
+//        }
+//        ++end;
+//        jsr = -1;
+//        if(start < min) min = start;
+//        if(end > max) max = end;
+//
+//        len = fread(mem + start, 1, end - start, in);
+//        if(len != end - start)
+//        {
+//            LOG(LOG_ERROR, ("Error: unexpected end of xex-file.\n"));
+//            fclose(in);
+//            exit(-1);
+//        }
+//        LOG(LOG_VERBOSE, (" xex chunk loading from $%04X to $%04X\n",
+//                          start, end));
+//    }
+//
+//    if(run == -1 && jsr != -1) run = jsr;
+//
+//    info->start = min;
+//    info->end = max;
+//    info->basic_var_start = -1;
+//    info->run = -1;
+//    if(run != -1)
+//    {
+//        info->run = run;
+//    }
+//}
+//
+// static void load_oric_tap(unsigned char mem[65536], FILE *in,
+//                          struct load_info *info)
+//{
+//    int c;
+//    int autostart;
+//    int start, end, len;
+//
+//    /* read oric tap header */
+//
+//    /* next byte must be 0x16 as we have already read two and must
+//     * have at least three */
+//    if(get_byte(in) != 0x16)
+//    {
+//        LOG(LOG_ERROR, ("Error: fewer than three lead-in bytes ($16) "
+//                        "in Oric tap-file header.\n"));
+//        fclose(in);
+//        exit(-1);
+//    }
+//    /* optionally more 0x16 bytes */
+//    while((c = get_byte(in)) == 0x16);
+//    /* next byte must be 0x24 */
+//    if(c != 0x24)
+//    {
+//        LOG(LOG_ERROR, ("Error: bad sync byte after lead-in in Oric tap-file "
+//                        "header, got $%02X but expected $24\n", c));
+//        fclose(in);
+//        exit(-1);
+//    }
+//
+//    /* now we are in sync, lets be lenient */
+//    get_byte(in); /* should be 0x0 */
+//    get_byte(in); /* should be 0x0 */
+//    get_byte(in); /* should be 0x0 or 0x80 */
+//    autostart = (get_byte(in) != 0);  /* should be 0x0, 0x80 or 0xc7 */
+//    end = get_be_word(in) + 1; /* the header end address is inclusive */
+//    start = get_be_word(in);
+//    get_byte(in); /* should be 0x0 */
+//    /* read optional file name */
+//    while(get_byte(in) != 0x0);
+//
+//    /* read the data */
+//    len = fread(mem + start, 1, end - start, in);
+//    if(len != end - start)
+//    {
+//        LOG(LOG_BRIEF, ("Warning: Oric tap-file contains %d byte(s) data "
+//                        "less than expected.\n", end - start - len));
+//        end = start + len;
+//    }
+//    LOG(LOG_VERBOSE, (" Oric tap-file loading from $%04X to $%04X\n",
+//                      start, end));
+//
+//    /* fill in the fields */
+//    info->start = start;
+//    info->end = end;
+//    info->run = -1;
+//    info->basic_var_start = -1;
+//    if(autostart)
+//    {
+//        info->run = start;
+//    }
+//    if(info->basic_txt_start >= start &&
+//       info->basic_txt_start < end)
+//    {
+//        info->basic_var_start = end - 1;
+//    }
+//}
+//#endif
+static void load_prg(unsigned char mem[65536], FILE *in,
+    struct load_info *info)
+{
+    int len;
+    len = (int)fread(mem + info->start, 1, 65536 - info->start, in);
+
+    info->end = info->start + len;
+    info->basic_var_start = -1;
+    info->run = -1;
+    if (info->basic_txt_start >= info->start && info->basic_txt_start < info->end) {
+        info->basic_var_start = info->end;
+    }
+}
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+static void load_prg_data(unsigned char mem[65536], uint8_t *data,
+    size_t data_length, struct load_info *info)
+{
+    int len = MIN(65536 - info->start, (int)data_length);
+    memcpy(mem + info->start, data, len);
+
+    info->end = info->start + len;
+    info->basic_var_start = -1;
+    info->run = -1;
+    if (info->basic_txt_start >= info->start && info->basic_txt_start < info->end) {
+        info->basic_var_start = info->end;
+    }
+}
+
+void load_located(char *filename, unsigned char mem[65536],
+    struct load_info *info)
+{
+    int load;
+    FILE *in;
+
+    in = open_file(filename, &load);
+#if 0
+    if(load == -1)
+    {
+        /* file is an xex file */
+        load_xex(mem, in, info);
+    }
+    else if(load == -2)
+    {
+        /* file is an oric tap file */
+        load_oric_tap(mem, in, info);
+    }
+    else
+#endif
+    {
+        /* file is a located plain file or a prg file */
+        info->start = load;
+        load_prg(mem, in, info);
+    }
+    fclose(in);
+
+    LOG(LOG_NORMAL, (" filename: \"%s\", loading from $%04X to $%04X\n", filename, info->start, info->end));
+}
+
+void load_data(uint8_t *data, size_t data_length, unsigned char mem[65536],
+    struct load_info *info)
+{
+    int load = data[0] + data[1] * 0x100;
+
+    info->start = load;
+    load_prg_data(mem, data + 2, data_length - 2, info);
+
+    //    LOG(LOG_NORMAL,
+    //        ("loading data from $%04X to $%04X\n",
+    //         info->start, info->end));
+}
+
+/* returns 0 if ok, 1 otherwise */
+int str_to_int(const char *str, int *value)
+{
+    int status = 0;
+    do {
+        char *str_end;
+        long lval;
+
+        /* base 0 is auto detect */
+        int base = 0;
+
+        if (*str == '\0') {
+            /* no string to parse */
+            status = 1;
+            break;
+        }
+
+        if (*str == '$') {
+            /* a $ prefix specifies base 16 */
+            ++str;
+            base = 16;
+        }
+
+        lval = strtol(str, &str_end, base);
+
+        if (*str_end != '\0') {
+            /* there is garbage in the string */
+            status = 1;
+            break;
+        }
+
+        if (value != NULL) {
+            /* all is well, set the out parameter */
+            *value = (int)lval;
+        }
+    } while (0);
+
+    return status;
+}
+
+const char *fixup_appl(char *appl)
+{
+    char *applp;
+
+    /* strip pathprefix from appl */
+    applp = strrchr(appl, '\\');
+    if (applp != NULL) {
+        appl = applp + 1;
+    }
+    applp = strrchr(appl, '/');
+    if (applp != NULL) {
+        appl = applp + 1;
+    }
+    /* strip possible exe suffix */
+    applp = appl + strlen(appl) - 4;
+    if (strcmp(applp, ".exe") == 0 || strcmp(applp, ".EXE") == 0) {
+        *applp = '\0';
+    }
+    return appl;
+}

--- a/terps/unp64/exo_util.h
+++ b/terps/unp64/exo_util.h
@@ -1,0 +1,60 @@
+#ifndef EXO_UTIL_ALREADY_INCLUDED
+#define EXO_UTIL_ALREADY_INCLUDED
+
+/*
+ * Copyright (c) 2008 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+#include <stdint.h>
+
+#include "log.h"
+#include "membuf.h"
+
+/*
+ * target is the basic token for the sys/call basic command
+ * it may be -1 for hardcoded detection of a few targets.
+ */
+int find_sys(const unsigned char *buf, int target);
+
+struct load_info {
+  int basic_txt_start; /* in */
+  int basic_var_start; /* out */
+  int run;             /* out */
+  int start;           /* out */
+  int end;             /* out */
+};
+
+void load_located(char *filename, unsigned char mem[65536],
+                  struct load_info *info);
+
+void load_data(uint8_t *data, size_t data_length, unsigned char mem[65536],
+               struct load_info *info);
+
+int str_to_int(const char *str, int *value);
+
+const char *fixup_appl(char *appl);
+
+#endif

--- a/terps/unp64/int.h
+++ b/terps/unp64/int.h
@@ -1,0 +1,39 @@
+#ifndef INCLUDED_INT
+#define INCLUDED_INT
+
+/*
+ * Copyright (c) 2005 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+typedef signed char i8;
+typedef signed short int i16;
+typedef signed int i32;
+
+typedef unsigned char u8;
+typedef unsigned short int u16;
+typedef unsigned int u32;
+
+#endif

--- a/terps/unp64/log.c
+++ b/terps/unp64/log.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2002, 2003 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * This file is a part of the Exomizer v1.1 release
+ *
+ */
+
+#include "log.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef WIN32
+#define vsnprintf _vsnprintf
+#endif
+#ifdef DJGPP
+#define vsnprintf(A, B, C, D) vsprintf((A), (C), (D))
+#endif
+
+struct log_output {
+    enum log_level min;
+    enum log_level max;
+    FILE *stream;
+    log_formatter_f *f;
+};
+
+struct log_ctx {
+    enum log_level level;
+    int out_len;
+    struct log_output *out;
+    int buf_len;
+    char *buf;
+};
+
+struct log_ctx *G_log_ctx = NULL;
+enum log_level G_log_level = 0;
+enum log_level G_log_log_level = 0;
+
+struct log_ctx *log_new(void)
+{
+    struct log_ctx *ctx;
+
+    ctx = malloc(sizeof(*ctx));
+    if (ctx == NULL) {
+        fprintf(stderr, "fatal error, can't allocate memory for log context\n");
+        exit(1);
+    }
+    ctx->level = LOG_NORMAL;
+    ctx->out_len = 0;
+    ctx->out = NULL;
+    ctx->buf_len = 0;
+    ctx->buf = NULL;
+
+    return ctx;
+}
+
+/* log_delete closes all added output streams
+ * and files except for stdout and stderr
+ */
+void log_delete(struct log_ctx *ctx)
+{
+    int i;
+
+    for (i = 0; i < ctx->out_len; ++i) {
+        FILE *file = ctx->out[i].stream;
+        if (file != stderr && file != stdout) {
+            fclose(file);
+        }
+    }
+    free(ctx->out);
+    free(ctx->buf);
+    free(ctx);
+}
+
+void log_set_level(struct log_ctx *ctx, /* IN/OUT */
+    enum log_level level) /* IN */
+{
+    ctx->level = level;
+}
+
+void log_add_output_stream(struct log_ctx *ctx, /* IN/OUT */
+    enum log_level min, /* IN */
+    enum log_level max, /* IN */
+    log_formatter_f *default_f, /* IN */
+    FILE *out_stream) /* IN */
+{
+    struct log_output *out;
+
+    ctx->out_len++;
+    ctx->out = realloc(ctx->out, ctx->out_len * sizeof(*(ctx->out)));
+    if (ctx->out == NULL) {
+        fprintf(stderr, "fatal error, can't allocate memory for log output\n");
+        exit(1);
+    }
+    out = &(ctx->out[ctx->out_len - 1]);
+    out->min = min;
+    out->max = max;
+    out->stream = out_stream;
+    out->f = default_f;
+}
+
+void raw_log_formatter(FILE *out, /* IN */
+    enum log_level level, /* IN */
+    const char *context, /* IN */
+    const char *log) /* IN */
+{
+    fprintf(out, "%s", log);
+    fflush(out);
+}
+
+void log_vlog(struct log_ctx *ctx, /* IN */
+    enum log_level level, /* IN */
+    const char *context, /* IN */
+    log_formatter_f *f, /* IN */
+    const char *printf_str, /* IN */
+    va_list argp)
+{
+    int len;
+    int i;
+
+    if (ctx->level < level) {
+        /* don't log this */
+        return;
+    }
+
+    len = 0;
+    do {
+        if (len >= ctx->buf_len) {
+            ctx->buf_len = len + 1024;
+            ctx->buf = realloc(ctx->buf, ctx->buf_len);
+            if (ctx->buf == NULL) {
+                fprintf(stderr, "fatal error, can't allocate memory for log log\n");
+                exit(1);
+            }
+        }
+        len = vsnprintf(ctx->buf, ctx->buf_len, printf_str, argp);
+    }
+
+    while (len >= ctx->buf_len);
+
+    for (i = 0; i < ctx->out_len; ++i) {
+        struct log_output *o = &ctx->out[i];
+        log_formatter_f *of = f;
+
+        if (level >= o->min && level <= o->max) {
+            /* generate log for this output */
+            if (of == NULL) {
+                of = o->f;
+            }
+            if (of != NULL) {
+                of(o->stream, level, context, ctx->buf);
+            } else {
+                fprintf(o->stream, "%s\n", ctx->buf);
+                fflush(o->stream);
+            }
+        }
+    }
+}
+
+void log_log_default(const char *printf_str, /* IN */
+    ...)
+{
+    va_list argp;
+    va_start(argp, printf_str);
+    log_vlog(G_log_ctx, G_log_log_level, NULL, raw_log_formatter, printf_str,
+        argp);
+}
+
+void log_log(struct log_ctx *ctx, /* IN */
+    enum log_level level, /* IN */
+    const char *context, /* IN */
+    log_formatter_f *f, /* IN */
+    const char *printf_str, /* IN */
+    ...)
+{
+    va_list argp;
+    va_start(argp, printf_str);
+    log_vlog(ctx, level, context, f, printf_str, argp);
+}
+
+void hex_dump(int level, unsigned char *p, int len)
+{
+    int i = 0;
+    for (;;) {
+        LOG(level, ("%02x", p[i]));
+        if (++i % 8 == 0 || i == len) {
+            LOG(level, ("\n"));
+        } else {
+            LOG(level, (" "));
+        }
+        if (i == len) {
+            break;
+        }
+    }
+}

--- a/terps/unp64/log.c
+++ b/terps/unp64/log.c
@@ -1,29 +1,22 @@
 /*
- * Copyright (c) 2002, 2003 Magnus Lind.
+ * Copyright (c) 2002 - 2023 Magnus Lind.
  *
- * This software is provided 'as-is', without any express or implied warranty.
- * In no event will the authors be held liable for any damages arising from
- * the use of this software.
  *
- * Permission is granted to anyone to use this software, alter it and re-
- * distribute it freely for any non-commercial, non-profit purpose subject to
- * the following restrictions:
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
  *
- *   1. The origin of this software must not be misrepresented; you must not
- *   claim that you wrote the original software. If you use this software in a
- *   product, an acknowledgment in the product documentation would be
- *   appreciated but is not required.
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
  *
- *   2. Altered source versions must be plainly marked as such, and must not
- *   be misrepresented as being the original software.
- *
- *   3. This notice may not be removed or altered from any distribution.
- *
- *   4. The names of this software and/or it's copyright holders may not be
- *   used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *
- * This file is a part of the Exomizer v1.1 release
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
  *
  */
 

--- a/terps/unp64/log.h
+++ b/terps/unp64/log.h
@@ -1,0 +1,132 @@
+#ifndef ALREADY_INCLUDED_LOG
+#define ALREADY_INCLUDED_LOG
+/*
+ * Copyright (c) 2002, 2003 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+
+enum log_level {
+  LOG_MIN = -99,
+  LOG_FATAL = -40,
+  LOG_ERROR = -30,
+  LOG_WARNING = -20,
+  LOG_BRIEF = -10,
+  LOG_NORMAL = 0,
+  LOG_VERBOSE = 10,
+  LOG_TRACE = 20,
+  LOG_DEBUG = 30,
+  LOG_DUMP = 40,
+  LOG_MAX = 99
+};
+
+typedef void log_formatter_f(FILE *out,            /* IN */
+                             enum log_level level, /* IN */
+                             const char *context,  /* IN */
+                             const char *);        /* IN */
+
+/*
+ * this log output function adds nothing
+ */
+void raw_log_formatter(FILE *out,            /* IN */
+                       enum log_level level, /* IN */
+                       const char *context,  /* IN */
+                       const char *log);     /* IN */
+
+struct log_output;
+
+struct log_ctx;
+
+struct log_ctx *log_new(void);
+
+/* log_delete closes all added output streams
+ * and files except for stdout and stderr
+ */
+void log_delete(struct log_ctx *ctx);
+
+void log_set_level(struct log_ctx *ctx,   /* IN/OUT */
+                   enum log_level level); /* IN */
+
+void log_add_output_stream(struct log_ctx *ctx,        /* IN/OUT */
+                           enum log_level min,         /* IN */
+                           enum log_level max,         /* IN */
+                           log_formatter_f *default_f, /* IN */
+                           FILE *out_stream);          /* IN */
+
+void log_vlog(struct log_ctx *ctx,    /* IN */
+              enum log_level level,   /* IN */
+              const char *context,    /* IN */
+              log_formatter_f *f,     /* IN */
+              const char *printf_str, /* IN */
+              va_list argp);
+
+void log_log_default(const char *printf_str, /* IN */
+                     ...);
+
+/* some helper macros */
+
+extern struct log_ctx *G_log_ctx;
+extern enum log_level G_log_level;
+extern enum log_level G_log_log_level;
+
+#define LOG_SET_LEVEL(L)                                                       \
+  do {                                                                         \
+    log_set_level(G_log_ctx, (L));                                             \
+    G_log_level = (L);                                                         \
+  } while (0)
+
+#define LOG_INIT(L)                                                            \
+  do {                                                                         \
+    G_log_ctx = log_new();                                                     \
+    log_set_level(G_log_ctx, (L));                                             \
+    G_log_level = (L);                                                         \
+  } while (0)
+
+#define LOG_INIT_CONSOLE(X)                                                    \
+  do {                                                                         \
+    G_log_ctx = log_new();                                                     \
+    log_set_level(G_log_ctx, (X));                                             \
+    G_log_level = (X);                                                         \
+    log_add_output_stream(G_log_ctx, LOG_WARNING, LOG_MAX, NULL, stdout);      \
+    log_add_output_stream(G_log_ctx, LOG_MIN, LOG_WARNING - 1, NULL, stderr);  \
+  } while (0)
+
+#define LOG_FREE log_delete(G_log_ctx)
+
+#define IS_LOGGABLE(L) (G_log_level >= (L))
+
+#define LOG(L, M)                                                              \
+  do {                                                                         \
+    if (IS_LOGGABLE(L)) {                                                      \
+      G_log_log_level = (L);                                                   \
+      log_log_default M;                                                       \
+    }                                                                          \
+  } while (0)
+
+void hex_dump(int level, unsigned char *p, int len);
+
+#endif

--- a/terps/unp64/membuf.h
+++ b/terps/unp64/membuf.h
@@ -1,0 +1,61 @@
+#ifndef ALREADY_INCLUDED_MEMBUF
+#define ALREADY_INCLUDED_MEMBUF
+
+/*
+ * Copyright (c) 2002 - 2005 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+#define STATIC_MEMBUF_INIT                                                     \
+  { 0, 0, 0 }
+
+struct membuf {
+  void *buf;
+  int len;
+  int size;
+};
+
+void membuf_init(struct membuf *sb);
+void membuf_clear(struct membuf *sb);
+void membuf_free(struct membuf *sb);
+void membuf_new(struct membuf **sbp);
+void membuf_delete(struct membuf **sbp);
+int membuf_memlen(const struct membuf *sb);
+void membuf_truncate(struct membuf *sb, int len);
+
+/* returns the new len or < 0 if failure */
+int membuf_trim(struct membuf *sb, int pos);
+
+void *membuf_memcpy(struct membuf *sb, int offset, const void *mem, int len);
+void *membuf_append(struct membuf *sb, const void *mem, int len);
+void *membuf_append_char(struct membuf *sb, char c);
+void *membuf_insert(struct membuf *sb, int offset, const void *mem, int len);
+void membuf_remove(struct membuf *sb, int offset, int len);
+void membuf_atleast(struct membuf *sb, int size);
+void membuf_atmost(struct membuf *sb, int size);
+int membuf_get_size(const struct membuf *sb);
+void *membuf_get(const struct membuf *sb);
+
+#endif

--- a/terps/unp64/scanners/1001card.c
+++ b/terps/unp64/scanners/1001card.c
@@ -1,0 +1,209 @@
+/*1001 / TCI*/
+#include "../unp64.h"
+void Scn_1001card(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q,p;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        if(/*(*(unsigned int*)(mem+0x812)==0x8630A278)*/ mem[0x815]==0x86 &&
+           ((*(unsigned int*)(mem+0x816)&0xfff0ffff)==0xB9A0A001) &&
+           (*(unsigned int*)(mem+0x81a)==0xFA99082A) &&
+           (*(unsigned int*)(mem+0x886)==0x01154CC1) )
+        {
+            Unp->DepAdr=0x100;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x815;
+            Unp->RetAdr=mem[0x940]|mem[0x941]<<8;
+            Unp->EndAdr=mem[0x82e]|mem[0x82f]<<8;
+            PrintInfo(Unp,_I_1001_4);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* HTL hack? */
+    if( Unp->DepAdr==0 )
+    {
+        if(mem[0x813]==0xe6 &&
+           ((*(unsigned int*)(mem+0x814)&0xfff0ffff)==0xB9A0A001) &&
+           (*(unsigned int*)(mem+0x818)==0xee04082A) &&
+           (*(unsigned int*)(mem+0x81c)==0xB900FA99) &&
+           (*(unsigned int*)(mem+0x886)==0x01154CC1) )
+        {
+            Unp->DepAdr=0x100;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x813;
+            Unp->RetAdr=mem[0x940]|mem[0x941]<<8;
+            Unp->EndAdr=mem[0x82e]|mem[0x82f]<<8;
+            PrintInfo(Unp,_I_1001_HTL);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if(/*(*(unsigned int*)(mem+0x812)==0xE6B0A278) &&*/
+           (*(unsigned int*)(mem+0x852)==0x0A006D4C) &&
+           (*(unsigned int*)(mem+0x816)==0x9D01B501) &&
+           (*(unsigned int*)(mem+0x81a)==0x54BD034F) )
+        {
+            Unp->DepAdr=0x334;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x812;
+            Unp->RetAdr=mem[0x916]|mem[0x917]<<8;
+            Unp->fEndBf=0x63;Unp->EndAdC=0xffff;
+            PrintInfo(Unp,_I_1001_NEWPACK);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        /*  original is at $0840, there are also hacks at $0801 and others
+        */
+        for(p=0x0801;p<0x841;p++)
+        {
+            if(((mem[p]==0x78)||
+                (*(unsigned int*)(mem+p)==0x018536A9)||
+                (*(unsigned int*)(mem+p)==0x7800A000)
+               ) &&
+               (mem[p+6]==0xb9)&&
+               (*(unsigned short int*)(mem+p+0x7)==(p+0x18)) &&
+               (*(unsigned int*)(mem+p+0x09)==0xb900fb99) &&
+               (*(unsigned int*)(mem+p+0x0f)==0xC8040099) &&
+               (*(unsigned int*)(mem+p+0x13)==0xFF4CF1D0) )
+            {
+                Unp->DepAdr=0x0ff;
+                break;
+            }
+        }
+        if(Unp->DepAdr)
+        {
+            Unp->Forced=p;
+            if(*(unsigned int*)(mem+p)==0x7800A000)
+                mem[p]=0xea;
+            //Unp->EndAdr=0x2d;
+            Unp->EndAdr=mem[p+0x18]|mem[p+0x19]<<8;Unp->EndAdr++;
+            for(q=p+0x97;q<p+0xba;q++)
+            {
+                if((mem[q]==0xa9)||(mem[q]==0x85))
+                {
+                    q++;
+                    continue;
+                }
+                if((mem[q]==0x20&&mem[q+3]==0x4c)||(mem[q]==0x4c))
+                {
+                    Unp->RetAdr=mem[q+1]|mem[q+2]<<8;
+                    if((mem[q]==0x20)&&(Unp->RetAdr==0xa659))
+                    {
+                        Unp->RetAdr=mem[q+4]|mem[q+5]<<8;
+                        mem[q]=0x2c;
+                    }
+                    break;
+                }
+            }
+            PrintInfo(Unp,_I_1001_OLDPACK);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x814)==0xA6A00185) &&
+           (*(unsigned int*)(mem+0x819)==0xFA990835) &&
+           (*(unsigned int*)(mem+0x821)==0x88033399) &&
+           (*(unsigned int*)(mem+0x911)==0xA5034D4C) )
+        {
+            Unp->DepAdr=0x100;
+            if(Unp->info->run == -1)
+            {
+                for(p=0x0801;p<0x813;p++)
+                {
+                    if(mem[p]== 0x78)
+                    {
+                        Unp->Forced=p;
+                        break;
+                    }
+                }
+            }
+            Unp->RetAdr=mem[0x952]|mem[0x953]<<8;
+            Unp->EndAdr=mem[0x839]|mem[0x83a]<<8;
+            PrintInfo(Unp,_I_1001_CRAM);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x80d)==0x86F0A278) &&
+           (*(unsigned int*)(mem+0x81a)==0x01004CF7) &&
+           (*(unsigned int*)(mem+0x8fc)==0x017A4CF7) )
+        {
+            Unp->DepAdr=0x100;
+            Unp->Forced=0x80d;
+            Unp->RetAdr=mem[0x83f]|mem[0x840]<<8;
+            Unp->EndAdr=mem[0x81e]|mem[0x81f]<<8;
+            Unp->fStrAf=0xf9;Unp->StrAdC=0xffff;
+            PrintInfo(Unp,_I_1001_ACM);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Datel UltraCompander - variant at 2061, identical to v4/crunch */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x813)==0xCFB95AA0) &&
+           (*(unsigned int*)(mem+0x81b)==0x990875B9) &&
+           (*(unsigned int*)(mem+0x839)==0xF1D0C808) &&
+           (*(unsigned int*)(mem+0x884)==0x01154CC1) )
+        {
+            Unp->DepAdr=0x100;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x813;
+            for(q=0x92c;q<0x935;q++)
+            {
+                if(mem[q]==0xfc&&mem[q+9]==0x4c)
+                {
+                    Unp->RetAdr=mem[q+0xa]|mem[q+0xb]<<8;
+                    break;
+                }
+            }
+            Unp->fStrAf=0xfe;Unp->StrAdC=0xffff;
+            Unp->EndAdr=mem[0x82c]|mem[0x82d]<<8;
+            PrintInfo(Unp,_I_DATELUC);
+            Unp->IdFlag=1;return;
+        }
+
+    }
+    /* Datel UltraCompander - Compactor, very similar to screencrunch */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x80d)==0x1CBD7FA2) &&
+           (*(unsigned int*)(mem+0x811)==0x01009D08) &&
+           (*(unsigned int*)(mem+0x874)==0x0176200C) &&
+           (*(unsigned int*)(mem+0x881)==0xDDD001A2) )
+        {
+            Unp->Forced=0x80d;
+            Unp->DepAdr=0x100;
+            Unp->EndAdr=0xae;
+            Unp->StrMem=mem[0x84e]|mem[0x850]<<8;
+            Unp->RetAdr=mem[0x890]|mem[0x891]<<8;
+            PrintInfo(Unp,_I_DATELUCC);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Datel UltraCompander - Packer */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x80d)==0xA201E678) &&
+           (*(unsigned int*)(mem+0x81f)==0x9D0911BD) &&
+           (*(unsigned int*)(mem+0x84b)==0x80006D4C) &&
+           (*(unsigned int*)(mem+0x90d)==0x02A84C00) )
+        {
+            Unp->DepAdr=0x2a8;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x80d;
+            Unp->RetAdr=mem[0x85f]|mem[0x860]<<8;
+            Unp->fEndBf=0x63;Unp->EndAdC=0xffff;
+            PrintInfo(Unp,_I_DATELUCP);
+            Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/AbuzeCrunch.c
+++ b/terps/unp64/scanners/AbuzeCrunch.c
@@ -1,0 +1,87 @@
+/* AbuzeCrunch */
+#include "../unp64.h"
+void Scn_AbuzeCrunch(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q,p=0;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        for(q=0x80b;q<0x820;q++)
+        {
+            if((*(unsigned int*)(mem+q     )==0x1BA200A0) &&
+               (*(unsigned int*)(mem+q+0x13)==0x10CAA095) &&
+               (*(unsigned short int*)(mem+q+0x20)==0x4CF7) )
+            {
+                p=mem[q+0xc]|mem[q+0xd]<<8;
+                if((*(unsigned int*)(mem+p+0x25)==0xFFA9FE91)||
+                   (*(unsigned int*)(mem+p+0x25)==0xFeA5FE91) )
+                {
+                    Unp->DepAdr=mem[q+0x22]|mem[q+0x23]<<8;
+                    break;
+                }
+            }
+         }
+         if( Unp->DepAdr )
+         {
+            Unp->EndAdr=mem[p+0x4]|mem[p+0x5]<<8;Unp->EndAdr++;
+            Unp->Forced=q;
+            if(mem[p+0x2f]==0xa5)
+                Unp->RetAdr=mem[p+0x3f]|mem[p+0x40]<<8;
+            if(mem[p+0x2f]==0xa9)
+                Unp->RetAdr=mem[p+0x3d]|mem[p+0x3e]<<8;
+            Unp->fStrAf=0xfe;
+            PrintInfo(Unp,_I_ABUZECRUNCH);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        for(q=0x80b;q<0x820;q++)
+        {
+            if((*(unsigned int*)(mem+q    )==0xA27800A0) &&
+               (*(unsigned int*)(mem+q+4  )==0xBAA59AFF) &&
+               (*(unsigned short int*)(mem+q+0x2c)==0x4CF7) )
+            {
+                p=mem[q+0x12]|mem[q+0x13]<<8;
+                if( *(unsigned int*)(mem+p+0x25)==0xFeA5FE91 )
+                {
+                    Unp->DepAdr=mem[q+0x2e]|mem[q+0x2f]<<8;
+                    break;
+                }
+            }
+         }
+         if( Unp->DepAdr )
+         {
+            Unp->EndAdr=mem[p+0x4]|mem[p+0x5]<<8;Unp->EndAdr++;
+            Unp->Forced=q;
+            Unp->RetAdr=mem[p+0x42]|mem[p+0x43]<<8;
+            Unp->fStrAf=0xfe;
+            PrintInfo(Unp,_I_ABUZECR37);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Abuze 5.0/FLT */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x80b)==0x1BA200A0) &&
+           (*(unsigned int*)(mem+0x813)==0x10CAA095) &&
+           (*(unsigned int*)(mem+0x822)==0x011F4C01) )
+        {
+            p=mem[0x819]|mem[0x81a]<<8;
+            if(*(unsigned int*)(mem+p+0x06)==0x9101E520)
+            {
+                Unp->DepAdr=0x11f;
+                if(Unp->info->run == -1)
+                    Unp->Forced=0x80b;
+                Unp->RetAdr=mem[p+0x23]|mem[p+0x24]<<8;
+                Unp->EndAdr=mem[p+0x4]|mem[p+0x5]<<8;Unp->EndAdr++;
+                Unp->fStrAf=0xfe;
+                PrintInfo(Unp,_I_ABUZECR50);
+                Unp->IdFlag=1;return;
+            }
+        }
+    }
+}

--- a/terps/unp64/scanners/ActionPacker.c
+++ b/terps/unp64/scanners/ActionPacker.c
@@ -1,0 +1,24 @@
+/* Action(?) packer */
+#include "../unp64.h"
+void Scn_ActionPacker(unpstr *Unp) {
+  unsigned char *mem;
+
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x811) == 0x018538A9) &&
+        (*(unsigned int *)(mem + 0x81d) == 0xCEF7D0E8) &&
+        (*(unsigned int *)(mem + 0x82d) == 0x0F9D0837) &&
+        (*(unsigned int *)(mem + 0x84b) == 0x03D00120)) {
+      Unp->DepAdr = 0x110;
+      Unp->Forced = 0x811;
+      Unp->StrMem = mem[0x848] | mem[0x849] << 8;
+      Unp->fEndAf = 0x120;
+      Unp->RetAdr = mem[0x863] | mem[0x864] << 8;
+      PrintInfo(Unp, _I_ACTIONP);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/ByteBoiler.c
+++ b/terps/unp64/scanners/ByteBoiler.c
@@ -1,0 +1,67 @@
+/* Byteboiler/OneWay */
+#include "../unp64.h"
+void Scn_ByteBoiler(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x813) == 0xE800F09D) &&
+        (*(unsigned int *)(mem + 0x818) == 0x014E4CF7)) {
+      p = mem[0x811] | mem[0x812] << 8;
+      if (*(unsigned int *)(mem + p + 1) == 0x02D0FAA5) {
+        Unp->DepAdr = 0x14e;
+        Unp->Forced = 0x80b;
+        Unp->RetAdr = mem[p + 0x5c] | mem[p + 0x5d] << 8;
+        Unp->EndAdr = mem[p + 0x0e] | mem[p + 0x0f] << 8;
+        Unp->EndAdr++;
+        Unp->fStrAf = 0xfe;
+        PrintInfo(Unp, _I_BYTEBOILER);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  /* CPX hack */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x80b) == 0xA97800A2) &&
+        (*(unsigned int *)(mem + 0x815) == 0x4C01E6D0)) {
+      q = mem[0x819] | mem[0x81a] << 8;
+      if ((*(unsigned int *)(mem + q + 3) == 0xE800F09D) &&
+          (*(unsigned int *)(mem + q + 8) == 0x014E4CF7)) {
+        p = mem[q + 1] | mem[q + 2] << 8;
+        if (*(unsigned int *)(mem + p + 1) == 0x02D0FAA5) {
+          Unp->DepAdr = 0x14e;
+          Unp->Forced = 0x80b;
+          Unp->RetAdr = mem[p + 0x5c] | mem[p + 0x5d] << 8;
+          Unp->EndAdr = mem[p + 0x0e] | mem[p + 0x0f] << 8;
+          Unp->EndAdr++;
+          Unp->fStrAf = 0xfe;
+          PrintInfo(Unp, _I_BYTEBOICPX);
+          Unp->IdFlag = 1;
+          return;
+        }
+      }
+    }
+  }
+  /* SCS hack */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x813) == 0xE800F09D) &&
+        (*(unsigned int *)(mem + 0x818) == 0x01bf4CF7)) {
+      p = mem[0x811] | mem[0x812] << 8;
+      if ((*(unsigned int *)(mem + p + 1) == 0x02D0FAA5) &&
+          (*(unsigned int *)(mem + p + 0xdd) == 0x014e4c01)) {
+        Unp->DepAdr = 0x14e;
+        Unp->Forced = 0x80b;
+        Unp->RetAdr = mem[p + 0x5c] | mem[p + 0x5d] << 8;
+        Unp->EndAdr = mem[p + 0x0e] | mem[p + 0x0f] << 8;
+        Unp->EndAdr++;
+        Unp->fStrAf = 0xfe;
+        PrintInfo(Unp, _I_BYTEBOISCS);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+}

--- a/terps/unp64/scanners/CCS.c
+++ b/terps/unp64/scanners/CCS.c
@@ -1,0 +1,215 @@
+/* CCS packers */
+#include "../unp64.h"
+void Scn_CCS(unpstr *Unp)
+{
+    unsigned char *mem;
+    int p;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x817)==0xB901E678) &&
+            (*(unsigned int*)(mem+0x81b)==0xFD990831) &&
+            (*(unsigned int*)(mem+0x8ff)==0xFEE60290) &&
+            (*(unsigned int*)(mem+0x90f)==0x02903985)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x817;
+            Unp->DepAdr=0x0ff;
+            Unp->fEndAf=0x2d;
+            Unp->EndAdC=0xffff;
+            Unp->RetAdr=mem[0x8ed]|mem[0x8ee]<<8;
+            if(Unp->RetAdr==0xa659)
+            {
+                mem[0x8ec]=0x2c;
+                Unp->RetAdr=mem[0x8f0]|mem[0x8f1]<<8;
+            }
+            PrintInfo(Unp,_I_CCSMAXS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* derived from supercomp/eqseq */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x80b)==0x8C7800A0) &&
+            (*(unsigned int*)(mem+0x812)==0x0099082F) &&
+            (*(unsigned int*)(mem+0x846)==0x0DADF2D0) &&
+            (*(unsigned int*)(mem+0x8c0)==0xF001124C)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x80b;
+            Unp->DepAdr=0x100;
+            Unp->EndAdr=0xae;
+            Unp->RetAdr=mem[0x8f1]|mem[0x8f2]<<8;
+            if(Unp->RetAdr==0xa659)
+            {
+                mem[0x8f0]=0x2c;
+                Unp->RetAdr=mem[0x8f4]|mem[0x8f5]<<8;
+            }
+            PrintInfo(Unp,_I_SUPCOMEQCCS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x814)==0xB901E678) &&
+            (*(unsigned int*)(mem+0x818)==0xFD990829) &&
+            (*(unsigned int*)(mem+0x8a1)==0xFDA6FDB1) &&
+            (*(unsigned int*)(mem+0x8a5)==0xFEC602D0)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x814;
+            Unp->DepAdr=0x0ff;
+            Unp->fEndBf=0x39;
+            PrintInfo(Unp,_I_CCSPACK);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x818)==0x2CB901E6) &&
+            (*(unsigned int*)(mem+0x81c)==0x00FB9908) &&
+            (*(unsigned int*)(mem+0x850)==0xFBB1C84A) &&
+            (*(unsigned int*)(mem+0x854)==0xB1C81185)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x812;
+            Unp->DepAdr=0x0ff;
+            Unp->EndAdr=0xae;
+            PrintInfo(Unp,_I_CCSCRUNCH1);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x818)==0x2CB901E6) &&
+            (*(unsigned int*)(mem+0x81c)==0x00FB9908) &&
+            (*(unsigned int*)(mem+0x851)==0xFBB1C812) &&
+            (*(unsigned int*)(mem+0x855)==0xB1C81185)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x812;
+            Unp->DepAdr=0x0ff;
+            Unp->EndAdr=0xae;
+            PrintInfo(Unp,_I_CCSCRUNCH2);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x82c)==0x018538A9) &&
+            (*(unsigned int*)(mem+0x831)==0xFD990842) &&
+            (*(unsigned int*)(mem+0x83e)==0x00FF4CF1) &&
+            (*(unsigned int*)(mem+0x8a5)==0x50C651C6)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x822;
+            Unp->DepAdr=0x0ff;
+            Unp->fEndBf=0x39;
+            Unp->RetAdr=mem[0x8ea]|mem[0x8eb]<<8;
+            PrintInfo(Unp,_I_CCSSCRE);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned short int*)(mem+0x81a)==0x00A0) &&
+           ((*(unsigned int*)(mem+0x820)==0xFB990837)||
+            (*(unsigned int*)(mem+0x824)==0xFB990837) ) &&
+            (*(unsigned int*)(mem+0x83b)==0xFD91FBB1) &&
+            (*(unsigned int*)(mem+0x8bc)==0xEE00FC99)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x81a;
+            Unp->DepAdr=0x0ff;
+            Unp->fEndAf=0x39;
+            Unp->EndAdC=0xffff;
+            Unp->RetAdr=mem[0x8b3]|mem[0x8b4]<<8;
+            PrintInfo(Unp,_I_CCSSPEC);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x812)==0xE67800A0) &&
+            (*(unsigned int*)(mem+0x816)==0x0823B901) &&
+            (*(unsigned int*)(mem+0x81a)==0xC800FD99) &&
+            (*(unsigned int*)(mem+0x81e)==0xFF4CF7D0) &&
+            (*(unsigned int*)(mem+0x885)==0xFDA6FDB1)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x812;
+            Unp->DepAdr=0x0ff;
+            // $2d is unreliable, Executer uses line number at $0803/4,
+            // which is read at $0039/3a by basic, as end address,
+            // then can set arbitrarily $2d/$ae pointers after unpack.
+            //Unp->fEndAf=0x2d;
+            Unp->EndAdr=mem[0x803]|mem[0x804]<<8;
+            Unp->EndAdr++;
+            if(*(unsigned int*)(mem+0x87f)==0x4CA65920)
+                mem[0x87f]=0x2c;
+            Unp->RetAdr=mem[0x883]|mem[0x884]<<8;
+            PrintInfo(Unp,_I_CCSEXEC);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x812)==0xE67800A0) &&
+            (*(unsigned int*)(mem+0x816)==0x084CB901) &&
+            (*(unsigned int*)(mem+0x81a)==0xA900FB99) &&
+            (*(unsigned int*)(mem+0x848)==0x00FF4CE2)
+          )
+        {
+            if(Unp->info->run == -1)
+                Unp->Forced=0x812;
+            Unp->DepAdr=0x0ff;
+            Unp->fEndAf=0x2d;
+            Unp->EndAdC=0xffff;
+            PrintInfo(Unp,_I_CCSUNKN);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Triad Hack */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x838)==0xB9080099) &&
+            (*(unsigned int*)(mem+0x83f)==0xD0880816) &&
+            (*(unsigned int*)(mem+0x8ff)==0xFEE60290) &&
+            (*(unsigned int*)(mem+0x90f)==0x02903985)
+          )
+        {
+            if(Unp->info->run == -1)
+            {
+                for(p=0x80b;p<0x820;p++)
+                {
+                    if((mem[p]&0xa0)==0xa0)
+                    {
+                        Unp->Forced=p;
+                        break;
+                    }
+                }
+            }
+            Unp->DepAdr=0x0ff;
+            Unp->fEndAf=0x2d;
+            Unp->EndAdC=0xffff;
+            Unp->RetAdr=mem[0x8ed]|mem[0x8ee]<<8;
+            if(Unp->RetAdr==0xa659)
+            {
+                mem[0x8ec]=0x2c;
+                Unp->RetAdr=mem[0x8f0]|mem[0x8f1]<<8;
+            }
+            PrintInfo(Unp,_I_CCSHACK);
+            Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/Caution.c
+++ b/terps/unp64/scanners/Caution.c
@@ -1,0 +1,115 @@
+/* Caution Quickpacker, 3 variants */
+#include "../unp64.h"
+void Scn_Caution(unpstr *Unp)
+{
+    unsigned char *mem;
+
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    /* quickpacker 1.0 sysless */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x801)==0xE67800A2) &&
+            (*(unsigned int*)(mem+0x805)==0x07EDBD01) &&
+            (*(unsigned int*)(mem+0x80d)==0x00284CF8) &&
+            (*(unsigned int*)(mem+0x844)==0xAC00334C) )
+        {
+            Unp->Forced=0x801;
+            Unp->DepAdr=0x28;
+            Unp->RetAdr=mem[0x86b]|mem[0x86c]<<8;
+            Unp->EndAdr=mem[0x85a]|mem[0x85b]<<8;
+            Unp->fStrAf=mem[0x863];
+            Unp->StrAdC=EA_ADDFF|0xffff;
+            PrintInfo(Unp,_I_CAUTION10);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* quickpacker 2.x + sys */
+    if( Unp->DepAdr==0 )
+    {
+        if(((*(unsigned int*)(mem+0x80b)&0xf0ffffff)==0x60A200A0) &&
+            (*(unsigned int*)(mem+0x80f)==0x0801BD78) &&
+            (*(unsigned int*)(mem+0x813)==0xD0CA0095) &&
+            (*(unsigned int*)(mem+0x81e)==0xD0C80291) &&
+            (*(unsigned int*)(mem+0x817)==0x001A4CF8) )
+        {
+            Unp->Forced=0x80b;
+            Unp->DepAdr=0x01a;
+            if(mem[0x80e]==0x69)
+            {
+                Unp->RetAdr=mem[0x842]|mem[0x843]<<8;
+                Unp->EndAdr=mem[0x850]|mem[0x851]<<8;Unp->EndAdr+=0x100;
+                Unp->fStrAf=0x4f;
+                Unp->StrAdC=0xffff|EA_USE_Y;
+                PrintInfo(Unp,_I_CAUTION25);
+                Unp->IdFlag=1;return;
+            }
+            else if(mem[0x80e]==0x6c)
+            {
+                Unp->RetAdr=mem[0x844]|mem[0x845]<<8;
+                Unp->EndAdr=mem[0x84e]|mem[0x84f]<<8;Unp->EndAdr++;
+                Unp->fStrAf=0x4d;
+                PrintInfo(Unp,_I_CAUTION20);
+                Unp->IdFlag=1;return;
+            }
+        }
+    }
+    /* strangely enough, sysless v2.0 depacker is at $0002 */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x83d)==0xAA004A20) &&
+            (*(unsigned int*)(mem+0x801)==0xA27800A0) &&
+            (*(unsigned int*)(mem+0x805)==0x080FBD55) &&
+            (*(unsigned int*)(mem+0x809)==0xD0CA0095) &&
+            (*(unsigned int*)(mem+0x80d)==0x00024CF8) )
+        {
+            Unp->Forced=0x801;
+            Unp->DepAdr=0x2;
+            Unp->RetAdr=mem[0x83b]|mem[0x83c]<<8;
+            Unp->EndAdr=mem[0x845]|mem[0x846]<<8;Unp->EndAdr++;
+            Unp->fStrAf=mem[0x849];
+            //Unp->StrAdC=0xffff;
+            PrintInfo(Unp,_I_CAUTION20SS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* same goes for v2.5 sysless, seems almost another packer */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x83b)==0xAA005520) &&
+            (*(unsigned int*)(mem+0x801)==0x60A200A0) &&
+            (*(unsigned int*)(mem+0x805)==0x0801BD78) &&
+            (*(unsigned int*)(mem+0x809)==0xD0CA0095) &&
+            (*(unsigned int*)(mem+0x80d)==0x00104CF8) )
+        {
+            Unp->Forced=0x801;
+            Unp->DepAdr=0x10;
+            Unp->RetAdr=mem[0x839]|mem[0x83a]<<8;
+            Unp->EndAdr=mem[0x847]|mem[0x848]<<8;Unp->EndAdr+=0x100;
+            Unp->fStrAf=0x46;
+            Unp->StrAdC=0xffff|EA_USE_Y;
+            PrintInfo(Unp,_I_CAUTION25SS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* hardpacker */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x80d)==0x8534A978) &&
+            (*(unsigned int*)(mem+0x811)==0xB9B3A001) &&
+            (*(unsigned int*)(mem+0x815)==0x4C99081F) &&
+            (*(unsigned int*)(mem+0x819)==0xF7D08803) &&
+            (*(unsigned int*)(mem+0x81d)==0xB9034D4C) )
+        {
+            Unp->Forced=0x80d;
+            Unp->DepAdr=0x34d;
+            Unp->RetAdr=mem[0x87f]|mem[0x880]<<8;
+            Unp->EndAdr=mem[0x88d]|mem[0x88e]<<8;
+            Unp->fStrAf=0x3ba;
+            Unp->StrAdC=EA_ADDFF|0xffff;
+            PrintInfo(Unp,_I_CAUTIONHP);
+            Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/Cruel.c
+++ b/terps/unp64/scanners/Cruel.c
@@ -1,0 +1,373 @@
+/* Cruel Crunch/Oneway and variants */
+#include "../unp64.h"
+void Scn_Cruel(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p, strtmp = 0;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    if (mem[0x810] == 0xb9 &&
+        ((*(unsigned int *)(mem + 0x813) & 0xfffffeff) == 0xC800FA99) &&
+        (*(unsigned short int *)(mem + 0x818) == 0x4CF7)) {
+      if (mem[0x814] == 0xFA) {
+        p = mem[0x811] | mem[0x812] << 8;
+        if (*(unsigned int *)(mem + p + 9) == 0xC8071C99) {
+          Unp->EndAdr = mem[p + 2] | mem[p + 3] << 8;
+          Unp->DepAdr = 0x100;
+          if (Unp->info->run == -1)
+            Unp->Forced = 0x80b;
+          Unp->fStrAf = 0xfc;
+          q = mem[p + 7] | mem[p + 8] << 8;
+          if ((mem[q + 0x8e] == 0xc6) && (mem[q + 0x8f] == 0x01) &&
+              (mem[q + 0x93] == 0xe6) && (mem[q + 0x94] == 0x01)) {
+            mem[q + 0x90] = 0x2c;
+          }
+          /* retadr is not always at the same addr, but at least can't
+             be anything < $07e8
+          */
+          // Unp->RetAdr=0x7e8;
+          q = mem[p + 7] | mem[p + 8] << 8;
+          if (mem[q + 0x3c] == 0x4c) {
+            /* v2.2/dynamix, v2.5/cross, v2.5/crest */
+            strtmp = *(unsigned short int *)(mem + q + 0x3d);
+            PrintInfo(Unp, _I_CRUEL22);
+          } else if (mem[q + 0x4a] == 0x4c) {
+            strtmp = *(unsigned short int *)(mem + q + 0x4b);
+            PrintInfo(Unp, _I_CRUELFAST2);
+          } else if (mem[q + 0x3f] == 0x4c) {
+            /* v2.2/oneway+scs, also hacked as cruel 2mhz 1.0 */
+            strtmp = *(unsigned short int *)(mem + q + 0x40);
+            PrintInfo(Unp, _I_CRUEL2MHZ);
+          } else {
+            /* todo: determine real retadr, for now a default seems ok */
+            strtmp = 0;
+            PrintInfo(Unp, _I_CRUEL_X);
+          }
+          if (strtmp) {
+            if (strtmp >= Unp->RetAdr) {
+              Unp->RetAdr = strtmp;
+            } else { /* now search it... variable code here */
+              strtmp += p - *(unsigned short int *)(mem + 0x814);
+              for (q = strtmp; q < Unp->info->end; q++) {
+                if ((mem[q] == 0xa9) || (mem[q] == 0x85)) {
+                  q++;
+                  continue;
+                }
+                if (mem[q] == 0x8d) {
+                  q += 2;
+                  continue;
+                }
+                if (mem[q] == 0x4c) {
+                  Unp->RetAdr = *(unsigned short int *)(mem + q + 1);
+                  ;
+                  break;
+                }
+              }
+            }
+          }
+        }
+      } else if (mem[0x814] == 0xFB) {
+        /* not Cruel2 but MSCRUNCH by Marco/Taboo
+           v1.0 works only with some old AR cart (unless patched ;)
+           v1.5 is infact more common
+        */
+        p = mem[0x811] | mem[0x812] << 8;
+        if (*(unsigned int *)(mem + p + 7) == 0xC8071C99) {
+          Unp->EndAdr = mem[p + 3] | mem[p + 4] << 8;
+          Unp->DepAdr = 0x100;
+          Unp->Forced = 0x80b;
+          Unp->fStrAf = 0xfe;
+          if ((mem[p + 0x93] == 0x4c) && (mem[p + 0xa1] == 0x4c)) {
+            Unp->RetAdr = mem[p + 0xa2] | mem[p + 0xa3] << 8;
+            PrintInfo(Unp, _I_CRUELMS15);
+          } else if ((mem[p + 0x8c] == 0x4c) && (mem[p + 0x94] == 0x4c)) {
+            Unp->RetAdr = mem[p + 0x95] | mem[p + 0x96] << 8;
+            PrintInfo(Unp, _I_CRUELMS10);
+          } else if ((mem[p + 0x20] == 0x4c) && (mem[p + 0x28] == 0x4c)) {
+            Unp->RetAdr = mem[p + 0x29] | mem[p + 0x2a] << 8;
+            PrintInfo(Unp, _I_CRUELMS1X);
+          } else {
+            PrintInfo(Unp, _I_CRUELMS_U);
+          }
+        }
+      }
+    }
+    if (Unp->DepAdr) {
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /* MSCRUNCH 1.5 hack by Anubis */
+  if (Unp->DepAdr == 0) {
+    if (mem[0x819] == 0x4c) {
+      p = mem[0x81a] | mem[0x81b] << 8;
+      if ((mem[p] == 0xa9) && (mem[p + 0x0f] == 0x30) &&
+          (*(unsigned int *)(mem + p + 0x13) == 0xCA04009D) &&
+          (*(unsigned int *)(mem + p + 0x38) == 0x01084C01)) {
+        q = mem[p + 0x1f] | mem[p + 0x20] << 8;
+        if (*(unsigned int *)(mem + q + 7) == 0xC8071C99) {
+          Unp->EndAdr = mem[q + 3] | mem[q + 4] << 8;
+          Unp->DepAdr = 0x100;
+          if (Unp->info->run == -1)
+            Unp->Forced = 0x819;
+          Unp->fStrAf = 0xfe;
+          Unp->RetAdr = mem[q + 0xa2] | mem[q + 0xa3] << 8;
+          PrintInfo(Unp, _I_CRUMSABS);
+        }
+      }
+    }
+  }
+  /* fast cruel 4.x */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
+        (*(unsigned int *)(mem + 0x813) == 0xC8034099) &&
+        ((*(unsigned int *)(mem + 0x818) == 0x03404cF7) ||
+         (*(unsigned int *)(mem + 0x818) == 0x03b34cF7) ||
+         (*(unsigned int *)(mem + 0x818) == 0x03db4cF7))) {
+      p = mem[0x811] | mem[0x812] << 8;
+      if (*(unsigned int *)(mem + p) == 0xa75801c6) {
+        p += 0x45;
+        q = mem[p] | mem[p + 1] << 8;
+        Unp->EndAdr = mem[q + 2] | mem[q + 3] << 8;
+        Unp->DepAdr = 0x340;
+        Unp->Forced = 0x80b;
+        Unp->fStrAf = 0xfc;
+        PrintInfo(Unp, _I_CRUELFAST4);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  /* Cruel 2.0 / (BB) packer header */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x837) == 0x9D0845BD) &&
+        (*(unsigned int *)(mem + 0x84f) == 0xE808039D) &&
+        (*(unsigned int *)(mem + 0x83b) == 0xC9E803B7)) {
+      Unp->DepAdr = mem[0x843] | mem[0x844] << 8;
+      if (Unp->info->run == -1)
+        Unp->Forced = 0x80d;
+      Unp->RetAdr = mem[0x868] | mem[0x869] << 8;
+      Unp->EndAdr = Unp->info->end - 0x90;
+      Unp->StrMem = 0x801;
+      PrintInfo(Unp, _I_CRUEL_HDR);
+      if (Unp->DebugP)
+        printmsg(mem, 0x86b, 40);
+      Unp->IdFlag = 1;
+      return;
+    }
+    if ((*(unsigned int *)(mem + 0x845) == 0x03E04CF2) &&
+        (*(unsigned int *)(mem + 0x852) == 0x9D0893BD) &&
+        (*(unsigned int *)(mem + 0x856) == 0xD0E80803)) {
+      Unp->DepAdr = mem[0x847] | mem[0x848] << 8;
+      if (Unp->info->run == -1)
+        Unp->Forced = 0x80d;
+      Unp->RetAdr = mem[0x869] | mem[0x86a] << 8;
+      Unp->EndAdr = Unp->info->end - 0x90;
+      Unp->StrMem = 0x801;
+      PrintInfo(Unp, _I_CRUEL_H22);
+      if (Unp->DebugP)
+        printmsg(mem, 0x86b, 40);
+      Unp->IdFlag = 1;
+      return;
+    }
+    if ((*(unsigned int *)(mem + 0x841) == 0x03B74CF5) &&
+        (*(unsigned int *)(mem + 0x84c) == 0x9D089BBD) &&
+        (*(unsigned int *)(mem + 0x850) == 0xD0E8080B)) {
+      Unp->DepAdr = mem[0x843] | mem[0x844] << 8;
+      if (Unp->info->run == -1) {
+        Unp->Forced = 0x811;
+      } else {
+        mem[0x808] = '5'; /* just to be safe, change sys for next layer */
+        mem[0x809] = '9'; /* this hdr leaves it as sys2065 */
+      }
+      Unp->RetAdr = mem[0x868] | mem[0x869] << 8; /* fixed $080b */
+      Unp->EndAdr = Unp->info->end - 0x90;
+      Unp->StrMem = 0x801;
+      PrintInfo(Unp, _I_CRUEL_H20);
+      if (Unp->DebugP)
+        printmsg(mem, 0x86b, 40);
+      Unp->IdFlag = 1;
+      return;
+    }
+    /* this is a totally useless header, cheers TCOM! */
+    if ((*(unsigned int *)(mem + 0x80b) == 0x1BB900A0) &&
+        (*(unsigned int *)(mem + 0x80f) == 0x03B79908) &&
+        (*(unsigned int *)(mem + 0x823) == 0x039D0840)) {
+      Unp->DepAdr = mem[0x819] | mem[0x81a] << 8;
+      if (Unp->info->run == -1)
+        Unp->Forced = 0x80b;
+      Unp->RetAdr = mem[0x83e] | mem[0x83f] << 8;
+      Unp->EndAdr = Unp->info->end - 0x3d;
+      Unp->StrMem = 0x801;
+      PrintInfo(Unp, _I_CRUEL_HTC);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /* Cruel 2.0 / (BB) packer sysless */
+  if (Unp->DepAdr == 0) {
+    if ((((*(unsigned int *)(mem + 0x80b)) & 0x0000ffff) == 0x000000A0) &&
+        (*(unsigned int *)(mem + 0x817) == 0xC800CB99) &&
+        (*(unsigned int *)(mem + 0x81b) == 0x004CF7D0) && mem[0x81f] == 1) {
+      p = mem[0x815] | mem[0x816] << 8;
+      p += 0x31;
+      if ((mem[p + 4] == 0xb9) &&
+          (*(unsigned int *)(mem + p + 7) == 0xC8072099)) {
+        Unp->Forced = 0x80b;
+        Unp->DepAdr = 0x100;
+        Unp->EndAdr = mem[p] | mem[p + 1] << 8;
+        Unp->fStrAf = 0xfc;
+        /* patch: some version contain a zp cleaner sub at $01a2 */
+        if ((*(unsigned int *)(mem + p + 0xa6) == 0x00A9CBA2) &&
+            (*(unsigned int *)(mem + p + 0xaa) == 0xD0E80095)) {
+          mem[p + 0xa6] = 0x60;
+        }
+        /* patch: some version expects $01==#$34 already set from the header */
+        if (*(unsigned int *)(mem + 0x811) == 0xb9eaeaea) {
+          mem[0x811] = 0xe6;
+          mem[0x812] = 0x01;
+        }
+        q = mem[p + 5] | mem[p + 6] << 8;
+        Unp->RetAdr = 0x7e8;
+        if (mem[q + 0x6c] == 0x4c)
+          Unp->RetAdr = mem[q + 0x6d] | mem[q + 0x6e] << 8;
+        PrintInfo(Unp, _I_CRUEL20);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  /* Cruel 2.1 / STA */
+  if (Unp->DepAdr == 0) {
+    if (mem[0x80b] == 0xa0 && (*(unsigned int *)(mem + 0x817) == 0xC800CB99) &&
+        (*(unsigned int *)(mem + 0x81b) == 0x004CF7D0) && mem[0x81f] == 1) {
+      p = mem[0x815] | mem[0x816] << 8;
+      p += 0x31;
+      if ((mem[p + 6] == 0xb9) &&
+          (*(unsigned int *)(mem + p + 9) == 0xC8072099)) {
+        Unp->Forced = 0x80b;
+        Unp->DepAdr = 0x100;
+        Unp->EndAdr = mem[p] | mem[p + 1] << 8;
+        Unp->fStrAf = 0xfc;
+        q = mem[p + 7] | mem[p + 8] << 8;
+        Unp->RetAdr = 0x7e8;
+        if (mem[q + 0x6c] == 0x4c)
+          Unp->RetAdr = mem[q + 0x6d] | mem[q + 0x6e] << 8;
+        PrintInfo(Unp, _I_CRUEL21);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  /* unknown cruel, jmp $00e9, found in Illusion/Random warez */
+  if (Unp->DepAdr == 0) {
+    if (mem[0x810] == 0xb9 && (*(unsigned int *)(mem + 0x813) == 0xC800e999) &&
+        (*(unsigned int *)(mem + 0x818) == 0x00e94CF7)) {
+      p = mem[0x811] | mem[0x812] << 8;
+      q = p - 0xed;
+      if ((*(unsigned int *)(mem + p) == 0x13F01284) &&
+          (*(unsigned int *)(mem + q) == 0xA9C8C8C8)) {
+        Unp->DepAdr = 0xe9;
+        Unp->EndAdr = mem[p + 0x13] | mem[p + 0x14] << 8;
+        Unp->RetAdr = mem[q + 0x38] | mem[q + 0x39] << 8;
+        if (Unp->info->run == -1)
+          Unp->Forced = 0x80b;
+        Unp->fStrAf = 0xfc;
+        PrintInfo(Unp, _I_CRUEL_ILS);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    if (mem[0x810] == 0xb9 && (*(unsigned int *)(mem + 0x813) == 0xC800ed99) &&
+        (*(unsigned int *)(mem + 0x818) == 0x01004CF7)) {
+      p = mem[0x811] | mem[0x812] << 8;
+      q = p - 0xed;
+      if ((*(unsigned int *)(mem + p) == 0x01C60888) &&
+          (*(unsigned int *)(mem + q) == 0xA9C8C8C8)) {
+        Unp->DepAdr = 0x100;
+        Unp->EndAdr = mem[p + 0x0f] | mem[p + 0x10] << 8;
+        Unp->RetAdr = mem[q + 0x38] | mem[q + 0x39] << 8;
+        if (Unp->info->run == -1)
+          Unp->Forced = 0x80b;
+        Unp->fStrAf = 0xfc;
+        PrintInfo(Unp, _I_CRUEL_RND);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  /* cruel 1.2 / unknown 2059 */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
+        (*(unsigned int *)(mem + 0x80f) == 0x0803B901) &&
+        (*(unsigned int *)(mem + 0x813) == 0xC800E399) &&
+        (*(unsigned int *)(mem + 0x817) == 0x004CF7D0) &&
+        (*(unsigned int *)(mem + 0x90b) == 0xC068FEC6)) {
+      Unp->DepAdr = 0x100;
+      Unp->Forced = 0x80b;
+      Unp->RetAdr = mem[0x91c] | mem[0x91d] << 8;
+      Unp->EndAdr = 0x2d;
+      Unp->fStrAf = 0xfc;
+      PrintInfo(Unp, _I_CRUEL12);
+      Unp->IdFlag = 1;
+      return;
+    }
+    /* this was found in Agile and S451 cracks, Galleon's "Cruel+Search"
+       it's actually the real v1.0
+    */
+    if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
+        (*(unsigned int *)(mem + 0x80f) == 0x0803B901) &&
+        (*(unsigned int *)(mem + 0x813) == 0xC800E399) &&
+        (*(unsigned int *)(mem + 0x8c5) == 0x011D4C04) &&
+        (*(unsigned int *)(mem + 0x90b) == 0xB1486018)) {
+      Unp->DepAdr = 0x100;
+      Unp->Forced = 0x80b;
+      Unp->RetAdr = mem[0x92d] | mem[0x92e] << 8;
+      Unp->EndAdr = 0x2d;
+      Unp->fStrAf = 0xfc;
+      PrintInfo(Unp, _I_CRUEL10);
+      Unp->IdFlag = 1;
+      return;
+    }
+    if ((*(unsigned int *)(mem + 0x80b) == 0xE67800A0) &&
+        (*(unsigned int *)(mem + 0x80f) == 0x0803B901) &&
+        (*(unsigned int *)(mem + 0x813) == 0xC800E399) &&
+        (*(unsigned int *)(mem + 0x8b7) == 0x011D4C04) &&
+        (*(unsigned int *)(mem + 0x8fc) == 0xB1486018)) {
+      Unp->DepAdr = 0x100;
+      Unp->Forced = 0x80b;
+      Unp->RetAdr = mem[0x91e] | mem[0x91f] << 8;
+      Unp->EndAdr = 0x2d;
+      Unp->fStrAf = 0xfc;
+      PrintInfo(Unp, _I_CRUEL14);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+
+  /* TKC "proggy crueler 2.3" (and 2.5) */
+  if (Unp->DepAdr == 0) {
+    if ((mem[0x810] == 0xb9) && (mem[0x819] == 0xa9) &&
+        (*(unsigned int *)(mem + 0x813) == 0xC800fa99) &&
+        (*(unsigned int *)(mem + 0x822) == 0x4CAF86AE)) {
+      p = mem[0x811] | mem[0x812] << 8;
+      q = p - 0x100;
+
+      if ((*(unsigned int *)(mem + p + 0x0c) == 0x20F7D0C8) &&
+          (*(unsigned int *)(mem + q) == 0xA9C8C8C8)) {
+        Unp->DepAdr = 0x100;
+        Unp->EndAdr = mem[p + 0x02] | mem[p + 0x03] << 8;
+        Unp->RetAdr = mem[q + 0x3f] | mem[q + 0x40] << 8;
+        if (Unp->info->run == -1)
+          Unp->Forced = 0x80b;
+        Unp->fStrAf = 0xfc;
+        PrintInfo(Unp, _I_CRUEL_TKC);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+}

--- a/terps/unp64/scanners/ECA.c
+++ b/terps/unp64/scanners/ECA.c
@@ -1,0 +1,167 @@
+/* ECA compacker */
+#include "../unp64.h"
+void Scn_ECA(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    // for(p=0x810;p<0x830;p+=0x4)
+    for (p = 0x80d; p < 0x830; p += 0x1) {
+      if ((*(unsigned int *)(mem + p + 0x08) == (unsigned int)0x2D9D0032 + p) &&
+          (*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
+          (*(unsigned int *)(mem + p + 0x0c) == 0xF710CA00)) {
+        if (((*(unsigned int *)(mem + p + 0x00) & 0xf4fff000) == 0x8434A000) &&
+            (*(unsigned int *)(mem + p + 0x04) == 0xBD05A201)) {
+          Unp->Forced = p + 1;
+        } else if (((*(unsigned int *)(mem + p + 0x00) & 0xffffff00) ==
+                    0x04A27800) &&
+                   (*(unsigned int *)(mem + p + 0x04) == 0xBDE80186)) {
+          Unp->Forced = p + 1;
+        } else if (((*(unsigned int *)(mem + p - 0x03) & 0xffffff00) ==
+                    0x04A27800) &&
+                   (*(unsigned int *)(mem + p + 0x04) == 0xBDE80186)) {
+          Unp->Forced = p - 2;
+        } else if (*(unsigned int *)(mem + p - 0x03) == 0x8D00a978) {
+          Unp->Forced = p - 2;
+        }
+      }
+      if (!Unp->Forced) {
+        if ((*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
+            (*(unsigned int *)(mem + p + 0x02) == 0x8534A978) &&
+            (mem[p - 3] == 0xa0)) {
+          Unp->Forced = p - 3;
+          if (mem[p + 0x0d6] == 0x20 && mem[p + 0x0d7] == 0xe0 &&
+              mem[p + 0x0d8] == 0x03 && mem[p + 0x1da] == 0x5b &&
+              mem[p + 0x1e7] == 0x59) {
+            /* antiprotection :D */
+            mem[p + 0x0d6] = 0x4c;
+            mem[p + 0x0d7] = 0xae;
+            mem[p + 0x0d8] = 0xa7;
+          }
+        }
+      }
+      if (!Unp->Forced) { /* FDT */
+        if ((*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
+            (*(unsigned int *)(mem + p + 0x03) == 0x8604A278) &&
+            (*(unsigned int *)(mem + p + 0x0a) == 0x2D950842)) {
+          Unp->Forced = p + 3;
+        }
+      }
+      if (!Unp->Forced) {
+        /* decibel hacks */
+        if ((*(unsigned int *)(mem + p + 0x3a) == 0x2a2a2a2a) &&
+            (*(unsigned int *)(mem + p + 0x00) == 0x9D085EBD) &&
+            (*(unsigned int *)(mem + p - 0x06) == 0x018534A9)) {
+          Unp->Forced = p - 0x6;
+        }
+      }
+      if (Unp->Forced) {
+        for (q = 0xd6; q < 0xde; q++) {
+          if (mem[p + q] == 0x20) {
+            if ((*(unsigned short int *)(mem + p + q + 1) == 0xa659) ||
+                (*(unsigned short int *)(mem + p + q + 1) == 0xff81) ||
+                (*(unsigned short int *)(mem + p + q + 1) == 0xe3bf) ||
+                (*(unsigned short int *)(mem + p + q + 1) == 0xe5a0) ||
+                (*(unsigned short int *)(mem + p + q + 1) == 0xe518)) {
+              mem[p + q] = 0x2c;
+              q += 2;
+              continue;
+            } else {
+              Unp->RetAdr = mem[p + q + 1] | mem[p + q + 2] << 8;
+              break;
+            }
+          }
+          if (mem[p + q] == 0x4c) {
+            Unp->RetAdr = mem[p + q + 1] | mem[p + q + 2] << 8;
+            break;
+          }
+        }
+        Unp->DepAdr = mem[p + 0x30] | mem[p + 0x31] << 8;
+        // some use $2d, some $ae
+        for (q = 0xed; q < 0x108; q++) {
+          if (*(unsigned int *)(mem + p + q) == 0xA518F7D0) {
+            Unp->EndAdr = mem[p + q + 4];
+            // if(Unp->DebugP)
+            // printf("EndAdr from $%02x\n",Unp->EndAdr);
+            break;
+          }
+        }
+        /*
+        if anything it's unpacked to $d000-efff, it will be copied
+        to $e000-ffff as last action in unpacker before starting.
+        0196  20 DA 01  JSR $01DA ; some have this jsr nopped, reloc doesn't
+        happen 0199  A9 37     LDA #$37 019b  85 01     STA $01 019d  58 CLI
+        019e  20 00 0D  JSR $0D00 ; retaddr can be either here or following
+        01a1  4C AE A7  JMP $A7AE
+        01da  B9 00 EF  LDA $EF00,Y
+        01dd  99 00 FF  STA $FF00,Y
+        01e0  C8        INY
+        01e1  D0 F7     BNE $01DA
+        01e3  CE DC 01  DEC $01DC
+        01e6  CE DF 01  DEC $01DF
+        01e9  AD DF 01  LDA $01DF
+        01ec  C9 DF     CMP #$DF   ;<< not fixed, found as lower as $44 for
+        example 01ee  D0 EA     BNE $01DA 01f0  60        RTS Because of this,
+        $d000-dfff will be a copy of $e000-efff. So if $2d points to >= $d000,
+        SOMETIMES it's better save upto $ffff or: mem[$2d]|(mem[$2e]+$10)<<8
+        Still it's not a rule and I don't know exactly when.
+        17/06/09: Implemented but still experimental, so better check
+        extensively. use -v to know when it does the adjustments. 28/10/09:
+        whoops, was clearing ONLY $d000-dfff =)
+        */
+        Unp->StrMem = mem[p + 0x32] | mem[p + 0x33] << 8;
+        PrintInfo(Unp, _I_ECA);
+        for (q = 0xcd; q < 0xd0; q++) {
+          if ((*(unsigned int *)(mem + p + q) & 0xffff00ff) == 0xa9010020) {
+            Unp->ECAFlg = mem[p + q + 1] | mem[p + q + 2] << 8;
+            for (q = 0x110; q < 0x11f; q++) {
+              if ((*(unsigned int *)(mem + p + q) == 0x99EF00B9) &&
+                  (mem[p + q + 0x12] == 0xc9)) {
+                Unp->ECAFlg |= (mem[p + q + 0x13] - 0xf) << 24;
+                break;
+              }
+            }
+            if (Unp->DebugP)
+              fprintf(stderr,
+                      "ECA reloc active at $%04x, from $%04x-$efff to "
+                      "$%04x-$ffff (use -l)\n",
+                      Unp->ECAFlg & 0xffff, (Unp->ECAFlg >> 16) & 0xffff,
+                      0x1000 + ((Unp->ECAFlg >> 16) & 0xffff));
+            break;
+          }
+        }
+        /* radwar hack has a BRK here, fffe/f used as IRQ/BRK vector */
+        if (mem[0x8e1] == 0) {
+          if (Unp->DebugP)
+            fprintf(stderr, "RWE BRK Hack patched\n");
+          mem[0x8e1] = 0x6c;
+          mem[0x8e2] = 0xfe;
+          mem[0x8e3] = 0xff;
+        }
+        break;
+      }
+    }
+    if (Unp->DepAdr) {
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /* old packer, many old 1985 warez used this */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x81b) == 0x018534A9) &&
+        (*(unsigned int *)(mem + 0x822) == 0xAFC600A0) &&
+        (*(unsigned int *)(mem + 0x826) == 0xB1082DCE) &&
+        (*(unsigned int *)(mem + 0x85b) == 0x2A2A2A2A)) {
+      Unp->Forced = 0x81b;
+      Unp->DepAdr = 0x100;
+      Unp->StrMem = mem[0x853] | mem[0x854] << 8;
+      Unp->EndAdr = mem[0x895];
+      Unp->RetAdr = mem[0x885] | mem[0x886] << 8;
+      PrintInfo(Unp, _I_ECAOLD);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/Exomizer.c
+++ b/terps/unp64/scanners/Exomizer.c
@@ -1,0 +1,157 @@
+/* scan for Exomizer */
+#include "../unp64.h"
+void Scn_Exomizer(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  /* exomizer 3.x */
+  if (Unp->DepAdr == 0) {
+    for (p = Unp->info->end - 1; p > Unp->info->start; p--) {
+      if ((*(unsigned int *)(mem + p) == 0x100A8069) &&
+          (*(unsigned int *)(mem + p + 4) == 0xD0FD060F) &&
+          mem[p - 6] == 0x4c && mem[p - 4] == 0x01) {
+        p -= 5;
+        q = 2;
+        if (mem[p - q] == 0x8a)
+          q++;
+
+        /* low byte of EndAdr, it's a lda $ff00,y */
+
+        if ((mem[p - q - 1] == mem[p - q - 3]) &&
+            (mem[p - q - 2] ==
+             mem[p - q])) { /* a0 xx a0 xx -> exomizer 3.0/3.01 */
+          Unp->ExoFnd = 0x30;
+        } else { /* d0 c1 a0 xx -> exomizer 3.0.2, force +1 in start/end */
+          Unp->ExoFnd = 0x32;
+        }
+        Unp->ExoFnd |= (mem[p - q] << 8);
+        break;
+      }
+    }
+    if (Unp->ExoFnd) {
+      Unp->DepAdr = 0x100 | mem[p];
+      if ((Unp->ExoFnd & 0xff) == 0x30)
+        PrintInfo(Unp, _I_EXOM3);
+      else
+        PrintInfo(Unp, _I_EXOM302);
+      for (; p < Unp->info->end; p++) {
+        if (*(unsigned int *)(mem + p) == 0x7d010020)
+          break;
+      }
+      for (; p < Unp->info->end; p++) {
+        if (mem[p] == 0x4c) {
+          Unp->RetAdr = 0;
+          if ((Unp->RetAdr = mem[p + 1] | mem[p + 2] << 8) >= 0x200) {
+            if (!Unp->IdOnly && Unp->DebugP)
+              fprintf(stderr, "return = $%04x\n", Unp->RetAdr);
+            break;
+          } else { /* it's a jmp $01xx, goto next */
+            p++;
+            p++;
+          }
+        }
+      }
+      if (Unp->info->run == -1) {
+        p = Unp->info->start;
+        q = p + 0x10;
+        for (; p < q; p++) {
+          if ((mem[p] == 0xba) && (mem[p + 1] == 0xbd)) {
+            Unp->Forced = p;
+            break;
+          }
+        }
+        for (q = p - 1; q >= Unp->info->start; q--) {
+          if (mem[q] == 0xe6)
+            Unp->Forced = q;
+          if (mem[q] == 0xa0)
+            Unp->Forced = q;
+          if (mem[q] == 0x78)
+            Unp->Forced = q;
+        }
+      }
+    }
+  }
+  /* exomizer 1.x/2.x */
+  if (Unp->DepAdr == 0) {
+    for (p = Unp->info->end - 1; p > Unp->info->start; p--) {
+      if ((((*(unsigned int *)(mem + p) == 0x4CF7D088) &&
+            (*(unsigned int *)(mem + p - 0x0d) == 0xD034C0C8)) ||
+           ((*(unsigned int *)(mem + p) == 0x4CA7A438) &&
+            (*(unsigned int *)(mem + p - 0x0c) == 0x799FA5AE)) ||
+           ((*(unsigned int *)(mem + p) == 0x4CECD08A) &&
+            (*(unsigned int *)(mem + p - 0x13) == 0xCECA0EB0)) ||
+           ((*(unsigned int *)(mem + p) == 0x4C00A0D3) &&
+            (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8)) ||
+           ((*(unsigned int *)(mem + p) == 0x4C00A0D2) &&
+            (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8))) &&
+          mem[p + 5] == 1) {
+        p += 4;
+        Unp->ExoFnd = 1;
+        break;
+      } else if ((((*(unsigned int *)(mem + p) == 0x8C00A0d2) &&
+                   (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8)) ||
+                  ((*(unsigned int *)(mem + p) == 0x8C00A0d3) &&
+                   (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8)) ||
+                  ((*(unsigned int *)(mem + p) == 0x8C00A0cf) &&
+                   (*(unsigned int *)(mem + p - 0x04) == 0xD034C0C8))) &&
+                 mem[p + 6] == 0x4c && mem[p + 8] == 1) {
+        p += 7;
+        Unp->ExoFnd = 1;
+        break;
+      }
+    }
+    if (Unp->ExoFnd) {
+      Unp->DepAdr = 0x100 | mem[p];
+      PrintInfo(Unp, _I_EXOM);
+      if (Unp->DepAdr >= 0x134 && Unp->DepAdr <= 0x14a /*0x13e*/) {
+        for (p = Unp->info->end - 4; p > Unp->info->start;
+             p--) { /* 02 04 04 30 20 10 80 00 */
+          if (*(unsigned int *)(mem + p) == 0x30040402)
+            break;
+        }
+      } else {
+        // exception for exo v1.x, otherwise add 8 to the counter and
+        // scan backward from here
+        if (Unp->DepAdr != 0x143)
+          p += 0x08;
+        else
+          p -= 0xb8;
+      }
+      for (; p > Unp->info->start; p--) {
+        // incredibly there can be a program starting at $4c00 :P
+        if ((mem[p] == 0x4c) && (mem[p - 1] != 0x4c) && (mem[p - 2] != 0x4c)) {
+          Unp->RetAdr = 0;
+          if ((Unp->RetAdr = mem[p + 1] | mem[p + 2] << 8) >= 0x200) {
+            if (!Unp->IdOnly && Unp->DebugP)
+              fprintf(stderr, "return = $%04x\n", Unp->RetAdr);
+            break;
+          }
+        }
+      }
+      if (Unp->info->run == -1) {
+        p = Unp->info->start;
+        q = p + 0x10;
+        for (; p < q; p++) {
+          if ((mem[p] == 0xba) && (mem[p + 1] == 0xbd)) {
+            Unp->Forced = p;
+            break;
+          }
+        }
+        for (q = p - 1; q >= Unp->info->start; q--) {
+          if (mem[q] == 0xe6)
+            Unp->Forced = q;
+          if (mem[q] == 0xa0)
+            Unp->Forced = q;
+          if (mem[q] == 0x78)
+            Unp->Forced = q;
+        }
+      }
+    }
+  }
+  if (Unp->DepAdr != 0) {
+    Unp->IdFlag = 1;
+    return;
+  }
+}

--- a/terps/unp64/scanners/Expert.c
+++ b/terps/unp64/scanners/Expert.c
@@ -1,0 +1,240 @@
+/* check for Trilogic Expert */
+#include "../unp64.h"
+void Scn_Expert(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    for (q = 0x81b; q < 0x81d; q++) {
+      if ((*(unsigned int *)(mem + q + 0x00) == 0x852FA978) &&
+          (*(unsigned int *)(mem + q + 0x04) == 0x8534A900) &&
+          (*(unsigned int *)(mem + q + 0x14) == 0x03860286)) {
+        for (p = 0x900; p < 0xfff0; p++) {
+          if ((*(unsigned int *)(mem + p + 1) == 0x00084C9A) &&
+              (*(unsigned int *)(mem + p - 4) == 0xA2058604)) {
+            if (Unp->info->run == -1) {
+              Unp->Forced = q;
+              Unp->info->run = q;
+            }
+            q = 0x100 + mem[p] + 1;
+            if (q != 0x100) {
+              Unp->DepAdr = q;
+            }
+          }
+        }
+        break;
+      }
+    }
+    if (Unp->DepAdr) {
+      Unp->RTIFrc = 1;
+      if (*(unsigned int *)(mem + 0x835) == 0x6E8D48A9) {
+        p = 0;
+        if (*(unsigned int *)(mem + 0x92c) == 0x4902B100) {
+          PrintInfo(Unp, _I_EXPERT27);
+          if (!Unp->IdOnly) {
+            p = 0x876;
+            if (Unp->DebugP)
+              fprintf(stderr, "\nantihack patched @ $%04x\n", p);
+            mem[p] = 0x00; /* 1st anti hack */
+            p = mem[0x930];
+          }
+        } else if (*(unsigned int *)(mem + 0x92f) == 0x4902B100) {
+          PrintInfo(Unp, _I_EXPERT29);
+          if (!Unp->IdOnly) {
+            p = 0x873;
+            if (Unp->DebugP)
+              fprintf(stderr, "\nantihack patched @ $%04x\n", p);
+            mem[p] = 0xa9; /* 1st anti hack */
+            mem[p + 1] = 0x02;
+            p = mem[0x933];
+          }
+        } else {
+          PrintInfo(Unp, _I_EXPERT2X);
+        }
+        if (p && !Unp->IdOnly) {
+          p |= (p << 24) | (p << 16) | (p << 8);
+          for (q = 0x980; q < 0xfff0; q++) {
+            if (((mem[q] ^ (p & 0xff)) == 0xac) &&
+                ((mem[q + 3] ^ (p & 0xff)) == 0xc0) &&
+                (((*(unsigned int *)(mem + q + 7)) ^ p) == 0xC001F2AC)) {
+              if (Unp->DebugP)
+                fprintf(stderr, "\nantihack patched @ $%04x\n", q);
+              mem[q + 0x06] = (p & 0xff); /* 2nd anti hack */
+              mem[q + 0x0d] = (p & 0xff);
+              break;
+            }
+          }
+        }
+      } else {
+        PrintInfo(Unp, _I_EXPERT20);
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x81b) == 0x2FA9D878) &&
+        (*(unsigned int *)(mem + 0x82d) == 0x0873BDB0)) {
+      for (p = 0x900; p < 0xfff0; p++) {
+        if ((*(unsigned int *)(mem + p) == 0xA2F3D0CA) &&
+            (mem[p + 0x05] == 0x4c)) {
+          q = mem[p + 0x06] | mem[p + 0x07] << 8;
+          if (q != 0x100) {
+            Unp->DepAdr = q;
+            break;
+          }
+        }
+      }
+      if (Unp->DepAdr) {
+        Unp->RTIFrc = 1;
+        Unp->Forced = 0x81b;
+        PrintInfo(Unp, _I_EXPERT21);
+      }
+    }
+  }
+  /* 2.9 Expert User Club version, found in
+     BloodMoney/HTL & SWIV/Inceria
+  */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x81b) == 0x8C00A078) &&
+        (*(unsigned int *)(mem + 0x831) == 0x05860485) &&
+        (*(unsigned int *)(mem + 0x998) == 0x00084C9A)) {
+      p = mem[0x919];
+      q = p << 24 | p << 16 | p << 8 | p;
+      for (p = 0x900; p < 0xfff0; p++) {
+        if (((*(unsigned int *)(mem + p) ^ q) == 0xA2F3D0CA) &&
+            ((mem[p + 0x05] ^ (q & 0xff)) == 0x4c)) {
+          q = (mem[p + 0x06] ^ (q & 0xff)) | (mem[p + 0x07] ^ (q & 0xff)) << 8;
+          if (q != 0x100) {
+            Unp->DepAdr = q;
+            break;
+          }
+        }
+      }
+      if (Unp->DepAdr) {
+        Unp->RTIFrc = 1;
+        Unp->Forced = 0x81b;
+        PrintInfo(Unp, _I_EXPERT29EUC);
+      }
+    }
+  }
+  /* sys2070 A.S.S. */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x817) == 0x00852FA9) &&
+        (*(unsigned int *)(mem + 0x823) == 0x05860485) &&
+        (*(unsigned int *)(mem + 0x9a0) == 0x00084C9A)) {
+      p = mem[0x923];
+      q = p << 24 | p << 16 | p << 8 | p;
+      for (p = 0x900; p < 0xfff0; p++) {
+        if (((*(unsigned int *)(mem + p) ^ q) == 0xA2F3D0CA) &&
+            ((mem[p + 0x05] ^ (q & 0xff)) == 0x4c)) {
+          q = (mem[p + 0x06] ^ (q & 0xff)) | (mem[p + 0x07] ^ (q & 0xff)) << 8;
+          if (q != 0x100) {
+            Unp->DepAdr = q;
+            break;
+          }
+        }
+      }
+      if (Unp->DepAdr) {
+        Unp->RTIFrc = 1;
+        Unp->Forced = 0x81b;
+        PrintInfo(Unp, _I_EXPERTASS);
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x81b) == 0x7FA978D8) ||
+        (*(unsigned int *)(mem + 0x81b) == 0x7FA9D878) ||
+        (*(unsigned int *)(mem + 0x816) == 0x7FA978D8)) {
+      for (p = 0x900; p < 0xfff0; p++) {
+        if ((*(unsigned int *)(mem + p) == 0xA2F3D0CA) &&
+            (mem[p + 0x05] == 0x4c)) {
+          q = mem[p + 0x06] | mem[p + 0x07] << 8;
+          if (q != 0x100) {
+            Unp->DepAdr = q;
+            break;
+          }
+        }
+      }
+      if (Unp->DepAdr) {
+        Unp->RTIFrc = 1;
+        if (*(unsigned int *)(mem + 0x816) == 0x7FA978D8) {
+          q = 0x816;
+          PrintInfo(Unp, _I_EXPERT4X);
+          if (!Unp->IdOnly) {
+            for (p = 0x900; p < 0xfff0; p++) {
+              if ((*(unsigned int *)(mem + p) == 0xE0A9F0A2) &&
+                  (*(unsigned int *)(mem + p + 4) == 0xE807135D) &&
+                  (mem[p + 0x8] == 0xd0)) {
+                if (Unp->DebugP)
+                  fprintf(stderr, "\nantihack patched @ $%04x\n", p);
+                mem[p + 0x1] = 0x00;
+                mem[p + 0x3] = 0x98;
+                memset(mem + p + 4, 0xea, 6);
+                break;
+              }
+            }
+          }
+        } else {
+          q = 0x81b;
+          PrintInfo(Unp, _I_EXPERT3X);
+          if (!Unp->IdOnly) {
+            for (p = 0x900; p < 0xfff0; p++) {
+              if ((*(unsigned int *)(mem + p) == 0xCA08015D) &&
+                  (*(unsigned int *)(mem + p + 4) == 0xF8D003E0) &&
+                  (mem[p + 0xa] == 0xd0)) {
+                p += 0xa;
+                if (Unp->DebugP)
+                  fprintf(stderr, "\nantihack patched @ $%04x\n", p);
+                mem[p] = 0x24;
+                break;
+              }
+            }
+          }
+        }
+        if (Unp->info->run == -1) {
+          Unp->Forced = q;
+          Unp->info->run = q;
+        }
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    q = 0x81b;
+    if ((*(unsigned int *)(mem + q + 0x00) == 0x852FA978) &&
+        (*(unsigned int *)(mem + q + 0x04) == 0x8534A900) &&
+        (*(unsigned int *)(mem + q + 0x14) == 0x03860286) &&
+        (*(unsigned int *)(mem + q + 0x4f) == 0xA200594C) &&
+        (*(unsigned int *)(mem + q + 0xad) == 0x2000124C)) {
+      Unp->Forced = q;
+      Unp->info->run = q;
+      Unp->DepAdr = 0x12;
+      Unp->RTIFrc = 1;
+      PrintInfo(Unp, _I_EXPERT1X);
+    }
+  }
+  /* expert 2.11 (sys2074) & unknown sys2061 */
+  if (Unp->DepAdr == 0) {
+    for (q = 0x80d; q < 0x820; q++) {
+      if ((*(unsigned int *)(mem + q + 0x00) == 0x852FA978) &&
+          (*(unsigned int *)(mem + q + 0x04) == 0x8534A900) &&
+          (*(unsigned int *)(mem + q + 0x13) == 0x03840284) &&
+          (*(unsigned int *)(mem + q + 0x4f) == 0x084C003A) &&
+          (*(unsigned int *)(mem + q + 0xad) == 0x00AA2048)) {
+        Unp->Forced = q;
+        Unp->info->run = q;
+        Unp->DepAdr = 0x100 + mem[q + 0x17a] + 1;
+        break;
+      }
+    }
+    if (Unp->DepAdr != 0) {
+      Unp->RTIFrc = 1;
+      PrintInfo(Unp, _I_EXPERT211);
+    }
+  }
+
+  if (Unp->DepAdr != 0) {
+    Unp->IdFlag = 1;
+    return;
+  }
+}

--- a/terps/unp64/scanners/FinalSuperComp.c
+++ b/terps/unp64/scanners/FinalSuperComp.c
@@ -1,0 +1,271 @@
+/* FinalSuperCompressor/flexible */
+#include "../unp64.h"
+void Scn_FinalSuperComp(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q,p;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        if(((*(unsigned int*)(mem+0x810)&0xff00ff00)==0x9A00A200) &&
+            (*(unsigned int*)(mem+0x832)==0x0DF008C9) &&
+            (*(unsigned int*)(mem+0x836)==0xB1083DCE) &&
+            (*(unsigned int*)(mem+0x8af)==0x4C00FFBD) &&
+            ((mem[0x88e]==0x4c)||(mem[0x889]==0x4c)) )
+        {
+            mem[0x812]=0xff; /* fixed, can't be otherwise */
+            Unp->DepAdr=mem[0x856]|mem[0x857]<<8;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x811;
+            for(p=0x889;p<0x88f;p++)
+            {
+                if(mem[p]==0x4c)
+                {
+                    Unp->RetAdr=mem[p+1]|mem[p+2]<<8;
+                    break;
+                }
+            }
+            Unp->StrMem=mem[0x872]|mem[0x873]<<8;
+            Unp->EndAdr=mem[0x84e]|mem[0x852]<<8;Unp->EndAdr++;
+            PrintInfo(Unp,_I_SUPCOMFLEX);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* SC/EqualSequences, FinalPack4/UA and TLC packer (sys2061/2064/2065/2066) */
+    if( Unp->DepAdr==0 )
+    {
+        for(p=0x80d;p<0x830;p++)
+        {
+            if(mem[p+2]==0xb9)
+            {
+                if( mem[p+5]==0x99 && mem[p+0x15]==0x4c &&
+                    mem[p+0x10]==mem[p+0x81] &&
+                    (*(unsigned int*)(mem+p+0x78)==0x18F7D0FC) &&
+                    (*(unsigned int*)(mem+p+0x8c)==0xD0FCC4C8) )
+                {
+                    Unp->DepAdr=mem[p+0x16]|mem[p+0x17]<<8;
+                    for(q=0x80b;q<0x813;q++)
+                    {
+                        if(mem[q]==0x78)
+                        {
+                            Unp->Forced=q;
+                            break;
+                        }
+                    }
+                    if(q==0x813)
+                    {
+                        if(mem[p]==0xa0)
+                            Unp->Forced=p;
+                    }
+                    Unp->EndAdr=mem[p+0x10]; /* either 0x2d or 0xae */
+                    Unp->StrMem=mem[p+0x2c]|mem[p+0x2d]<<8; /* $0800 fixed? */
+                    p+=0x40;
+                    while((mem[p]!=0x4c) && (p<0x860))
+                        p++;
+                    Unp->RetAdr=mem[p+1]|mem[p+2]<<8;
+                    PrintInfo(Unp,_I_SUPCOMEQSE);
+                    break;
+                }
+            }
+        }
+        if(Unp->DepAdr)
+        {
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* SC/Equal chars */
+    if( Unp->DepAdr==0 )
+    {
+        if(((*(unsigned int*)(mem+0x810)&0xf0ffffff)==0xA0A93878) &&
+           ((*(unsigned int*)(mem+0x814)==0xFC852DE5)||
+            (*(unsigned int*)(mem+0x814)==0xFC85aeE5))&&
+           ((*(unsigned int*)(mem+0x818)==0xafE508A9)||
+            (*(unsigned int*)(mem+0x818)==0x2EE508A9))&&
+           ((*(unsigned int*)(mem+0x844)&0x00ffffff)==0x00004C9A) )
+        {
+            Unp->DepAdr=mem[0x846]|mem[0x847]<<8;
+            Unp->Forced=0x810;
+            Unp->RetAdr=mem[0x872]|mem[0x873]<<8;
+            Unp->EndAdr=mem[0x866]; /* either 0x2d or 0xae */
+            Unp->StrMem=mem[0x857]|mem[0x858]<<8;
+            Unp->StrMem+=mem[0x849]; /* ldx #$?? -> sta $????,x; not always 0! */
+            PrintInfo(Unp,_I_SUPCOMEQCH);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* FinalSuperCompressor/flexible hacked? */
+    if( Unp->DepAdr==0 )
+    {
+        if(((*(unsigned int*)(mem+0x80d)&0xff00ffff)==0x9A00A278) &&
+            (*(unsigned int*)(mem+0x814)==0x9D0847BD) &&
+            (*(unsigned int*)(mem+0x818)==0x21BD0334) &&
+            (*(unsigned int*)(mem+0x81c)==0x040E9D09) &&
+            mem[0x878]==0x4c)
+        {
+            mem[0x80f]=0xff; /* fixed, can't be otherwise */
+            Unp->DepAdr=0x334;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x80d;
+            Unp->RetAdr=mem[0x879]|mem[0x87a]<<8;
+            //Unp->StrMem=mem[0x861]|mem[0x862]<<8;
+            /* patch */
+            mem[0x2a7]=0x85;
+            mem[0x2a8]=0x01;
+            mem[0x2a9]=0x4c;
+            mem[0x2aa]=mem[0x879];
+            mem[0x2ab]=mem[0x87a];
+            Unp->StrMem=0x2a7;
+            Unp->fEndAf=0x34e; Unp->EndAdC=0xffff;
+            Unp->Recurs=RECUMAX-2;
+            PrintInfo(Unp,_I_SUPCOMFH11);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* FinalSuperCompressor/flexible hacked? 2nd layer */
+    if( Unp->DepAdr==0 )
+    {
+        if(Unp->info->start == 0x2a7 )
+        {
+            if( mem[0x2a7]==0x85&&
+                mem[0x2a8]==0x01&&
+                mem[0x2a9]==0x4c )
+            {
+                p=mem[0x2aa]|mem[0x2ab]<<8;
+                if( (*(unsigned int*)(mem+p     )==((((mem[0x2aa]+0x15)&0xff)<<24)|0x00B99EA0)) &&
+                    (*(unsigned int*)(mem+p+0x96)==0x033B4CFE) )
+                {
+                    Unp->Forced=0x2a7;
+                    Unp->DepAdr=0x334;
+                    Unp->RetAdr=mem[p+0x2c]|mem[p+0x2d]<<8;
+                    //Unp->StrMem=mem[p+0x17]|mem[p+0x18];
+                    Unp->StrMem=0x2ac;
+                    mem[0x2ac]=0x85;
+                    mem[0x2ad]=0x01;
+                    mem[0x2ae]=0x4c;
+                    mem[0x2af]=mem[p+0x2c];
+                    mem[0x2b0]=mem[p+0x2d];
+                    Unp->fEndAf=0x335; Unp->EndAdC=EA_USE_Y|0xffff;
+                    PrintInfo(Unp,_I_SUPCOMFH12);
+                    Unp->IdFlag=1;return;
+                }
+            }
+        }
+    }
+    /* FinalSuperCompressor/flexible hacked? 3rd layer */
+    if( Unp->DepAdr==0 )
+    {
+        if(Unp->info->start == 0x2ac )
+        {
+            if( mem[0x2ac]==0x85&&
+                mem[0x2ad]==0x01&&
+                mem[0x2ae]==0x4c )
+            {
+                p=mem[0x2af]|mem[0x2b0]<<8;
+                if( (mem[p]==0xa9) &&
+                    (*(unsigned int*)(mem+p+0x0a)==0xAF852E85)&&
+                    (*(unsigned int*)(mem+p+0x1f)==0x8D034B4C) )
+                {
+                    Unp->Forced=0x2ac;
+                    Unp->DepAdr=0x34b;
+                    Unp->fEndAf=0x2d;
+                    PrintInfo(Unp,_I_SUPCOMFH13);
+                    Unp->IdFlag=1;return;
+                }
+            }
+        }
+    }
+    /* another special hack */
+    if( Unp->DepAdr==0 )
+    {
+        if(((*(unsigned int*)(mem+0x80d)&0xff00ffff)==0x9a00a278) &&
+            (*(unsigned int*)(mem+0x811)==0x018534a9) &&
+            (*(unsigned int*)(mem+0x818)==0x34990846) &&
+            (*(unsigned int*)(mem+0x81c)==0x0927b903) &&
+            (mem[0x87e]==0x4c))
+        {
+            mem[0x80f]=0xff; /* fixed, can't be otherwise */
+            Unp->DepAdr=0x334;
+            if(Unp->info->run == -1)
+                Unp->Forced=0x80d;
+            //Unp->RetAdr=mem[0x87f]|mem[0x880]<<8;
+            Unp->RetAdr=0x7f8;
+            //Unp->StrMem=mem[0x860]|mem[0x861]<<8;
+            Unp->StrMem=Unp->RetAdr;
+            Unp->fEndAf=0x34e;
+            p=0x7f8;
+            mem[p++]=0x85;
+            mem[p++]=0x01;
+            mem[p++]=0x4c;
+            mem[p++]=mem[0x87f];
+            mem[p++]=mem[0x880];
+            //Unp->Recurs=6;
+            PrintInfo(Unp,_I_SUPCOMFH21);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Flexible / Generic Hack */
+    if( Unp->DepAdr==0 )
+    {
+        if( (*(unsigned int*)(mem+0x8b0)==0x4D4C00FF) &&
+            (*(unsigned int*)(mem+0x918)==0x4D4C0187) &&
+            (*(unsigned int*)(mem+0x818)==0x57BDCCA2) &&
+           ((*(unsigned int*)(mem+0x81c)&0xf0ffffff)==0x00339d08) &&
+            (mem[0x88e]==0x4c))
+        {
+            Unp->DepAdr=mem[0x856]|mem[0x857]<<8;
+            for(p=0x80b;p<0x818;p++)
+            {
+                if(mem[p]==0x78)
+                {
+                    Unp->Forced=p;
+                    break;
+                }
+            }
+            Unp->RetAdr=mem[0x88f]|mem[0x890]<<8;
+            Unp->StrMem=mem[0x872]|mem[0x873]<<8;
+            Unp->EndAdr=mem[0x84e]|mem[0x852]<<8;Unp->EndAdr++;
+            PrintInfo(Unp,_I_SUPCOMHACK);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* eq seq + indirect jmp ($0348) -> expects $00b9 containing $60 (rts) */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x810)==0x8534A978) &&
+           (*(unsigned int*)(mem+0x834)==0x03354C48) &&
+           (*(unsigned int*)(mem+0x850)==0xF0C81BF0) &&
+           (*(unsigned int*)(mem+0x865)==0xEE03486C) )
+        {
+            Unp->DepAdr=0x335;
+            Unp->Forced=0x810;
+            Unp->RetAdr=mem[0x82f]|mem[0x80e]<<8;Unp->RetAdr++;
+            mem[0xb9]=0x60;
+            mem[0x865]=0x4c;
+            mem[0x866]=Unp->RetAdr&0xff;
+            mem[0x867]=Unp->RetAdr>>8;
+            Unp->EndAdr=mem[0x825]; /* either 0x2d or 0xae */
+            Unp->StrMem=mem[0x84c]|mem[0x84d]<<8;
+            PrintInfo(Unp,_I_SUPCOMEQB9);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* eq char hack, usually 2nd layer of previous eq seq hack */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x810)==0x1EB97FA0) &&
+           (*(unsigned int*)(mem+0x814)==0x033B9908) &&
+           (*(unsigned int*)(mem+0x838)==0xFE912DB1) &&
+           (*(unsigned int*)(mem+0x88a)==0xFE850369) )
+        {
+            Unp->DepAdr=0x33b;
+            Unp->Forced=0x810;
+            Unp->RetAdr=mem[0x89a]|mem[0x89b]<<8;
+            Unp->fEndAf=0x2d;
+            Unp->StrMem=0x800; /* fixed */
+            PrintInfo(Unp,_I_SUPCOMEQC9);
+            Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/Intros.c
+++ b/terps/unp64/scanners/Intros.c
@@ -1,0 +1,463 @@
+/* Bypass known intros that need some fiddling */
+/* Also some virus added here, they can be easily removed, so why not? */
+
+#include "../unp64.h"
+void Scn_Intros(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q=0,p;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    /* HIV virus */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x80b)==0x10DD002C) &&
+           (*(unsigned int*)(mem+0x84f)==0x34A9EDDD) &&
+           (*(unsigned int*)(mem+0x8a1)==0xA94D2D57) &&
+           (*(unsigned int*)(mem+0x9bc)==0xF004B120) )
+        {
+            Unp->Forced=0x859;
+            Unp->DepAdr=0x100;
+            Unp->RetAdr=0xa7ae;
+            //Unp->StrMem=mem[0x9fb]|mem[0x9fc]<<8;
+            Unp->StrMem=0x801;
+            Unp->EndAdr=0x2d;
+            PrintInfo(Unp,_I_HIVIRUS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* BHP virus */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x821)==0xADA707F0) &&
+           (*(unsigned int*)(mem+0x825)==0x32A55DA6) &&
+           (*(unsigned int*)(mem+0x920)==0xD13D20D1) &&
+           (*(unsigned int*)(mem+0xef5)==0x02CD4C20) )
+        {
+            Unp->Forced=0x831;
+            Unp->DepAdr=0x2ab;
+            Unp->RetAdr=0xa7ae;
+            Unp->RtAFrc=1;
+            Unp->StrMem=0x801;
+            Unp->EndAdr=0x2d;
+            PrintInfo(Unp,_I_BHPVIRUS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Bula virus */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x810)==0x78084220) &&
+           (*(unsigned int*)(mem+0x853)==0x4DA908F6) &&
+           (*(unsigned int*)(mem+0xa00)==0xF00348AD) &&
+           (*(unsigned int*)(mem+0xac4)==0x04B14C0D) )
+        {
+            Unp->Forced=0x810;
+            Unp->DepAdr=0x340;
+            Unp->RetAdr=0xa7ae;
+            Unp->RtAFrc=1;
+            Unp->StrMem=0x801;
+            Unp->EndAdr=Unp->info->end-0x2fa;
+            PrintInfo(Unp,_I_BULAVIRUS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Coder virus */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x81f)==0xD3018D08) &&
+           (*(unsigned int*)(mem+0x823)==0xA9082D8D) &&
+           (*(unsigned int*)(mem+0x89F)==0x78802C20) &&
+           (*(unsigned int*)(mem+0x8AF)==0x6CE3974C) )
+        {
+            Unp->Forced=0x812;
+            Unp->DepAdr=0x2b3;
+            Unp->RetAdr=0xa7ae;
+            Unp->RtAFrc=1;
+            Unp->StrMem=0x801;
+            Unp->EndAdr=0x2d;
+            PrintInfo(Unp,_I_CODERVIRUS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Boa virus */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x80b)==0x10A900A0) &&
+           (*(unsigned int*)(mem+0x81b)==0xEDDD2008) &&
+           (*(unsigned int*)(mem+0x85F)==0x0401004C) &&
+           (*(unsigned int*)(mem+0x9F6)==0x04EE4C00) )
+        {
+            Unp->Forced=0x80b;
+            Unp->DepAdr=0x100;
+            Unp->RetAdr=0xa7ae;
+            Unp->RtAFrc=1;
+            Unp->StrMem=0x801;
+            Unp->EndAdr=0x2d;
+            PrintInfo(Unp,_I_BOAVIRUS);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Relax intros */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0xB50)==0x0C632078) &&
+           (*(unsigned int*)(mem+0xb54)==0xA90C5A20) &&
+           (*(unsigned int*)(mem+0xc30)==0x4C0D6420) &&
+           (*(unsigned int*)(mem+0xc34)==0x00A2EA31) )
+        {
+            Unp->Forced=2070;
+            Unp->DepAdr=0x100;
+            Unp->RetAdr=mem[0xbea]|mem[0xbeb]<<8;
+            Unp->RtAFrc=1;
+            Unp->StrMem=0x0801;
+            Unp->EndAdr=0x2d;
+            mem[0xbae]=0x24; /* lda $c5 is not simulated in UNP64 */
+            PrintInfo(Unp,_I_IRELAX1);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x816)==0x2ABD00A2) &&
+           (*(unsigned int*)(mem+0x81a)==0xCE009D08) &&
+           (*(unsigned int*)(mem+0x826)==0xCE004CF1) &&
+           (*(unsigned int*)(mem+0x9F9)==0x5A5A5A5A) )
+        {
+            Unp->Forced=0x816;
+            Unp->DepAdr=0xcf7e; /* highmem unpacker always need to be managed */
+            Unp->RetAdr=mem[0x9a9]|mem[0x9aa]<<8;
+            Unp->RtAFrc=1;
+            Unp->StrMem=0x0801;
+            Unp->EndAdr=0x2d;
+            PrintInfo(Unp,_I_IRELAX2);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* F4CG */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x812)==0x20FDA320) &&
+           (*(unsigned int*)(mem+0x890)==0x06309DD8) &&
+           (*(unsigned int*)(mem+0x9BF)==0xA2A9D023) &&
+           (*(unsigned int*)(mem+0xa29)==0xFFFF2CFF) )
+        {
+            Unp->Forced=0x812;
+            Unp->DepAdr=0x110;
+            p=mem[0x8ee];
+            Unp->RetAdr=(mem[0xe44]^p)|(mem[0xe45]^p)<<8;
+            Unp->StrMem=0x0801;
+            Unp->EndAdr=mem[0x8f8]|mem[0x8fc]<<8;
+            mem[0xa2d]=0x4c;  /* indirect jmp $0110 using basic rom */
+            mem[0xa2e]=0x10;
+            mem[0xa2f]=0x01;
+            PrintInfo(Unp,_I_IF4CG23);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Triad */
+    if( Unp->DepAdr==0 )
+    {
+        for(p=0x80d;p<0x828;p++)
+        {
+            if( (*(unsigned int*)(mem+p+0x000)==0xA9D0228D) &&
+                (*(unsigned int*)(mem+p+0x00c)==0x06979D0A) &&
+                (*(unsigned int*)(mem+p+0x0a0)==0x03489D03) &&
+                (*(unsigned int*)(mem+p+0x0a4)==0x9D0371BD) )
+            {
+
+                for(q=0;q<5;q+=4)
+                {
+                    if( (*(unsigned int*)(mem+p+0x1ec+q)==0x04409D04) &&
+                        (*(unsigned int*)(mem+p+0x210+q)==0x607EFF60) )
+                    {
+                        Unp->DepAdr=0x100;
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+        if(Unp->DepAdr)
+        {
+            Unp->Forced=p;
+            Unp->RetAdr=mem[p+q+0x28a]|mem[p+q+1+0x28a]<<8;
+            Unp->EndAdr=mem[p+q+0x19e]|mem[p+q+0x1a4]<<8;
+            Unp->StrMem=0x801;
+            PrintInfo(Unp,_I_ITRIAD1);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x81f)==0xA2D0228D) &&
+           (*(unsigned int*)(mem+0x823)==0x0A5CBD28) &&
+           (*(unsigned int*)(mem+0x8d7)==0x8509754C) &&
+           (*(unsigned int*)(mem+0x975)==0x07A053A2) )
+        {
+            Unp->DepAdr=0x100;
+            Unp->Forced=0x81f;
+            Unp->RetAdr=mem[0xac3]|mem[0xac4]<<8;
+            Unp->EndAdr=mem[0x9cd]|mem[0x9d3]<<8;
+            Unp->StrMem=0x801;
+            PrintInfo(Unp,_I_ITRIAD2);
+            Unp->IdFlag=1;return;
+        }
+    }
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x821)==0xA9D0228D) &&
+           (*(unsigned int*)(mem+0x82a)==0x0A3aBD28) &&
+           (*(unsigned int*)(mem+0x8a7)==0x85093c4C) &&
+           (*(unsigned int*)(mem+0x93c)==0x17108EC6) )
+        {
+            Unp->DepAdr=0x100;
+            Unp->Forced=0x821;
+            Unp->RetAdr=mem[0xa99]|mem[0xa9a]<<8;
+            Unp->EndAdr=mem[0x9bc]|mem[0x9c2]<<8;
+            Unp->StrMem=0x801;
+            PrintInfo(Unp,_I_ITRIAD5);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* Snacky/G*P */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x818)==0x018533A9) &&
+           (*(unsigned int*)(mem+0x888)==0x08684C03) &&
+           (*(unsigned int*)(mem+0x898)==0x40A9FAD0) &&
+           (*(unsigned int*)(mem+0xa2d)==0x0A2E4C58) )
+        {
+            for(q=0xc3c;q<0xc4f;q++)
+            {
+                if((mem[q  ]==0xa9)&&
+                   (mem[q+2]==0x85)&&
+                   (mem[q+3]==0x01)&&
+                   (mem[q+4]==0x4c))
+                {
+                    Unp->Forced=q;
+                    Unp->EndAdr=mem[q+5]|mem[q+6]<<8;
+                    break;
+                }
+                if((mem[q  ]==0x84)&&
+                   (mem[q+1]==0x01)&&
+                   (mem[q+2]==0x4c))
+                {
+                    Unp->Forced=q;
+                    Unp->EndAdr=mem[q+3]|mem[q+4]<<8;
+                    break;
+                }
+            }
+            Unp->DepAdr=0x340;
+            Unp->StrMem=0x801;
+            PrintInfo(Unp,_I_IGP2);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* 711 introdes 3 */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x1118)==0x8D01A978) &&
+           (*(unsigned int*)(mem+0x111c)==0x1A8DDC0D) &&
+           (*(unsigned int*)(mem+0x1174)==0x11534C2A) &&
+           (*(unsigned int*)(mem+0x2B30)==0x786001F0) )
+        {
+            Unp->Forced=0x2b33;
+            /* it restores $3fff by saving it to $02 =) */
+            mem[2]=mem[0x3fff];
+            if(*(unsigned int*)(mem+0x2B4F)==0xE803409D)
+            {
+               Unp->DepAdr=0x340;
+               Unp->StrMem=mem[0x2b65]|mem[0x2b69]<<8;
+               Unp->EndAdr=Unp->info->end - (mem[0x2b5d]|mem[0x2b61]<<8) + Unp->StrMem;
+               p=0x2b7f;
+               if(*(unsigned int*)(mem+p-1)==0x4CA65920)
+               {
+                   mem[p-1]=0x2c;
+                   p+=3;
+               }
+               Unp->RetAdr=mem[p]|mem[p+1]<<8;
+            }
+            PrintInfo(Unp,_I_I711ID3);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* BN 1872 intromaker(?), magic disk and so on */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x4800)==0x48F02078) &&
+           (*(unsigned int*)(mem+0x4E67)==0x48004CFC) &&
+           (*(unsigned int*)(mem+0x4851)==0x4E00BD78) &&
+           (*(unsigned int*)(mem+0x4855)==0xE800FA9D) )
+        {
+            Unp->Forced=0x4851;
+            Unp->DepAdr=0xfa;
+            Unp->EndAdr=0x2d;
+            Unp->StrMem=0x800;
+            PrintInfo(Unp,_I_IBN1872);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* generic excell/ikari reloc routine */
+    if( Unp->DepAdr==0 )
+    {
+        for (p=0xe00;p<0x3400;p++)
+        {
+            if((*(unsigned int*)(mem+p+0x00)==0x01A90385) &&
+               (*(unsigned int*)(mem+p+0x04)==0x08A90485) &&
+               (*(unsigned int*)(mem+p+0x10)==0xE6F9D0C8) )
+            {
+                for(q=p+0x4e;q<p+0x70;q++)
+                {
+                    if((*(unsigned int*)(mem+q)&0xffffff00)==0x00206C00)
+                    {
+                        q=1;
+                        break;
+                    }
+                }
+                if(q!=1)
+                    break;
+
+                if((mem[p-0x100+0xec]==0xa2)  &&
+                   (mem[p-0x100+0xee]==0xbd)  &&
+                   (*(unsigned int*)(mem+p-0x100+0xe8)==0x018534A9) &&
+                   (*(unsigned int*)(mem+p-0x100+0xf1)==0xE804009D) &&
+                   (*(unsigned int*)(mem+p-0x100+0xf5)==0x004CF7D0) )
+                {
+                    Unp->Forced=p-0x100+0xe8;
+                    Unp->DepAdr=0x400;
+                    break;
+                }
+                if((mem[p-0x100+0xc8]==0xa2)  &&
+                   (mem[p-0x100+0xca]==0xbd)  &&
+                   (*(unsigned int*)(mem+(mem[p-0x100+0xcb]|mem[p-0x100+0xcc]<<8)+0x0f) ==0x018534A9) &&
+                   (*(unsigned int*)(mem+p-0x100+0xcd)==0xA904009D) &&
+                   (*(unsigned int*)(mem+p-0x100+0xe3)==0x040F4CF8) )
+                {
+                    Unp->Forced=p-0x100+0xc8;
+                    Unp->DepAdr=0x40f;
+                    break;
+                }
+            }
+        }
+
+        if(Unp->DepAdr)
+        {
+            Unp->EndAdr=mem[p+0x22]|mem[p+0x24]<<8;
+            Unp->StrMem=0x801;
+            for(q=p+0x29;q<p+0x39;q++)
+            {
+                if((mem[q]==0xa9)||(mem[q]==0xa2)||(mem[q]==0xa0)||
+                   (mem[q]==0x85)||(mem[q]==0x86))
+                {
+                   q++;
+                   continue;
+                }
+                if((mem[q]==0x8d)||(mem[q]==0x8e))
+                {
+                   q+=2;
+                   continue;
+                }
+                if((mem[q]==0x20)||(mem[q]==0x4c))
+                {
+                    Unp->RetAdr=mem[q+1]|mem[q+2]<<8;
+                    if((Unp->RetAdr==0xa659)&&(mem[q]==0x20))
+                    {
+                        mem[q]=0x2c;
+                        Unp->RetAdr=0;
+                        continue;
+                    }
+                    break;
+                }
+            }
+            PrintInfo(Unp,_I_IEXIKARI);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* ikari-06 by tridos/ikari */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0xC00)==0xD0CAA5A2) &&
+           (*(unsigned int*)(mem+0xC10)==0xE807A00C) &&
+           (*(unsigned int*)(mem+0xC20)==0x201CFB20) &&
+           (*(unsigned int*)(mem+0xfe8)==0x60BD80A2) &&
+           (*(unsigned int*)(mem+0xd60)==0x8534A978) )
+        {
+            Unp->Forced=0xfe8;
+            Unp->DepAdr=0x334;
+            Unp->EndAdr=0x2d;
+            Unp->StrMem=0x801;
+            Unp->RetAdr=mem[0xda0]|mem[0xda1]<<8;
+            PrintInfo(Unp,_I_IIKARI06);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* flt-01 version at $0801 */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x998)==0x78FF5B20) &&
+           (*(unsigned int*)(mem+0x9a8)==0xBE8DFAB1) &&
+           (*(unsigned int*)(mem+0xd3b)==0xFD152078) &&
+           (*(unsigned int*)(mem+0xd4b)==0xD0CA033B) &&
+           (*(unsigned int*)(mem+0xd5b)==0xA90DFD4C) )
+        {
+            Unp->Forced=0xd3b;
+            Unp->DepAdr=0x33c;
+            Unp->EndAdr=mem[0xb5c]|mem[0xb62]<<8;
+            Unp->StrMem=0x801;
+            Unp->RetAdr=mem[0xb6b]|mem[0xb6c]<<8;
+            PrintInfo(Unp,_I_IFLT01);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* s451-09 at $0801 */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x801)==0xE67800A0) &&
+           (*(unsigned int*)(mem+0x805)==0xA62DA501) &&
+           (*(unsigned int*)(mem+0x82a)==0xFD91FBB1) &&
+           (*(unsigned int*)(mem+0x831)==0xC6E6D00F) &&
+           (*(unsigned int*)(mem+0x841)==0x61BE0004) )
+        {
+            /* first moves $0839-(eof) to $1000 */
+            p=mem[0x837];
+            if((p==0x3e)||(p==0x48))
+            {
+                Unp->EndAdr=mem[0x80f]|mem[0x811]<<8;
+                memmove(mem+0x1000,mem+0x839,Unp->EndAdr-0x1000);
+                if(p==0x3e)
+                {
+                    Unp->StrMem=mem[0x113c]|mem[0x113d]<<8;
+                }
+                else/* if(p==0x48) */
+                {
+                    Unp->StrMem=mem[0x114c]|mem[0x114d]<<8;
+                }
+                Unp->DepAdr=Unp->StrMem;
+                Unp->RetAdr=Unp->StrMem;
+                Unp->Forced=Unp->StrMem;
+                PrintInfo(Unp,_I_IS45109);
+                Unp->IdFlag=1;return;
+            }
+        }
+    }
+    /* Super_Titlemaker/DSCompware */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x820)==0x8536A978) &&
+           (*(unsigned int*)(mem+0x830)==0x8570A9F9) &&
+           (*(unsigned int*)(mem+0x860)==0xB100A0B5) &&
+           (*(unsigned int*)(mem+0x864)==0xE60285B2) )
+        {
+           Unp->EndAdr=mem[0x854]|mem[0x852]<<8;
+           //Unp->EndAdC=1;
+           Unp->DepAdr=0x851;
+           Unp->RetAdr=mem[0x88a]|mem[0x88b]<<8;
+           Unp->StrMem=Unp->RetAdr;
+           Unp->Forced=0x820;
+           PrintInfo(Unp,_I_DSCTITMK);
+           Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/MasterCompressor.c
+++ b/terps/unp64/scanners/MasterCompressor.c
@@ -1,0 +1,102 @@
+/* MC and clones
+   Timecruncher 1.x/2.x are the same
+   Which is the original?
+*/
+#include "../unp64.h"
+void Scn_MasterCompressor(unpstr *Unp) {
+  unsigned char *mem;
+  int p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    for (p = 0x80d; p < 0x880; p++) {
+      if (((*(unsigned int *)(mem + p + 0x005) & 0x00ffffff) == 0x00BDD2A2) &&
+          (*(unsigned int *)(mem + p + 0x00a) == 0xE000F99D) &&
+          (*(unsigned int *)(mem + p + 0x017) == 0xCAEDD0CA) &&
+          (*(unsigned int *)(mem + p + 0x031) == 0x84C82E86) &&
+          ((*(unsigned int *)(mem + p + 0x035) & 0x0000ffff) == 0x00004C2D) &&
+          (*(unsigned int *)(mem + p + 0x134) == 0xDBD0FFE6)) {
+        if (/*mem[p]==0x78&&*/ mem[p + 1] == 0xa9 &&
+            (*(unsigned int *)(mem + p + 0x003) == 0xD2A20185)) {
+          Unp->DepAdr = mem[p + 0x37] | mem[p + 0x38] << 8;
+          Unp->Forced = p + 1;
+          if (mem[p + 0x12b] == 0x020) // jsr $0400, unuseful fx
+            mem[p + 0x12b] = 0x2c;
+        } else if (*(unsigned int *)(mem + p) == 0xD024E0E8) {
+          /* HTL version */
+          Unp->DepAdr = mem[p + 0x37] | mem[p + 0x38] << 8;
+          Unp->Forced = 0x840;
+        }
+        if (Unp->DepAdr) {
+          Unp->RetAdr = mem[p + 0x13e] | mem[p + 0x13f] << 8;
+          Unp->EndAdr = 0x2d;
+          Unp->fStrBf = Unp->EndAdr;
+          PrintInfo(Unp, _I_MASTCOMP);
+          Unp->IdFlag = 1;
+          return;
+        }
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    for (p = 0x80d; p < 0x880; p++) {
+      if (((*(unsigned int *)(mem + p + 0x005) & 0x00ffffff) == 0x00BDD2A2) &&
+          (*(unsigned int *)(mem + p + 0x00a) == 0xE000F99D) &&
+          (*(unsigned int *)(mem + p + 0x017) == 0xCAEDD0CA) &&
+          (*(unsigned int *)(mem + p + 0x031) == 0x84C82E86) &&
+          ((*(unsigned int *)(mem + p + 0x035) & 0x0000ffff) == 0x00004C2D) &&
+          (*(unsigned int *)(mem + p + 0x12d) == 0xe2D0FFE6)) {
+        if (mem[p + 1] == 0xa9 &&
+            (*(unsigned int *)(mem + p + 0x003) == 0xD2A20185)) {
+          Unp->DepAdr = mem[p + 0x37] | mem[p + 0x38] << 8;
+          Unp->Forced = p + 1;
+        }
+        if (Unp->DepAdr) {
+          if (mem[p + 0x136] == 0x4c)
+            Unp->RetAdr = mem[p + 0x137] | mem[p + 0x138] << 8;
+          else if (mem[p + 0x13d] == 0x4c)
+            Unp->RetAdr = mem[p + 0x13e] | mem[p + 0x13f] << 8;
+          Unp->EndAdr = 0x2d;
+          Unp->fStrBf = Unp->EndAdr;
+          PrintInfo(Unp, _I_MASTCRLX);
+          Unp->IdFlag = 1;
+          return;
+        }
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    p = 0x812;
+    if ((*(unsigned int *)(mem + p + 0x000) == 0xE67800A0) &&
+        (*(unsigned int *)(mem + p + 0x004) == 0x0841B901) &&
+        (*(unsigned int *)(mem + p + 0x008) == 0xB900FA99) &&
+        (*(unsigned int *)(mem + p + 0x00c) == 0x34990910)) {
+      Unp->DepAdr = 0x100;
+      Unp->Forced = p;
+      Unp->RetAdr = mem[0x943] | mem[0x944] << 8;
+      Unp->EndAdr = 0x2d;
+      Unp->fStrBf = Unp->EndAdr;
+      PrintInfo(Unp, _I_MASTCAGL);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /* Fred/Channel4 hack */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x811) == 0xA9A98078) &&
+        (*(unsigned int *)(mem + 0x815) == 0x85EE8034) &&
+        (*(unsigned int *)(mem + 0x819) == 0x802DA201) &&
+        (*(unsigned int *)(mem + 0x882) == 0x01004C2D)) {
+      Unp->DepAdr = 0x100;
+      Unp->Forced = 0x811;
+      Unp->RetAdr = mem[0x98b] | mem[0x98c] << 8;
+      if (Unp->RetAdr < 0x800)
+        Unp->RtAFrc = 1;
+      Unp->EndAdr = 0x2d;
+      PrintInfo(Unp, _I_MASTCHF);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/Megabyte.c
+++ b/terps/unp64/scanners/Megabyte.c
@@ -1,0 +1,54 @@
+/* Megabyte Cruncher 64 / ABC cruncher */
+#include "../unp64.h"
+void Scn_Megabyte(unpstr *Unp) {
+  unsigned char *mem;
+  int p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    p = 0;
+    if (mem[0x816] == 0x4c)
+      p = mem[0x817] | mem[0x818] << 8;
+    else if ((Unp->info->run == 0x810) && (mem[0x814] == 0x4c) &&
+             ((*(unsigned int *)(mem + 0x810) & 0xffff00ff) == 0x018500A9))
+      p = mem[0x815] | mem[0x816] << 8;
+    if (p) {
+      if ((mem[p + 0] == 0x78) && (mem[p + 1] == 0xa2) &&
+          (mem[p + 3] == 0xa0) &&
+          (*(unsigned int *)(mem + p + 0x05) == 0x15841486) &&
+          (*(unsigned int *)(mem + p + 0x1d) == 0x03804CF7)) {
+        Unp->DepAdr = 0x380;
+        Unp->EndAdr = mem[p + 0x55] | mem[p + 0x56] << 8;
+        Unp->EndAdr++;
+        Unp->StrMem = 0x801;
+        Unp->RetAdr = 0x801; /* ususally it just runs */
+        PrintInfo(Unp, _I_MBCR1);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  if (Unp->DepAdr == 0) {
+    p = 0;
+    if ((mem[0x81a] == 0x4c) &&
+        ((*(unsigned int *)(mem + 0x816) & 0xffff00ff) == 0x018500A9))
+      p = mem[0x81b] | mem[0x81c] << 8;
+    if (p) {
+      if ((mem[p + 0] == 0x78) && (mem[p + 1] == 0xa2) &&
+          (mem[p + 3] == 0xa0) &&
+          (*(unsigned int *)(mem + p + 0x05) == 0x15841486) &&
+          (*(unsigned int *)(mem + p + 0x1d) == 0x03844CF7)) {
+        Unp->DepAdr = 0x384;
+        Unp->Forced = 0x816;
+        Unp->EndAdr = mem[p + 0x59] | mem[p + 0x5a] << 8;
+        Unp->EndAdr++;
+        Unp->StrMem = 0x801;
+        Unp->RetAdr = 0x801; /* ususally it just runs */
+        PrintInfo(Unp, _I_MBCR2);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+}

--- a/terps/unp64/scanners/MrCross.c
+++ b/terps/unp64/scanners/MrCross.c
@@ -1,0 +1,59 @@
+/* Mr.Cross linker */
+#include "../unp64.h"
+void Scn_MrCross(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q,p;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        /*
+        there are sysless versions and also can be at
+        different address than $0801
+        */
+        p=Unp->info->run;
+        if(p==-1)
+            p=Unp->info->start;
+        for (q=p+0x80;p<q;p++)
+        {
+            if((*(unsigned int*)(mem+p+0x00)==0x8538A978) &&
+               (*(unsigned int*)(mem+p+0x04)==0x9AF9A201) &&
+               (*(unsigned int*)(mem+p+0x0b)==0xCA01069D) &&
+               (*(unsigned int*)(mem+p+0x36)==0x60D8d000+(p>>8))  /*((p+0x3b)>>8)*/
+              )
+            {
+                Unp->DepAdr=mem[p+0x96]|mem[p+0x97]<<8;Unp->DepAdr+=0x1f;
+                Unp->Forced=p;
+                Unp->RetAdr=mem[p+0x9a]|mem[p+0x9b]<<8;
+                Unp->StrMem=mem[p+0x4d]|mem[p+0x4e]<<8;
+                Unp->MonEnd=(mem[p+0x87])<<24|
+                            (mem[p+0x86])<<16|
+                            (mem[p+0x8d])<< 8|
+                            (mem[p+0x8c]);
+                PrintInfo(Unp,_I_MRCROSS2);
+                break;
+            }
+            if((*(unsigned int*)(mem+p+0x00)==0x8538A978) &&
+               (*(unsigned int*)(mem+p+0x04)==0x9AF9A201) &&
+               (*(unsigned int*)(mem+p+0x0b)==0xCA01089D) &&
+               (*(unsigned int*)(mem+p+0x36)==0xe0D8d000+(p>>8))  /*((p+0xc8)>>8)*/
+              )
+            {
+                Unp->DepAdr=0x1f6;
+                Unp->Forced=p;
+                Unp->RetAdr=mem[p+0xaa]|mem[p+0xab]<<8;
+                Unp->StrMem=mem[p+0x53]|mem[p+0x54]<<8;
+                Unp->fEndAf=0x1a7;
+                Unp->EndAdC=0xffff;
+                PrintInfo(Unp,_I_MRCROSS1);
+                break;
+            }
+        }
+        if(Unp->DepAdr)
+        {
+            Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/MrZ.c
+++ b/terps/unp64/scanners/MrZ.c
@@ -1,0 +1,123 @@
+/*
+MrZ/Triad packer, does cover also some triad intros.
+found also as "SYS2069 PSHYCO!" in some Censor warez.
+*/
+#include "../unp64.h"
+void Scn_MrZ(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q,p=0;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        for(q=0x810;q<0x880;q++)
+        {
+            if((*(unsigned int*)(mem+q    )==0x8D00A978)&&
+               (*(unsigned int*)(mem+q+4  )==0x0BA9D020)&&
+               (*(unsigned int*)(mem+q+8  )==0xE6D0118D)&&
+               (*(unsigned short int*)(mem+q+0xc)==(unsigned short int )0x4c01) )
+            {
+                p=mem[q+0xe]|mem[q+0xf]<<8;
+                Unp->Forced=q;
+                break;
+            }
+            if((*(unsigned int*)(mem+q    )==0x208D00A9)&&
+               (*(unsigned int*)(mem+q+4  )==0x8D0BA9D0)&&
+               (*(unsigned int*)(mem+q+8  )==0xE678D011)&&
+               (*(unsigned short int*)(mem+q+0xc)==(unsigned short int )0x4c01) )
+            {
+                p=mem[q+0xe]|mem[q+0xf]<<8;
+                Unp->Forced=q;
+                break;
+            }
+            if((*(unsigned int*)(mem+q    )==0xD9409901)&&
+               (*(unsigned int*)(mem+q+4  )==0xD0FCC6C8)&&
+               (*(unsigned int*)(mem+q+8  )==0xDFD0E8ED)&&
+               (*(unsigned int*)(mem+q+0xc)==0x4C01E678) )
+            {
+                p=mem[q+0x10]|mem[q+0x11]<<8;
+                break;
+            }
+            /* mrz crunch, identical apart preamble? %) */
+            if((*(unsigned int*)(mem+q+0x00)==0x6FD0116F)&&
+               (*(unsigned int*)(mem+q+0x0a)==0xFACA0820)&&
+               (*(unsigned int*)(mem+q+0x1b)==0x3737261F)&&
+               (*(unsigned int*)(mem+q+0x42)==0x4C01E678) )
+            {
+                p=mem[q+0x46]|mem[q+0x47]<<8;
+                break;
+            }
+        }
+        if(p)
+        {
+            if((*(unsigned int*)(mem+p     )==0xA29AFAA2)&&
+               (*(unsigned int*)(mem+p+0x08)==0x10CA3995)&&
+               (*(unsigned int*)(mem+p+0x2b)==0xB901004C)
+              )
+            {
+                Unp->DepAdr=0x100;
+                Unp->EndAdr=mem[p+0x36]|mem[p+0x37]<<8;
+                if(Unp->EndAdr==0)
+                    Unp->EndAdr=0x10000;
+                Unp->fStrAf=0x41; /*str_add=EA_USE_Y; Y is stored at $6d*/
+                for(q=p+0x8c;q<Unp->info->end;q++)
+                {
+                    if((mem[q]==0xa9)||(mem[q]==0xc6))
+                    {
+                        q++;
+                        continue;
+                    }
+                    if(mem[q]==0x8d)
+                    {
+                        q+=2;
+                        continue;
+                    }
+                    if((mem[q]==0x20)&&(
+                      (*(unsigned short int*)(mem+q+1)==0xe3bf)||
+                      (*(unsigned short int*)(mem+q+1)==0xfda3)||
+                      (*(unsigned short int*)(mem+q+1)==0xa660)||
+                      (*(unsigned short int*)(mem+q+1)==0xa68e)||
+                      (*(unsigned short int*)(mem+q+1)==0xa659)))
+                    {
+                        mem[q]=0x2c;
+                        q+=2;
+                        continue;
+                    }
+                    if(mem[q]==0x4c)
+                    {
+                        Unp->RetAdr=mem[q+1]|mem[q+2]<<8;
+                        //if(Unp->DebugP)
+                            //printf("Startaddres patch # $%04x\n",q);
+                        p=2;
+                        mem[p++]=0xA5; /* fix for start address */
+                        mem[p++]=0x41; /*     *=$02             */
+                        mem[p++]=0x18; /*     lda $41           */
+                        mem[p++]=0x65; /*     clc               */
+                        mem[p++]=0x6D; /*     adc $6d           */
+                        mem[p++]=0x85; /*     sta $41           */
+                        mem[p++]=0x41; /*     bcc noh           */
+                        mem[p++]=0x90; /*     inc $42           */
+                        mem[p++]=0x02; /* noh rts               */
+                        mem[p++]=0xE6; /*                       */
+                        mem[p++]=0x42; /*                       */
+                        mem[p++]=0x4c; /*     jmp realstart     */
+                        mem[p++]=mem[q+1];
+                        mem[p++]=mem[q+2];
+
+                        mem[q+0]=0x4c;
+                        mem[q+1]=0x02;
+                        mem[q+2]=0x00;
+
+                        break;
+                    }
+                }
+                //if(Unp->DebugP)
+                    //printf("Retaddr $%04x\n",Unp->RetAdr);
+                PrintInfo(Unp,_I_MRZPACK);
+                Unp->IdFlag=1;return;
+            }
+        }
+    }
+}

--- a/terps/unp64/scanners/PuCrunch.c
+++ b/terps/unp64/scanners/PuCrunch.c
@@ -1,0 +1,170 @@
+/* PuCrunch */
+#include "../unp64.h"
+void Scn_PuCrunch(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    if ((mem[0x80d] == 0x78) &&
+        (*(unsigned int *)(mem + 0x813) == 0x34A20185) &&
+        (*(unsigned int *)(mem + 0x817) == 0x9D0842BD) &&
+        (*(unsigned int *)(mem + 0x81b) == 0xD0CA01FF) &&
+        (*(unsigned int *)(mem + 0x83d) == 0x4CEDD088)) {
+      for (p = 0x912; p < 0x938; p++) {
+        if ((*(unsigned int *)(mem + p) == 0x2D85FAA5) &&
+            (*(unsigned int *)(mem + p + 4) == 0x2E85FBA5)) {
+          Unp->EndAdr = 0xfa;
+          Unp->StrMem = mem[0x879] | mem[0x87a] << 8;
+          Unp->DepAdr = mem[0x841] | mem[0x842] << 8;
+          Unp->RetAdr = mem[p + 0xa] | mem[p + 0xb] << 8;
+          Unp->Forced = 0x80d;
+          PrintInfo(Unp, _I_PUCRUNCH);
+          break;
+        }
+      }
+    } else if ((mem[0x80d] == 0x78) &&
+               (*(unsigned int *)(mem + 0x81a) == 0x10CA4B95) &&
+               (*(unsigned int *)(mem + 0x81e) == 0xBD3BA2F8) &&
+               (*(unsigned int *)(mem + 0x847) == 0x4CEDD088)) {
+      for (p = 0x912; p < 0x938; p++) {
+        if ((*(unsigned int *)(mem + p) == 0x2D85FAA5) &&
+            (*(unsigned int *)(mem + p + 4) == 0x2E85FBA5)) {
+          Unp->EndAdr = 0xfa;
+          Unp->StrMem = mem[0x88a] | mem[0x88b] << 8;
+          Unp->DepAdr = mem[0x84b] | mem[0x84c] << 8;
+          Unp->RetAdr = mem[p + 0xa] | mem[p + 0xb] << 8;
+          Unp->Forced = 0x80d;
+          PrintInfo(Unp, _I_PUCRUNCW);
+          break;
+        }
+      }
+    } else if ((mem[0x80d] == 0x78) &&
+               (*(unsigned int *)(mem + 0x811) == 0x85AAA901) &&
+               (*(unsigned int *)(mem + 0x81d) == 0xF69D083C) &&
+               (*(unsigned int *)(mem + 0x861) == 0xC501C320) &&
+               (*(unsigned int *)(mem + 0x839) == 0x01164CED)) {
+      Unp->EndAdr = 0xfa;
+      Unp->StrMem = mem[0x840] | mem[0x841] << 8;
+      Unp->DepAdr = 0x116;
+      Unp->RetAdr = mem[0x8df] | mem[0x8e0] << 8;
+      Unp->Forced = 0x80d;
+      PrintInfo(Unp, _I_PUCRUNCS);
+    } else if ((mem[0x80d] == 0x78) &&
+               (*(unsigned int *)(mem + 0x811) == 0x85AAA901) &&
+               (*(unsigned int *)(mem + 0x81d) == 0xF69D083C) &&
+               (*(unsigned int *)(mem + 0x861) == 0xC501C820) &&
+               (*(unsigned int *)(mem + 0x839) == 0x01164CED)) {
+      Unp->EndAdr = 0xfa;
+      Unp->StrMem = mem[0x840] | mem[0x841] << 8;
+      Unp->DepAdr = 0x116;
+      if (mem[0x8de] == 0xa9) {
+        Unp->RetAdr = mem[0x8e1] | mem[0x8e2] << 8;
+        if ((Unp->RetAdr == 0xa871) && (mem[0x8e0] == 0x20) &&
+            (mem[0x8e3] == 0x4c)) {
+          mem[0x8e0] = 0x2c;
+          Unp->RetAdr = mem[0x8e4] | mem[0x8e5] << 8;
+        }
+      } else {
+        Unp->RetAdr = mem[0x8df] | mem[0x8e0] << 8;
+      }
+      Unp->Forced = 0x80d;
+      PrintInfo(Unp, _I_PUCRUNCS);
+    } else {
+      /* unknown old/hacked pucrunch ? */
+      for (p = 0x80d; p < 0x820; p++) {
+        if (mem[p] == 0x78) {
+          q = p;
+          for (; p < 0x824; p++) {
+            if (((*(unsigned int *)(mem + p) & 0xf0ffffff) == 0xF0BD53A2) &&
+                (*(unsigned int *)(mem + p + 4) == 0x01FF9D08) &&
+                (*(unsigned int *)(mem + p + 8) == 0xA2F7D0CA)) {
+              Unp->Forced = q;
+              q = mem[p + 3] & 0xf; /* can be $f0 or $f2, q&0x0f as offset */
+              p = mem[p + 0xe] | mem[p + 0xf] << 8;
+              if (mem[p - 2] == 0x4c && mem[p + 0xa0 + q] == 0x85) {
+                Unp->DepAdr = mem[p - 1] | mem[p] << 8;
+                Unp->StrMem = mem[p + 4] | mem[p + 5] << 8;
+                Unp->EndAdr = 0xfa;
+                p += 0xa2;
+                q = p + 8;
+                for (; p < q; p++) {
+                  if ((*(unsigned int *)(mem + p) == 0x2D85FAA5) &&
+                      (mem[p + 9] == 0x4c)) {
+                    Unp->RetAdr = mem[p + 0xa] | mem[p + 0xb] << 8;
+                    break;
+                  }
+                }
+                PrintInfo(Unp, _I_PUCRUNCO);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    /* various old/hacked pucrunch */
+    /* common pattern, variable pos from 0x79 to 0xd1
+    90 ?? C8 20 ?? 0? 85 ?? C9 ?0 90 0B A2 0? 20 ?? 0? 85 ?? 20 ?? 0? A8 20 ??
+    0? AA BD ?? 0? E0 20 90 0? 8A (A2 03) not always 20 ?? 02 A6
+    ?? E8 20 F9
+    */
+    if (Unp->DepAdr == 0) {
+      Unp->IdFlag = 0;
+      for (q = 0x70; q < 0xff; q++) {
+        if (((*(unsigned int *)(mem + 0x801 + q) & 0xFFFF00FF) == 0x20C80090) &&
+            ((*(unsigned int *)(mem + 0x801 + q + 8) & 0xFFFF0FFF) ==
+             0x0B9000C9) &&
+            ((*(unsigned int *)(mem + 0x801 + q + 12) & 0x00FFF0FF) ==
+             0x002000A2) &&
+            ((*(unsigned int *)(mem + 0x801 + q + 30) & 0xF0FFFFFf) ==
+             0x009020E0)) {
+          Unp->IdFlag = _I_PUCRUNCG;
+          break;
+        }
+      }
+      if (Unp->IdFlag) {
+        for (p = 0x801 + q + 34; p < 0x9ff; p++) {
+          if (*(unsigned int *)(mem + p) == 0x00F920E8) {
+            for (; p < 0x9ff; p++) {
+              if (mem[p] == 0x4c) {
+                Unp->RetAdr = mem[p + 1] | mem[p + 2] << 8;
+                if (Unp->RetAdr > 0x257)
+                  break;
+              }
+            }
+            break;
+          }
+        }
+        for (p = 0; p < 0x40; p++) {
+          if (Unp->info->run == -1)
+            if (Unp->Forced == 0) {
+              if (mem[0x801 + p] == 0x78) {
+                Unp->Forced = 0x801 + p;
+                Unp->info->run = Unp->Forced;
+              }
+            }
+          if ((*(unsigned int *)(mem + 0x801 + p) == 0xCA00F69D) &&
+              (mem[0x801 + p + 0x1b] == 0x4c)) {
+            q = 0x801 + p + 0x1c;
+            Unp->DepAdr = mem[q] | mem[q + 1] << 8;
+            q = 0x801 + p - 2;
+            p = mem[q] | mem[q + 1] << 8;
+            if ((mem[p + 3] == 0x8d) && (mem[p + 6] == 0xe6)) {
+              Unp->StrMem = mem[p + 4] | mem[p + 5] << 8;
+            }
+            break;
+          }
+        }
+        Unp->EndAdr = 0xfa; // some hacks DON'T xfer fa/b to 2d/e
+        Unp->IdFlag = 1;
+        PrintInfo(Unp, _I_PUCRUNCG);
+      }
+    }
+    if (Unp->DepAdr) {
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/Section8.c
+++ b/terps/unp64/scanners/Section8.c
@@ -1,0 +1,79 @@
+/* Section8 packer?
+   found mainly at $0827, also at $0828, some at $0810 and even $081b
+*/
+#include "../unp64.h"
+void Scn_Section8(unpstr *Unp) {
+  unsigned char *mem;
+  int p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    for (p = 0x810; p <= 0x828; p++) {
+      if ((*(unsigned int *)(mem + p) ==
+          (unsigned int)(0x00BD00A2 + (((p & 0xff) + 0x11) << 24))) &&
+          (*(unsigned int *)(mem + p + 0x04) == 0x01009D08) &&
+          (*(unsigned int *)(mem + p + 0x10) == 0x34A97801) &&
+          (*(unsigned int *)(mem + p + 0x6a) == 0xB1017820) &&
+          (*(unsigned int *)(mem + p + 0x78) == 0x017F20AE)) {
+        Unp->DepAdr = 0x100;
+        break;
+      }
+    }
+    if (Unp->DepAdr) {
+      if (Unp->info->run == -1)
+        Unp->Forced = p;
+      Unp->StrMem = mem[p + 0x47] | mem[p + 0x4b] << 8;
+      Unp->RetAdr = mem[p + 0x87] | mem[p + 0x88] << 8;
+      if (Unp->RetAdr == 0xf7) {
+        Unp->RetAdr = 0xa7ae;
+        mem[p + 0x87] = 0xae;
+        mem[p + 0x88] = 0xa7;
+      }
+      Unp->EndAdr = 0xae;
+      PrintInfo(Unp, _I_S8PACK);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /* Crackman variant? */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x827) == 0x38BD00A2) &&
+        (*(unsigned int *)(mem + 0x82b) == 0x01009D08) &&
+        (*(unsigned int *)(mem + 0x837) == 0x34A97801) &&
+        (*(unsigned int *)(mem + 0x891) == 0xB1018420) &&
+        (*(unsigned int *)(mem + 0x89f) == 0x018b20AE)) {
+      Unp->DepAdr = 0x100;
+      if (Unp->info->run == -1)
+        Unp->Forced = 0x827;
+      Unp->StrMem = mem[0x86e] | mem[0x872] << 8;
+      if (*(unsigned short int *)(mem + 0x8b7) == 0xff5b) {
+        mem[0x8b6] = 0x2c;
+        Unp->RetAdr = mem[0x8ba] | mem[0x8bb] << 8;
+      } else {
+        Unp->RetAdr = mem[0x8b7] | mem[0x8b8] << 8;
+      }
+      Unp->EndAdr = 0xae;
+      PrintInfo(Unp, _I_CRMPACK);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /* PET||SLAN variant? */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x812) == 0x20BD00A2) &&
+        (*(unsigned int *)(mem + 0x816) == 0x033c9D08) &&
+        (*(unsigned int *)(mem + 0x863) == 0xB103B420) &&
+        (*(unsigned int *)(mem + 0x86c) == 0x03BB20AE)) {
+      Unp->DepAdr = 0x33c;
+      if (Unp->info->run == -1)
+        Unp->Forced = 0x812;
+      Unp->StrMem = mem[0x856] | mem[0x85a] << 8;
+      Unp->RetAdr = mem[0x896] | mem[0x897] << 8;
+      Unp->EndAdr = 0xae;
+      PrintInfo(Unp, _I_PETPACK);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/TBCMultiComp.c
+++ b/terps/unp64/scanners/TBCMultiComp.c
@@ -1,0 +1,139 @@
+/* TBC Multicompactor */
+#include "../unp64.h"
+void Scn_TBCMultiComp(unpstr *Unp) {
+  unsigned char *mem;
+  int p = 0, q = 0, strtmp;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    if (((*(unsigned int *)(mem + 0x82c) & 0xfffffffd) == 0x9ACA0184) &&
+        (*(unsigned int *)(mem + 0x830) == 0xA001004C) &&
+        (*(unsigned int *)(mem + 0x834) == 0x84FD8400) &&
+        (*(unsigned int *)(mem + 0x8a2) == 0x01494C01)) {
+      /*normal 2080*/
+      if (mem[0x84a] == 0x81) {
+        if (*(unsigned int *)(mem + 0x820) == 0x32BDE9A2) {
+          Unp->Forced = 0x820;
+          Unp->RetAdr = mem[0x8b2] | mem[0x8b3] << 8;
+          if (Unp->RetAdr == 0x1e1) {
+            if (*(unsigned int *)(mem + 0x916) == 0x4CA87120) {
+              p = *(unsigned short int *)(mem + 0x91a);
+              if (p == 0xa7ae) {
+                Unp->RetAdr = p;
+                mem[0x8b2] = 0xae;
+                mem[0x8b3] = 0xa7;
+              } else {
+                mem[0x916] = 0x2c;
+                Unp->RetAdr = p;
+              }
+            } else if ((mem[0x916] == 0x4C) || (mem[0x916] == 0x20)) {
+              Unp->RetAdr = mem[0x917] | mem[0x918] << 8;
+            } else if (mem[0x919] == 0x4c) {
+              Unp->RetAdr = mem[0x91a] | mem[0x91b] << 8;
+            }
+          }
+          if ((Unp->RetAdr == 0) && (mem[0x8b1] == 0)) {
+            Unp->RetAdr = 0xa7ae;
+            mem[0x8b1] = 0x4c;
+            mem[0x8b2] = 0xae;
+            mem[0x8b3] = 0xa7;
+          }
+          p = 0x8eb;
+        }
+      }
+      /*firelord 2076*/
+      else if (mem[0x84a] == 0x7b) {
+        if (*(unsigned int *)(mem + 0x81d) == 0x32BDE9A2) {
+          Unp->Forced = 0x81d;
+          Unp->RetAdr = mem[0x8ac] | mem[0x8ad] << 8;
+          p = 0x8eb;
+        }
+      }
+      if (Unp->Forced) {
+        Unp->DepAdr = 0x100;
+        Unp->StrMem = mem[p + 1] | mem[p + 2] << 8;
+        q = p;
+        q += mem[p];
+        Unp->EndAdr = 0;
+        for (; q > p; q -= 4) {
+          strtmp = (mem[q - 1] | mem[q] << 8);
+          if (strtmp == 0)
+            strtmp = 0x10000;
+          if (strtmp > Unp->EndAdr)
+            Unp->EndAdr = strtmp;
+        }
+        PrintInfo(Unp, _I_TBCMULTI);
+        Unp->IdFlag = 1;
+        return;
+      }
+    }
+  }
+  /* TBC Multicompactor ?  very similar but larger code */
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x822) == 0x9D083DBD) &&
+        (*(unsigned int *)(mem + 0x826) == 0xD0CA0333) &&
+        (*(unsigned int *)(mem + 0x832) == 0xF7D0CA00) &&
+        (*(unsigned int *)(mem + 0x836) == 0xCA018678) &&
+        (*(unsigned int *)(mem + 0x946) == 0xADC5AFA5)) {
+      if (Unp->info->run == -1) {
+        for (p = 0x81e; p < 0x821; p++) {
+          if (mem[p] == 0xa2) {
+            Unp->Forced = p;
+            break;
+          }
+        }
+      }
+      Unp->DepAdr = 0x334;
+      Unp->RetAdr = mem[0x92a] | mem[0x92b] << 8;
+      p = 0x94d;
+      Unp->StrMem = mem[p + 1] | mem[p + 2] << 8;
+      q = p;
+      q += mem[p];
+      Unp->EndAdr = 0;
+      for (; q > p; q -= 4) {
+        strtmp = (mem[q - 1] | mem[q] << 8);
+        if (strtmp == 0)
+          strtmp = 0x10000;
+        if (strtmp > Unp->EndAdr)
+          Unp->EndAdr = strtmp;
+      }
+      PrintInfo(Unp, _I_TBCMULT2);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+  /*"AUTOMATIC BREAK SYSTEM" found in Manowar Cracks*/
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x835) == 0x9D0845BD) &&
+        (*(unsigned int *)(mem + 0x839) == 0xD0CA00ff) &&
+        (*(unsigned int *)(mem + 0x83e) == 0xCA018678) &&
+        (*(unsigned int *)(mem + 0x8e1) == 0xADC5AFA5)) {
+      if (Unp->info->run == -1) {
+        for (p = 0x830; p < 0x834; p++) {
+          if (mem[p] == 0xa2) {
+            Unp->Forced = p;
+            break;
+          }
+        }
+      }
+      Unp->DepAdr = 0x100;
+      Unp->RetAdr = mem[0x8c5] | mem[0x8c6] << 8;
+      p = 0x8fe;
+      Unp->StrMem = mem[p + 1] | mem[p + 2] << 8;
+      q = p;
+      q += mem[p];
+      Unp->EndAdr = 0;
+      for (; q > p; q -= 4) {
+        strtmp = (mem[q - 1] | mem[q] << 8);
+        if (strtmp == 0)
+          strtmp = 0x10000;
+        if (strtmp > Unp->EndAdr)
+          Unp->EndAdr = strtmp;
+      }
+      PrintInfo(Unp, _I_TBCMULTMOW);
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/TCScrunch.c
+++ b/terps/unp64/scanners/TCScrunch.c
@@ -1,0 +1,51 @@
+/* TCS Crunch */
+#include "../unp64.h"
+void Scn_TCScrunch(unpstr *Unp) {
+  unsigned char *mem;
+  int q, p;
+  if (Unp->IdFlag)
+    return;
+  mem = Unp->mem;
+  if (Unp->DepAdr == 0) {
+    if ((*(unsigned int *)(mem + 0x819) == 0x018536A9) && mem[0x81d] == 0x4c) {
+      p = mem[0x81e] | mem[0x81f] << 8;
+      if (mem[p] == 0xa2 && mem[p + 2] == 0xbd &&
+          (*(unsigned int *)(mem + p + 0x05) == 0xE801109D) &&
+          ((*(unsigned int *)(mem + p + 0x38) == 0x01524CFB) ||
+           ((*(unsigned int *)(mem + p + 0x38) == 0x8DE1A9FB) &&
+            (*(unsigned int *)(mem + p + 0x3c) == 0x524C0328)))) {
+        Unp->DepAdr = 0x334;
+        Unp->Forced = 0x819;
+        Unp->EndAdr = 0x2d;
+        PrintInfo(Unp, _I_TCSCR2);
+      }
+    } else if ((*(unsigned int *)(mem + 0x819) == 0x018534A9) &&
+               mem[0x81d] == 0x4c) {
+      p = mem[0x81e] | mem[0x81f] << 8;
+      if (mem[p] == 0xa2 && mem[p + 2] == 0xbd &&
+          (*(unsigned int *)(mem + p + 0x05) == 0xE801109D) &&
+          (*(unsigned int *)(mem + p + 0x38) == 0x01304CFB)) {
+        Unp->DepAdr = 0x334;
+        Unp->Forced = 0x818;
+        if (mem[Unp->Forced] != 0x78)
+          Unp->Forced++;
+        Unp->EndAdr = 0x2d;
+        Unp->RetAdr = mem[p + 0xd9] | mem[p + 0xda] << 8;
+        p += 0xc8;
+        q = p + 6;
+        for (; p < q; p += 3) {
+          if ((mem[p] == 0x20) &&
+              (*(unsigned short int *)(mem + p + 1) >= 0xa000) &&
+              (*(unsigned short int *)(mem + p + 1) <= 0xbfff)) {
+            mem[p] = 0x2c;
+          }
+        }
+        PrintInfo(Unp, _I_TCSCR3);
+      }
+    }
+    if (Unp->DepAdr) {
+      Unp->IdFlag = 1;
+      return;
+    }
+  }
+}

--- a/terps/unp64/scanners/XTC.c
+++ b/terps/unp64/scanners/XTC.c
@@ -1,0 +1,156 @@
+/* XTC packer */
+#include "../unp64.h"
+void Scn_XTC(unpstr *Unp)
+{
+    unsigned char *mem;
+    int q=0,p;
+    if ( Unp->IdFlag )
+        return;
+    mem=Unp->mem;
+    if( Unp->DepAdr==0 )
+    {
+        if ( (*(unsigned short int*)(mem+0x80d)==0xE678) &&
+             (*(unsigned int*)(mem+0x811)==0x1BCE0818) &&
+             (*(unsigned int*)(mem+0x819)==0xC8000099) &&
+             (*(unsigned int*)(mem+0x82c)==0x4CF7D0CA) &&
+             mem[0x85c]==0x99)
+        {
+            Unp->RetAdr=mem[0x872]|mem[0x873]<<8;
+            Unp->DepAdr=0x100;
+            Unp->Forced=0x80d; /* the ldy #$00 can be missing, skipped */
+            Unp->fEndAf=0x121;
+            Unp->EndAdC=0xffff|EA_USE_Y;
+            Unp->StrMem=mem[0x85d]|mem[0x85e]<<8;
+            PrintInfo(Unp,_I_XTC21);
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* XTC packer 1.0 & 2.2/2.4 */
+    if( Unp->DepAdr==0 )
+    {
+        for(p=0x801;p<0x80c;p+=0x0a)
+        {
+            if( (*(unsigned short int*)(mem+p+0x02)==0xE678) &&
+                (*(unsigned int*)(mem+p+0x07)==(unsigned int)(0xce08|((p+0x10)<<16))) &&
+                (*(unsigned int*)(mem+p+0x0e)==0xC8000099) &&
+                (*(unsigned int*)(mem+p+0x23)==0x4CF7D0CA) )
+            {
+                /* has variable codebytes so addresses varies */
+                for(q=p+0x37;q<p+0x60;q+=4)
+                {
+                    if(mem[q]==0xc9)
+                        continue;
+                    if(mem[q]==0x99)
+                    {
+                        Unp->DepAdr=0x100;
+                        break;
+                    }
+                    break; /* unexpected byte, get out */
+                }
+                break;
+            }
+        }
+        if( Unp->DepAdr )
+        {
+            Unp->RetAdr=mem[q+0x16]|mem[q+0x17]<<8;
+            if(*(unsigned short int*)(mem+p     )!=0x00a0)
+              Unp->Forced=p+2; /* the ldy #$00 can be missing, skipped */
+            else
+              Unp->Forced=p;
+
+            Unp->fEndAf=mem[q+0x7]|mem[q+0x8]<<8;Unp->fEndAf--;
+            Unp->EndAdC=0xffff|EA_USE_Y;
+            Unp->StrMem=mem[q+1]|mem[q+2]<<8;
+            if (*(unsigned int*)(mem+q+0x1f) == 0xDDD00285)
+            {
+                PrintInfo(Unp,_I_XTC10);
+            }
+            else if(*(unsigned int*)(mem+q+0x1f) == 0xF620DFD0)
+            {
+                /* rockstar's 2.2+ & shade/light's 2.4 are all the same */
+                PrintInfo(Unp,_I_XTC22);
+            }
+            else
+            {   /* actually found to be Visiomizer 6.2/Zagon */
+            	Unp->DepAdr=mem[p+0x27]|mem[p+0x28]<<8;
+                PrintInfo(Unp,_I_VISIOM62);
+            }
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* XTC 2.3 / 6codezipper */
+    if( Unp->DepAdr==0 )
+    {
+        if((*(unsigned int*)(mem+0x803)==0xB9018478) &&
+           (*(unsigned int*)(mem+0x80b)==0xF7D0C8FF) &&
+           (*(unsigned int*)(mem+0x81b)==0x00FC9D08) &&
+           (*(unsigned int*)(mem+0x85b)==0xD0D0FFE4) )
+        {
+            Unp->DepAdr=mem[0x823]|mem[0x824]<<8;
+            Unp->Forced=0x803;
+            Unp->RetAdr=mem[0x865]|mem[0x866]<<8;
+            Unp->StrMem=mem[0x850]|mem[0x851]<<8;
+            Unp->EndAdC=0xffff|EA_USE_Y;
+            Unp->fEndAf=0x128;
+            PrintInfo(Unp,_I_XTC23 );
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* XTC 2.3 / G*P, probably by Rockstar */
+    if( Unp->DepAdr==0 )
+    {
+        if(((*(unsigned int*)(mem+0x803)==0xB901e678)||
+            (*(unsigned int*)(mem+0x803)==0xB9018478))&&
+           (*(unsigned int*)(mem+0x80b)==0xF7D0C8FF) &&
+           (*(unsigned int*)(mem+0x81b)==0x00F59D08) &&
+           (*(unsigned int*)(mem+0x85b)==0xD0D0F8E4) )
+        {
+            Unp->DepAdr=mem[0x823]|mem[0x824]<<8;
+            Unp->Forced=0x803;
+            Unp->RetAdr=mem[0x865]|mem[0x866]<<8;
+            Unp->StrMem=mem[0x850]|mem[0x851]<<8;
+            Unp->EndAdC=0xffff|EA_USE_Y;
+            Unp->fEndAf=0x121;
+            PrintInfo(Unp,_I_XTC23GP );
+            Unp->IdFlag=1;return;
+        }
+    }
+    /* XTC packer 2.x? found in G*P/NEI/Armageddon warez
+    just some different byte on copy loop, else is equal to 2.3
+    */
+    if( Unp->DepAdr==0 )
+    {
+        for(p=0x801;p<0x80c;p+=0x0a)
+        {
+            if(((*(unsigned int*)(mem+p+0x00)&0xffff0000)==0xE6780000) &&
+               ((*(unsigned int*)(mem+p+0x05)&0xffff00ff)==0xB90800CE) &&
+                (*(unsigned int*)(mem+p+0x0b)==0xC8000099) &&
+                (*(unsigned int*)(mem+p+0x1e)==0x4CF7D0CA) )
+            {
+                /* has variable codebytes so addresses varies */
+                for(q=p+0x36;q<p+0x60;q+=4)
+                {
+                    if(mem[q]==0xc9)
+                        continue;
+                    if(mem[q]==0x99)
+                    {
+                        Unp->DepAdr=0x100;
+                        break;
+                    }
+                    break; /* unexpected byte, get out */
+                }
+                break;
+            }
+        }
+        if( Unp->DepAdr )
+        {
+            Unp->RetAdr=mem[q+0x16]|mem[q+0x17]<<8;
+            Unp->Forced=p+2;
+            Unp->fEndAf=mem[q+0x7]|mem[q+0x8]<<8;Unp->fEndAf--;
+            Unp->EndAdC=0xffff|EA_USE_Y;
+            Unp->StrMem=mem[q+1]|mem[q+2]<<8;
+            PrintInfo(Unp,_I_XTC2XGP);
+            Unp->IdFlag=1;return;
+        }
+    }
+}

--- a/terps/unp64/scanners/_Scanners.c
+++ b/terps/unp64/scanners/_Scanners.c
@@ -254,12 +254,10 @@ void PrintInfo(unpstr *Unp, int id) {
         fprintf(stderr, DEPMASK2,"1001 CardCruncher","v4.x",Unp->DepAdr);
         break;
         case _I_1001_NEWPACK:
-        sprintf(appstr,"%s %s","1001 CardCruncher","New");
-        fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+        fprintf(stderr, DEPMASK,"1001 CardCruncher New Packer",Unp->DepAdr);
         break;
         case _I_1001_OLDPACK:
-        sprintf(appstr,"%s %s","1001 CardCruncher","Old");
-        fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+        fprintf(stderr, DEPMASK,"1001 CardCruncher Old Packer",Unp->DepAdr);
         break;
         case _I_1001_CRAM:
         fprintf(stderr, DEPMASK2,"1001 CardCruncher","CRAM",Unp->DepAdr);
@@ -626,16 +624,13 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK2,"Byte","Baby",Unp->DepAdr);
     //    break;
   case _I_BYTEBOILER:
-    sprintf(appstr, "%s%s", "Byte", "Boiler");
-    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "ByteBoiler", Unp->DepAdr);
     break;
   case _I_BYTEBOICPX:
-    sprintf(appstr, "%s%s", "Byte", "Boiler");
-    fprintf(stderr, DEPMASK2, appstr, "CPX", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "ByteBoiler", "CPX", Unp->DepAdr);
     break;
   case _I_BYTEBOISCS:
-    sprintf(appstr, "%s%s", "Byte", "Boiler");
-    fprintf(stderr, DEPMASK2, appstr, "SCS", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "ByteBoiler", "SCS", Unp->DepAdr);
     break;
     //    case _I_BYTEBOOZER:
     //    sprintf(appstr,"%s%s","Byte","Boozer");
@@ -676,46 +671,37 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK2,"Cadgers","Packer",Unp->DepAdr);
     //    break;
         case _I_CAUTION10:
-        sprintf(appstr,"%s%s","Quick","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"QuickPacker","v1.0",Unp->DepAdr);
         break;
         case _I_CAUTION25:
-        sprintf(appstr,"%s%s","Quick","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v2.5",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"QuickPacker","v2.5",Unp->DepAdr);
         break;
         case _I_CAUTION25SS:
-        sprintf(appstr,"%s%s","Quick","Packer");strcat(appstr,"/sysless");
-        fprintf(stderr, DEPMASK2,appstr,"v2.5",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"QuickPacker/Sysless","v2.5",Unp->DepAdr);
         break;
         case _I_CAUTION20:
-        sprintf(appstr,"%s%s","Quick","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"QuickPacker","v2.0",Unp->DepAdr);
         break;
         case _I_CAUTION20SS:
-        sprintf(appstr,"%s%s","Quick","Packer");strcat(appstr,"/sysless");
-        fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"QuickPacker/Sysless","v2.0",Unp->DepAdr);
         break;
         case _I_CAUTIONHP:
-        sprintf(appstr,"%s%s","Hard","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"HardPacker","v1.0",Unp->DepAdr);
         break;
     //    case _I_CCSMAXS:
     //    fprintf(stderr, DEPMASK2,"CCS","MaxShorter",Unp->DepAdr);
     //    break;
-    //    case _I_CCSCRUNCH1:
-    //    sprintf(appstr,"%s %s","CCS","Cruncher");
-    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
-    //    break;
-    //    case _I_CCSCRUNCH2:
-    //    sprintf(appstr,"%s %s","CCS","Cruncher");
-    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
-    //    break;
-    //    case _I_CCSPACK:
-    //    fprintf(stderr, DEPMASK2,"CCS","Packer",Unp->DepAdr);
-    //    break;
+        case _I_CCSCRUNCH1:
+        fprintf(stderr, DEPMASK2,"CCS Cruncher","v1.x",Unp->DepAdr);
+        break;
+        case _I_CCSCRUNCH2:
+        fprintf(stderr, DEPMASK2,"CCS Cruncher","v2.x",Unp->DepAdr);
+        break;
+        case _I_CCSPACK:
+        fprintf(stderr, DEPMASK2,"CCS","Packer",Unp->DepAdr);
+        break;
     //    case _I_CCSSCRE:
-    //    sprintf(appstr,"%s %s","CCS","ScreenShorter");
-    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    fprintf(stderr, DEPMASK2,"CCS ScreenShorter","v1.0",Unp->DepAdr);
     //    break;
     //    case _I_CCSSPEC:
     //    fprintf(stderr, DEPMASK2,"CCS","Special",Unp->DepAdr);
@@ -727,8 +713,7 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK2,"CCS","Unknown",Unp->DepAdr);
     //    break;
     //    case _I_CCSHACK:
-    //    sprintf(appstr,"%s %s","MaxShorter","Hack");
-    //    fprintf(stderr, DEPMASK2,"CCS",appstr,Unp->DepAdr);
+    //    fprintf(stderr, DEPMASK2,"CCS","MaxShorter Hack",Unp->DepAdr);
     //    break;
     //    case _I_CELERIP:
     //    fprintf(stderr, DEPMASK,"CeleriPack",Unp->DepAdr);
@@ -745,16 +730,13 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "CruelCrunch", "v2.2", Unp->DepAdr);
     break;
   case _I_CRUEL2MHZ:
-    sprintf(appstr, "%s / %s", "v2.2+", "2MHZ");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v2.2+ / 2MHZ", Unp->DepAdr);
     break;
   case _I_CRUELFAST2:
-    sprintf(appstr, "%s / %s", "v2.5", "fast");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v2.5 / fast", Unp->DepAdr);
     break;
   case _I_CRUELFAST4:
-    sprintf(appstr, "%s / %s", "v4.0", "fast");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v4.0 / fast", Unp->DepAdr);
     break;
   case _I_CRUEL_X:
     fprintf(stderr, DEPMASK2, "CruelCrunch", "vx.x", Unp->DepAdr);
@@ -776,20 +758,16 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK2,"MSCrunch",appstr,Unp->DepAdr);
     //    break;
   case _I_CRUEL_HDR:
-    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
-    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch header", Unp->DepAdr);
     break;
   case _I_CRUEL_H22:
-    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
-    fprintf(stderr, DEPMASK2, appstr, "v2.2", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "CruelCrunch header", "v2.2", Unp->DepAdr);
     break;
   case _I_CRUEL_H20:
-    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
-    fprintf(stderr, DEPMASK2, appstr, "v2.0", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "CruelCrunch header", "v2.0", Unp->DepAdr);
     break;
   case _I_CRUEL_HTC:
-    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
-    fprintf(stderr, DEPMASK2, appstr, "TCOM", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "CruelCrunch header", "TCOM", Unp->DepAdr);
     break;
   case _I_CRUEL20:
     fprintf(stderr, DEPMASK2, "CruelCrunch", "v2.0", Unp->DepAdr);
@@ -798,12 +776,10 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "CruelCrunch", "v2.1", Unp->DepAdr);
     break;
   case _I_CRUEL_ILS:
-    sprintf(appstr, "%s / %s", "v2.x", "ILS");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v2.x / ILS", Unp->DepAdr);
     break;
   case _I_CRUEL_RND:
-    sprintf(appstr, "%s / %s", "v2.x", "RND");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v2.x / RND", Unp->DepAdr);
     break;
   case _I_CRUEL10:
     fprintf(stderr, DEPMASK2, "CruelCrunch", "v1.0", Unp->DepAdr);
@@ -812,12 +788,10 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "CruelCrunch", "v1.2", Unp->DepAdr);
     break;
   case _I_CRUEL14:
-    sprintf(appstr, "%s / %s", "v1.4", "Light");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v1.4 / Light", Unp->DepAdr);
     break;
   case _I_CRUEL_TKC:
-    sprintf(appstr, "%s / %s", "v2.3", "TKC");
-    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "CruelCrunch v2.3 / TKC", Unp->DepAdr);
     break;
     //    case _I_TABOOCRUSH:
     //    fprintf(stderr, DEPMASK2,"Crush","/ Taboo",Unp->DepAdr);
@@ -860,8 +834,7 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
     //    break;
         case _I_DARKSQXTC :
-        sprintf(appstr,"%s / %s","DarkSqueezer","XTC");
-        fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+        fprintf(stderr, DEPMASK,"DarkSqueezer / XTC",Unp->DepAdr);
         break;
     //    case _I_DARKSQWOW:
     //    sprintf(appstr,"%s / %s","DarkSqueezer","Darkfiler");
@@ -951,9 +924,7 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.9", Unp->DepAdr);
     break;
   case _I_EXPERT29EUC:
-    strcpy(appstr, "v2.9");
-    strcat(appstr, "a/EUC");
-    fprintf(stderr, DEPMASK2, "Trilogic Expert", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "Trilogic Expert v2.9a/EUC", appstr, Unp->DepAdr);
     break;
   case _I_EXPERT2X:
     fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.x", Unp->DepAdr);
@@ -962,9 +933,7 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.0", Unp->DepAdr);
     break;
   case _I_EXPERT21:
-    strcpy(appstr, "v2.1");
-    strcat(appstr, "0MMC");
-    fprintf(stderr, DEPMASK2, "Trilogic Expert", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "Trilogic Expert v2.10MMC", Unp->DepAdr);
     break;
   case _I_EXPERT4X:
     fprintf(stderr, DEPMASK2, "Trilogic Expert", "v4.x", Unp->DepAdr);
@@ -973,8 +942,7 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "Trilogic Expert", "v3.x", Unp->DepAdr);
     break;
   case _I_EXPERTASS:
-    sprintf(appstr, "%s / %s", "Trilogic Expert", "ASS");
-    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "Trilogic Expert / ASS", Unp->DepAdr);
     break;
   case _I_EXPERT211:
     fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.11", Unp->DepAdr);
@@ -1126,31 +1094,22 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2,"Final","Compactor",Unp->DepAdr);
     break;
         case _I_SUPCOMFLEX:
-        sprintf(appstr,"%s %s","Super","Compressor");
-        fprintf(stderr, DEPMASK2,appstr,"/ Flexible",Unp->DepAdr);
+        fprintf(stderr, DEPMASK,"Super Compressor / Flexible",Unp->DepAdr);
         break;
         case _I_SUPCOMEQSE:
-        sprintf(appstr,"%s %s","Super","Compressor");
-        fprintf(stderr, DEPMASK2,appstr,"/ Equal sequences",Unp->DepAdr);
+        fprintf(stderr, DEPMASK,"Super Compressor / Equal sequences",Unp->DepAdr);
         break;
         case _I_SUPCOMEQB9:
-        sprintf(appstr,"%s %s","Super","Compressor");
-        strcat(appstr," "); strcat(appstr,"/ Equal sequences");
-        fprintf(stderr, DEPMASK2,appstr,"Hack",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"Super Compressor / Equal sequences","Hack",Unp->DepAdr);
         break;
         case _I_SUPCOMEQCCS:
-        sprintf(appstr,"%s %s","Super","Compressor");
-        strcat(appstr," "); strcat(appstr,"/ Equal sequences");
-        fprintf(stderr, DEPMASK2,appstr,"CCS",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"Super Compressor / Equal sequences","CCS",Unp->DepAdr);
         break;
         case _I_SUPCOMEQC9:
-        sprintf(appstr,"%s %s","Super","Compressor");
-        strcat(appstr," "); strcat(appstr,"/ Equal chars");
-        fprintf(stderr, DEPMASK2,appstr,"Hack",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"Super Compressor / Equal chars","Hack",Unp->DepAdr);
         break;
         case _I_SUPCOMEQCH:
-        sprintf(appstr,"%s %s","Super","Compressor");
-        fprintf(stderr, DEPMASK2,appstr,"/ Equal chars",Unp->DepAdr);
+        fprintf(stderr, DEPMASK,"Super Compressor / Equal chars",Unp->DepAdr);
         break;
     //    case _I_SUPCOMFH11:
     //    sprintf(appstr,"%s %s %s %c %s %c","Super","Compressor","Hack",
@@ -1530,25 +1489,16 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK,"MaschinenSprache-Kompressor",Unp->DepAdr);
     //    break;
   case _I_MASTCOMP:
-    sprintf(appstr, "%s%s", "Master", "Compressor");
-    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK, "Master Compressor", Unp->DepAdr);
     break;
   case _I_MASTCRLX:
-    sprintf(appstr, "%s%s", "Master", "Compressor");
-    strcat(appstr, " /");
-    fprintf(stderr, DEPMASK2, appstr, "Relax", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2,  "Master Compressor /", "Relax", Unp->DepAdr);
     break;
   case _I_MASTCAGL:
-    sprintf(appstr, "%s%s", "Master", "Compressor");
-    strcat(appstr, " /");
-    fprintf(stderr, DEPMASK2, appstr, "Agile", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "Master Compressor /", "Agile", Unp->DepAdr);
     break;
   case _I_MASTCHF:
-    sprintf(appstr, "%s%s", "Master", "Compressor");
-    strcat(appstr, " ");
-    strcat(appstr, "v3.5");
-    strcat(appstr, " /");
-    fprintf(stderr, DEPMASK2, appstr, "Channel4", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "Master Compressor v3.5 /", "Channel4", Unp->DepAdr);
     break;
     //    case _I_MATCHARP:
     //    sprintf(appstr,"%s%s","Char","Packer");
@@ -1801,8 +1751,7 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "Relax", "3-byter", Unp->DepAdr);
     break;
   case _I_RLXP2:
-    sprintf(appstr, "%s %s", "Relax", "Packer");
-    fprintf(stderr, DEPMASK2, appstr, "v2.x", Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "Relax Packer", "v2.x", Unp->DepAdr);
     break;
     //    case _I_SCRCR4:
     //    sprintf(appstr,"%s / %s","ScreenCrunch","2064");
@@ -1926,8 +1875,7 @@ void PrintInfo(unpstr *Unp, int id) {
     fprintf(stderr, DEPMASK2, "TBC Multicompactor", "v2.x", Unp->DepAdr);
     break;
   case _I_TBCMULTMOW:
-    sprintf(appstr, "%s / %s", "AutoBreakSystem", "Manowar");
-    fprintf(stderr, DEPMASK2, "TBC Multicompactor", appstr, Unp->DepAdr);
+    fprintf(stderr, DEPMASK2, "TBC Multicompactor", "AutoBreakSystem / Manowar", Unp->DepAdr);
     break;
     //    case _I_TCDLC1:
     //    fprintf(stderr, DEPMASK2,"TCD Link&Crunch","v1.x",Unp->DepAdr);
@@ -2393,34 +2341,22 @@ void PrintInfo(unpstr *Unp, int id) {
     //    fprintf(stderr, DEPMASK,"XIP",Unp->DepAdr);
     //    break;
         case _I_XTC10:
-        sprintf(appstr,"%s %s","XTC","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"XTC Packer","v1.0",Unp->DepAdr);
         break;
         case _I_XTC21:
-        sprintf(appstr,"%s %s","XTC","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v2.1",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"XTC Packer","v2.1",Unp->DepAdr);
         break;
         case _I_XTC22:
-        sprintf(appstr,"%s %s","XTC","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v2.2",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"XTC Packer","v2.2",Unp->DepAdr);
         break;
         case _I_XTC23:
-        sprintf(appstr,"%s %s","XTC","Packer");
-        fprintf(stderr, DEPMASK2,appstr,"v2.3",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"XTC Packer","v2.3",Unp->DepAdr);
         break;
         case _I_XTC23GP:
-        sprintf(appstr,"%s %s","XTC","Packer");
-        strcat(appstr," ");
-        strcat(appstr,"v2.3");
-        strcat(appstr," /");
-        fprintf(stderr, DEPMASK2,appstr,"G*P",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"XTC Packer v2.3 /","G*P",Unp->DepAdr);
         break;
         case _I_XTC2XGP:
-        sprintf(appstr,"%s %s","XTC","Packer");
-        strcat(appstr," ");
-        strcat(appstr,"v2.x");
-        strcat(appstr," /");
-        fprintf(stderr, DEPMASK2,appstr,"G*P",Unp->DepAdr);
+        fprintf(stderr, DEPMASK2,"XTC Packer v2.x /","G*P",Unp->DepAdr);
         break;
     //    case _I_ZIGAG:
     //    fprintf(stderr, DEPMASK2,"Zigag","Packer",Unp->DepAdr);

--- a/terps/unp64/scanners/_Scanners.c
+++ b/terps/unp64/scanners/_Scanners.c
@@ -1,0 +1,2878 @@
+#include "../unp64.h"
+
+Scnptr ScanFunc[] = {
+    //        Scn_NotPackers
+    //    ,Scn_Autostarters
+    //    ,Scn_XIP
+    //    ,Scn_OUG
+    //    ,Scn_IsePic
+    //    ,Scn_Optimus
+    Scn_ECA
+    //    ,Scn_xCodeZippers
+    ,
+    Scn_Expert
+    //    ,Scn_AR
+    //    ,Scn_BitImploder
+    //    ,Scn_Jox
+    //    ,Scn_ExplCrunch
+    //    ,Scn_ExplFaces
+    //    ,Scn_Facepacker
+    //    ,Scn_ABCruncher
+    //    ,Scn_BYG
+    //    ,Scn_FilecompactorTMC
+    //    ,Scn_ASCprot
+    //    ,Scn_CFB
+    //    ,Scn_Zipper
+    //    ,Scn_NSU
+    //    ,Scn_IDT
+    ,
+    Scn_Cruel,
+    Scn_PuCrunch
+    //    ,Scn_MDG
+    ,Scn_AbuzeCrunch
+    //    ,Scn_SledgeHammer
+    //    ,Scn_TimCrunch
+    //    ,Scn_TimeCruncher
+    //    ,Scn_BetaDynamic
+    //    ,Scn_DarkSqueezer
+    ,
+    Scn_ByteBoiler,
+    Scn_MrCross
+    //    ,Scn_1001card
+    //    ,Scn_WDRsoftp
+    //    ,Scn_DSCcoder
+    //    ,Scn_BonanzaBros
+    //    ,Scn_Agony
+    //    ,Scn_ExplXRated
+    //    ,Scn_ByteCompactor
+    ,
+    Scn_MasterCompressor
+    //    ,Scn_ScreenCrunch
+    //    ,Scn_MCCrackenComp
+    ,Scn_FinalSuperComp
+    //    ,Scn_4cPack
+    //    ,Scn_FXbytepress
+    //    ,Scn_FXbitstream
+    //    ,Scn_Trianon
+    //    ,Scn_KompressMaster711
+    //    ,Scn_TurboPacker
+    ,
+    Scn_TCScrunch,
+    Scn_TBCMultiComp
+    //    ,Scn_ByteBoozer
+    //    ,Scn_ALZ64
+          ,Scn_XTC
+    //    ,Scn_UniPacker
+    //    ,Scn_TCD
+    //    ,Scn_Matcham
+    //    ,Scn_Supercrunch
+    //    ,Scn_Superpack
+    //    ,Scn_BeefTrucker
+    //    ,Scn_TSB
+    //    ,Scn_ISC
+    //    ,Scn_TMM
+    //    ,Scn_FilecompactorMTB
+    //    ,Scn_EqByteComp
+    //    ,Scn_Galleon
+    //    ,Scn_BeastLink
+    //    ,Scn_BronxPacker
+    //    ,Scn_Oneway
+    //    ,Scn_CeleriPack
+    //    ,Scn_CadgersPacker
+    //    ,Scn_Crush
+    //    ,Scn_Lightmizer
+    //    ,Scn_Frog
+    //    ,Scn_FrontPacker
+    //    ,Scn_MartinPiper
+    //    ,Scn_Apack
+    //    ,Scn_ONS
+    //    ,Scn_FC3pack
+    //    ,Scn_Amnesia
+    //    ,Scn_Polonus
+    //    ,Scn_KressCrunch
+    //    ,Scn_SirMiniPack
+    //    ,Scn_MRD
+    ,
+    Scn_CCS
+    //    ,Scn_PZW
+    //    ,Scn_C4MRP
+    //    ,Scn_ILSCoder
+    //    ,Scn_MSI
+    //    ,Scn_U_111pack
+    //    ,Scn_Hawk
+    //    ,Scn_TSMcoder
+    //    ,Scn_Ikari
+    //    ,Scn_WGIcoder
+    //    ,Scn_HTLcoder
+    //    ,Scn_XDScoder
+    //    ,Scn_FDTcoder
+    //    ,Scn_SKLcoder
+    //    ,Scn_SpeediComp
+    //    ,Scn_U_DSC_MA
+    //    ,Scn_P100
+    //    ,Scn_MaschSprache
+    //    ,Scn_MegaCruncher
+    //    ,Scn_VIP
+    //    ,Scn_Gandalf
+    //    ,Scn_AEKcoder
+    //    ,Scn_LSTcoder
+    //    ,Scn_Eastlinker
+    //    ,Scn_Jazzcat
+    //    ,Scn_PITcoder
+    //    ,Scn_BitPacker
+    //    ,Scn_Rows
+    //    ,Scn_U_400All
+    //    ,Scn_U_439pack
+    //    ,Scn_64er
+    //    ,Scn_TMCcoder
+    //    ,Scn_ALScoder
+    //    ,Scn_UltraComp
+    //    ,Scn_FCG
+    ,
+    Scn_Megabyte
+    //    ,Scn_Zigag
+    //    ,Scn_Brains
+    //    ,Scn_Graffity
+    ,
+    Scn_Section8
+        ,Scn_MrZ
+    //    ,Scn_DD
+    //    ,Scn_PackOpt
+    //    ,Scn_Warlock
+    //    ,Scn_U_100pack
+    //    ,Scn_U_101pack
+    //    ,Scn_SyncroPack
+    //    ,Scn_Relax
+    //    ,Scn_Jazoo
+    //    ,Scn_WCC
+    //    ,Scn_LTS
+    //    ,Scn_Low
+    //    ,Scn_C_Noack
+    //    ,Scn_Koncina
+    //    ,Scn_U_Triad
+    //    ,Scn_RapEq
+    //    ,Scn_ByteKiller
+    //    ,Scn_Loadstar
+    //    ,Scn_Trashcan
+          ,Scn_Caution
+    //    ,Scn_U_25_pack
+    //    ,Scn_U_8e_pack
+    //    ,Scn_U_P3_pack
+    //    ,Scn_FalcoPack
+//    ,Scn_FP
+//    ,Scn_FinalCompactor
+    //    ,Scn_NEC
+    //    ,Scn_EnigmaMFFL
+    //    ,Scn_Shurigen
+    //    ,Scn_STL
+    //    ,Scn_GrafBinaer
+    //    ,Scn_AbyssCoder
+    //    ,Scn_SPC
+    //    ,Scn_FSW
+    //    ,Scn_BAM
+    //    ,Scn_Cobra
+    //    ,Scn_ByteBuster
+    //    ,Scn_Mekker
+    //    ,Scn_ByteStrainer
+    //    ,Scn_Jedi
+    //    ,Scn_Pride
+    //    ,Scn_StarCrunch
+    //    ,Scn_SpyPack
+    //    ,Scn_GPacker
+    //    ,Scn_Cadaver
+    //    ,Scn_Helmet
+    //    ,Scn_Excalibur
+    //    ,Scn_CNCD
+    //    ,Scn_Anticom
+    //    ,Scn_Antiram
+    //    ,Scn_BN1872
+    //    ,Scn_4wd
+    //    ,Scn_Huffer
+    //    ,Scn_NM156
+    //    ,Scn_Ratt
+    //    ,Scn_Byterapers
+    //    ,Scn_CIACrypt
+    //    ,Scn_PAN
+    //    ,Scn_TKC
+    //    ,Scn_UProt
+    //    ,Scn_YetiCoder
+    //    ,Scn_Panoramic
+    //    ,Scn_THS
+    //    ,Scn_WHO
+    //    ,Scn_KGBcoder
+    //    ,Scn_Pyra
+    ,
+    Scn_ActionPacker
+    //    ,Scn_CCrypt
+    //    ,Scn_TDT
+    //    ,Scn_Cult
+    //    ,Scn_Gimzo
+    //    ,Scn_BlackAdder
+    //    ,Scn_ICS8
+    //    ,Scn_Paradroid
+    //    ,Scn_Plasma
+    //    ,Scn_DrZoom
+    //    ,Scn_ExactCoder
+    //    ,Scn_CNETFixer
+    //    ,Scn_Triangle
+    //    ,Scn_SFLinker
+    //    ,Scn_Bongo
+    //    ,Scn_Jemasoft
+    //    ,Scn_TATCoder
+    //    ,Scn_RFOCoder
+    //    ,Scn_Doynamite
+    //    ,Scn_Nibbit
+    //    ,Scn_TLRLinker
+    //    ,Scn_TLRSubsizer
+    //    ,Scn_AdmiralP4kbar
+    //    ,Scn_ZeroCoder
+    //    ,Scn_NuCrunch
+    //    ,Scn_TinyCrunch
+    //    ,Scn_FileLinkerSDA
+    //    ,Scn_Inceria
+    ,
+    Scn_Exomizer
+        ,Scn_Intros
+    //    ,Scn_U_Generic801
+};
+
+void Scanners(unpstr *Unp) {
+  int x, y;
+  y = sizeof(ScanFunc) / sizeof(*ScanFunc);
+  for (x = 0; x < y; x++) {
+    (ScanFunc[x])(Unp);
+    if (Unp->IdFlag)
+      break;
+  }
+}
+/* all this to make a central strings pool with unique const strings
+   else every module would have own local strings, duplicated many times.
+*/
+void PrintInfo(unpstr *Unp, int id) {
+  switch (id) {
+        case _I_1001_4:
+        fprintf(stderr, DEPMASK2,"1001 CardCruncher","v4.x",Unp->DepAdr);
+        break;
+        case _I_1001_NEWPACK:
+        sprintf(appstr,"%s %s","1001 CardCruncher","New");
+        fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+        break;
+        case _I_1001_OLDPACK:
+        sprintf(appstr,"%s %s","1001 CardCruncher","Old");
+        fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+        break;
+        case _I_1001_CRAM:
+        fprintf(stderr, DEPMASK2,"1001 CardCruncher","CRAM",Unp->DepAdr);
+        break;
+        case _I_1001_ACM:
+        fprintf(stderr, DEPMASK2,"1001 CardCruncher","ACM",Unp->DepAdr);
+        break;
+        case _I_1001_HTL:
+        fprintf(stderr, DEPMASK2,"1001 CardCruncher","HTL",Unp->DepAdr);
+        break;
+    //    case _I_DATELUC:
+    //    fprintf(stderr, DEPMASK2,"Datel
+    //    UltraCompander","Cruncher",Unp->DepAdr); break; case _I_DATELUCP:
+    //    fprintf(stderr, DEPMASK2,"Datel UltraCompander","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_DATELUCC:
+    //    fprintf(stderr, DEPMASK2,"Datel
+    //    UltraCompander","Compactor",Unp->DepAdr); break; case _I_4CPACK:
+    //    fprintf(stderr, DEPMASK2,"4C","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP22:
+    //    sprintf(appstr,"%s %s","/ special","v2.2");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP23:
+    //    sprintf(appstr,"%s %s","/ special","v2.3");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP2U:
+    //    sprintf(appstr,"%s %s","/ special","v2.?");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP12:
+    //    sprintf(appstr,"%s %s","/ special","v1.2");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP13:
+    //    sprintf(appstr,"%s %s","/ special","v1.3");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP14:
+    //    sprintf(appstr,"%s %s","/ special","v1.4");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP15:
+    //    sprintf(appstr,"%s %s","/ special","v1.5");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_SP1U:
+    //    sprintf(appstr,"%s %s","/ special","v1.?");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERBITP:
+    //    sprintf(appstr,"%s%s","Bit","Packer");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERBITP1:
+    //    sprintf(appstr,"%s%s","Bit","Packer");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ special");
+    //    fprintf(stderr, DEPMASK2,"64er",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS41A:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.1");strcat(appstr,"A");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS41B:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.1");strcat(appstr,"B");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS41C:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.1");strcat(appstr,"C");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS40A:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.0");strcat(appstr,"A");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    break;
+    //    case _I_64ERS40B:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.0");strcat(appstr,"B");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS40C:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.0");strcat(appstr,"C");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS40D:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.0");strcat(appstr,"D");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS40DB:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.0");strcat(appstr,"DB");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERS40F:
+    //    strcpy(appstr,"64er");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v4.0");strcat(appstr,"F");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_15:
+    //    fprintf(stderr, DEPMASK2,"64er","v1.5",Unp->DepAdr);
+    //    break;
+    //    case _I_64ER_21:
+    //    fprintf(stderr, DEPMASK2,"64er","v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_HAPPYS32:
+    //    strcpy(appstr,"Happy-");strcat(appstr,"Packer");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v3.2");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_HAPPYS22:
+    //    strcpy(appstr,"Happy-");strcat(appstr,"Packer");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"/ Equal sequences");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v2.2");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_64ERAUTO:
+    //    fprintf(stderr, DEPMASK2,"64er","Autostarter",Unp->DepAdr);
+    //    break;
+    //    case _I_AB_CRUNCH:
+    //    sprintf(appstr,"%s%s","AB","Cruncher");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    case _I_ABUZECRUNCH:
+    fprintf(stderr, DEPMASK,"AbuzeCrunch",Unp->DepAdr);
+    break;
+    case _I_ABUZECR37:
+        fprintf(stderr, DEPMASK2,"AbuzeCrunch","v3.7",Unp->DepAdr);
+        break;
+    case _I_ABUZECR50:
+        fprintf(stderr, DEPMASK2,"AbuzeCrunch","v5.0",Unp->DepAdr);
+        break;
+    //    case _I_AEKCOD20 :
+    //    sprintf(appstr,"%s %s","AEK","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_AEKCOD11 :
+    //    sprintf(appstr,"%s %s","AEK","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_SYNCRO13:
+    //    sprintf(appstr,"%s %s","Syncro","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.3",Unp->DepAdr);
+    //    break;
+    //    case _I_SYNCRO14:
+    //    sprintf(appstr,"%s %s","Syncro","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.4",Unp->DepAdr);
+    //    break;
+    //    case _I_SYNCRO155:
+    //    sprintf(appstr,"%s %s","Syncro","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.55",Unp->DepAdr);
+    //    break;
+    //    case _I_SYNCRO12 :
+    //    sprintf(appstr,"%s %s","Syncro","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.2",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRPACK:
+    //    fprintf(stderr, DEPMASK2,"T.L.R.","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRPROT1:
+    //    sprintf(appstr,"%s %s","T.L.R.","Protector");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRPROT2:
+    //    sprintf(appstr,"%s %s","T.L.R.","Protector");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRLINK:
+    //    fprintf(stderr, DEPMASK2,"T.L.R.","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRLINKFM:
+    //    sprintf(appstr,"%s %s","T.L.R.","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"FullMem",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRSSIZER:
+    //    fprintf(stderr, DEPMASK2,"T.L.R.","Subsizer",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRSSIZD5:
+    //    sprintf(appstr,"%s %s","T.L.R.","Subsizer");
+    //    strcat(appstr," 0.5");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ dirty",Unp->DepAdr);
+    //    break;
+    //    case _I_TLRSSIZD6:
+    //    sprintf(appstr,"%s %s","T.L.R.","Subsizer");
+    //    strcat(appstr," 0.6");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ dirty",Unp->DepAdr);
+    //    break;
+    //    case _I_AGONYPACK:
+    //    sprintf(appstr,"%s %s","Agony","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKP20:
+    //    sprintf(appstr,"%s %s","Dark","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKP21:
+    //    sprintf(appstr,"%s %s","Dark","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKP31:
+    //    sprintf(appstr,"%s %s","Dark","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.1",Unp->DepAdr);
+    //    break;
+    //    case _I_JAP2:
+    //    sprintf(appstr,"%s %s","Just A","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_ALSCODER:
+    //    fprintf(stderr, DEPMASK2,"ALS","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_ALZ64:
+    //    fprintf(stderr, DEPMASK,"ALZ64/Kabuto",Unp->DepAdr);
+    //    break;
+    //    case _I_AMNESIA1:
+    //    sprintf(appstr,"%s %s","Amnesia","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_AMNESIA2:
+    //    sprintf(appstr,"%s %s","Amnesia","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_APACK:
+    //    fprintf(stderr, DEPMASK,"Apack/MadRom",Unp->DepAdr);
+    //    break;
+    //    case _I_GPACK:
+    //    fprintf(stderr, DEPMASK,"G-Packer/Oxyron",Unp->DepAdr);
+    //    break;
+    //    case _I_AR4  :
+    //    fprintf(stderr, DEPMASK2,"Action Replay","v4.x",Unp->DepAdr);
+    //    break;
+    //    case _I_AR3  :
+    //    fprintf(stderr, DEPMASK2,"Action Replay","v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_ARU  :
+    //    fprintf(stderr, DEPMASK2,"Action Replay","Unknown",Unp->DepAdr);
+    //    break;
+    //    case _I_AR42F:
+    //    sprintf(appstr,"%s %s","Action Replay","v4.x");
+    //    fprintf(stderr, DEPMASK2,appstr,"Split Freeze",Unp->DepAdr);
+    //    break;
+    //    case _I_SSNAP:
+    //    sprintf(appstr,"%s %s","Super","Snapshot");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FRZMACH:
+    //    fprintf(stderr, DEPMASK,"Freeze Machine",Unp->DepAdr);
+    //    break;
+    //    case _I_FRZMACH2F:
+    //    fprintf(stderr, DEPMASK2,"Freeze Machine","Split Freeze",Unp->DepAdr);
+    //    break;
+    //    case _I_ASCPROT:
+    //    fprintf(stderr, DEPMASK2,"ASC/SCF","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_BEASTLINK:
+    //    fprintf(stderr, DEPMASK,"BeastLink",Unp->DepAdr);
+    //    break;
+    //    case _I_BEEFTR56:
+    //    fprintf(stderr, DEPMASK2,"BeefTrucker","$56",Unp->DepAdr);
+    //    break;
+    //    case _I_BEEFTR54:
+    //    fprintf(stderr, DEPMASK2,"Zipplink","$54",Unp->DepAdr);
+    //    break;
+    //    case _I_BEEFTR2:
+    //    strcpy(appstr,"BeefTrucker");strcat(appstr,"/");strcat(appstr,"Zipplink");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BEEFTLB:
+    //    strcpy(appstr,"BeefTrucker");strcat(appstr,"/");strcat(appstr,"Zipplink");
+    //    fprintf(stderr, DEPMASK2,appstr,"LoadBack",Unp->DepAdr);
+    //    break;
+    //    case _I_ZIPLINK21:
+    //    fprintf(stderr, DEPMASK2,"Zip Link","v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_ZIPLINK25:
+    //    fprintf(stderr, DEPMASK2,"Zip Link","v2.5",Unp->DepAdr);
+    //    break;
+    //    case _I_BETADYN3:
+    //    sprintf(appstr,"%s %s","Beta Dynamic","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BETADYN3FX:
+    //    sprintf(appstr,"%s %s","Beta Dynamic","Compressor");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v3.x");strcat(appstr,"/");strcat(appstr,"FX");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BETADYN3CCS:
+    //    sprintf(appstr,"%s %s","Beta Dynamic","Compressor");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v3.x");strcat(appstr,"/");strcat(appstr,"CCS");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BETADYN2:
+    //    sprintf(appstr,"%s %s","Beta Dynamic","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BITIMP:
+    //    sprintf(appstr,"%s%s","Bit","Imploder");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BITPACK2:
+    //    sprintf(appstr,"%s%s","Bit","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BONANZA:
+    //    fprintf(stderr, DEPMASK2,"BonanzaBros","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_BRAINS:
+    //    fprintf(stderr, DEPMASK2,"Brains","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_BRONX:
+    //    fprintf(stderr, DEPMASK2,"Bronx","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_BYG1:
+    //    sprintf(appstr,"%s %s","BYG","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BYG2:
+    //    sprintf(appstr,"%s %s","BYG","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BYGBB:
+    //    fprintf(stderr, DEPMASK2,"Byte","Baby",Unp->DepAdr);
+    //    break;
+  case _I_BYTEBOILER:
+    sprintf(appstr, "%s%s", "Byte", "Boiler");
+    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    break;
+  case _I_BYTEBOICPX:
+    sprintf(appstr, "%s%s", "Byte", "Boiler");
+    fprintf(stderr, DEPMASK2, appstr, "CPX", Unp->DepAdr);
+    break;
+  case _I_BYTEBOISCS:
+    sprintf(appstr, "%s%s", "Byte", "Boiler");
+    fprintf(stderr, DEPMASK2, appstr, "SCS", Unp->DepAdr);
+    break;
+    //    case _I_BYTEBOOZER:
+    //    sprintf(appstr,"%s%s","Byte","Boozer");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BYTEBOOZ20:
+    //    sprintf(appstr,"%s%s","Byte","Boozer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_BYTEBOOZ11C:
+    //    sprintf(appstr,"%s%s","Byte","Boozer");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v1.1");strcat(appstr,"C");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BYTEBOOZ11E:
+    //    sprintf(appstr,"%s%s","Byte","Boozer");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"v1.1");strcat(appstr,"E");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_LAMEBOOZER:
+    //    sprintf(appstr,"%s%s","Lamer","Boozer");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BYTECOMP:
+    //    sprintf(appstr,"%s%s","Byte","Compactor");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_BYTEKILL:
+    //    sprintf(appstr,"%s%s","Byte","Killer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_C4MRP:
+    //    fprintf(stderr, DEPMASK,"C4MRP/RSi",Unp->DepAdr);
+    //    break;
+    //    case _I_CADGERS:
+    //    fprintf(stderr, DEPMASK2,"Cadgers","Packer",Unp->DepAdr);
+    //    break;
+        case _I_CAUTION10:
+        sprintf(appstr,"%s%s","Quick","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+        break;
+        case _I_CAUTION25:
+        sprintf(appstr,"%s%s","Quick","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v2.5",Unp->DepAdr);
+        break;
+        case _I_CAUTION25SS:
+        sprintf(appstr,"%s%s","Quick","Packer");strcat(appstr,"/sysless");
+        fprintf(stderr, DEPMASK2,appstr,"v2.5",Unp->DepAdr);
+        break;
+        case _I_CAUTION20:
+        sprintf(appstr,"%s%s","Quick","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+        break;
+        case _I_CAUTION20SS:
+        sprintf(appstr,"%s%s","Quick","Packer");strcat(appstr,"/sysless");
+        fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+        break;
+        case _I_CAUTIONHP:
+        sprintf(appstr,"%s%s","Hard","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+        break;
+    //    case _I_CCSMAXS:
+    //    fprintf(stderr, DEPMASK2,"CCS","MaxShorter",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSCRUNCH1:
+    //    sprintf(appstr,"%s %s","CCS","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSCRUNCH2:
+    //    sprintf(appstr,"%s %s","CCS","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSPACK:
+    //    fprintf(stderr, DEPMASK2,"CCS","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSSCRE:
+    //    sprintf(appstr,"%s %s","CCS","ScreenShorter");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSSPEC:
+    //    fprintf(stderr, DEPMASK2,"CCS","Special",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSEXEC:
+    //    fprintf(stderr, DEPMASK2,"CCS","Executer",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSUNKN:
+    //    fprintf(stderr, DEPMASK2,"CCS","Unknown",Unp->DepAdr);
+    //    break;
+    //    case _I_CCSHACK:
+    //    sprintf(appstr,"%s %s","MaxShorter","Hack");
+    //    fprintf(stderr, DEPMASK2,"CCS",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_CELERIP:
+    //    fprintf(stderr, DEPMASK,"CeleriPack",Unp->DepAdr);
+    //    break;
+    //    case _I_CFBCOD1:
+    //    sprintf(appstr,"%s %s","CFB","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_CFBCOD2:
+    //    sprintf(appstr,"%s %s","CFB","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+  case _I_CRUEL22:
+    fprintf(stderr, DEPMASK2, "CruelCrunch", "v2.2", Unp->DepAdr);
+    break;
+  case _I_CRUEL2MHZ:
+    sprintf(appstr, "%s / %s", "v2.2+", "2MHZ");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+  case _I_CRUELFAST2:
+    sprintf(appstr, "%s / %s", "v2.5", "fast");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+  case _I_CRUELFAST4:
+    sprintf(appstr, "%s / %s", "v4.0", "fast");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+  case _I_CRUEL_X:
+    fprintf(stderr, DEPMASK2, "CruelCrunch", "vx.x", Unp->DepAdr);
+    break;
+  case _I_CRUELMS15:
+    fprintf(stderr, DEPMASK2, "MSCrunch", "v1.5", Unp->DepAdr);
+    break;
+  case _I_CRUELMS10:
+    fprintf(stderr, DEPMASK2, "MSCrunch", "v1.0", Unp->DepAdr);
+    break;
+  case _I_CRUELMS1X:
+    fprintf(stderr, DEPMASK2, "MSCrunch", "v1.x", Unp->DepAdr);
+    break;
+  case _I_CRUELMS_U:
+    fprintf(stderr, DEPMASK2, "MSCrunch", "Unknown", Unp->DepAdr);
+    break;
+    //    case _I_CRUMSABS:
+    //    sprintf(appstr,"%s / %s","v1.5","ABS");
+    //    fprintf(stderr, DEPMASK2,"MSCrunch",appstr,Unp->DepAdr);
+    //    break;
+  case _I_CRUEL_HDR:
+    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
+    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    break;
+  case _I_CRUEL_H22:
+    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
+    fprintf(stderr, DEPMASK2, appstr, "v2.2", Unp->DepAdr);
+    break;
+  case _I_CRUEL_H20:
+    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
+    fprintf(stderr, DEPMASK2, appstr, "v2.0", Unp->DepAdr);
+    break;
+  case _I_CRUEL_HTC:
+    sprintf(appstr, "%s / %s", "CruelCrunch", "header");
+    fprintf(stderr, DEPMASK2, appstr, "TCOM", Unp->DepAdr);
+    break;
+  case _I_CRUEL20:
+    fprintf(stderr, DEPMASK2, "CruelCrunch", "v2.0", Unp->DepAdr);
+    break;
+  case _I_CRUEL21:
+    fprintf(stderr, DEPMASK2, "CruelCrunch", "v2.1", Unp->DepAdr);
+    break;
+  case _I_CRUEL_ILS:
+    sprintf(appstr, "%s / %s", "v2.x", "ILS");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+  case _I_CRUEL_RND:
+    sprintf(appstr, "%s / %s", "v2.x", "RND");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+  case _I_CRUEL10:
+    fprintf(stderr, DEPMASK2, "CruelCrunch", "v1.0", Unp->DepAdr);
+    break;
+  case _I_CRUEL12:
+    fprintf(stderr, DEPMASK2, "CruelCrunch", "v1.2", Unp->DepAdr);
+    break;
+  case _I_CRUEL14:
+    sprintf(appstr, "%s / %s", "v1.4", "Light");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+  case _I_CRUEL_TKC:
+    sprintf(appstr, "%s / %s", "v2.3", "TKC");
+    fprintf(stderr, DEPMASK2, "CruelCrunch", appstr, Unp->DepAdr);
+    break;
+    //    case _I_TABOOCRUSH:
+    //    fprintf(stderr, DEPMASK2,"Crush","/ Taboo",Unp->DepAdr);
+    //    break;
+    //    case _I_TABOOCRNCH:
+    //    sprintf(appstr,"%s %s","Unknown","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Taboo",Unp->DepAdr);
+    //    break;
+    //    case _I_TABOOPACK:
+    //    sprintf(appstr,"%s %s","Unknown","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Taboo",Unp->DepAdr);
+    //    break;
+    //    case _I_TABOOPACK64:
+    //    sprintf(appstr,"%s %s","Packer","64");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Taboo",Unp->DepAdr);
+    //    break;
+    //    case _I_CNOACK:
+    //    sprintf(appstr,"%s %s","Chris Noack","Mega");
+    //    strcat(appstr," ");strcat(appstr,"Byte");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_CNOACKLXT:
+    //    sprintf(appstr,"%s %s","Chris Noack","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Laxity",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQ08  :
+    //    fprintf(stderr, DEPMASK2,"DarkSqueezer","v0.8",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQ21  :
+    //    fprintf(stderr, DEPMASK2,"DarkSqueezer","v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQ2X  :
+    //    fprintf(stderr, DEPMASK2,"DarkSqueezer","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQ4   :
+    //    fprintf(stderr, DEPMASK2,"DarkSqueezer","v4.x",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQF4  :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","F4CG");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+        case _I_DARKSQXTC :
+        sprintf(appstr,"%s / %s","DarkSqueezer","XTC");
+        fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+        break;
+    //    case _I_DARKSQWOW:
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","Darkfiler");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQGP  :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","G*P");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQDOM  :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","DOM");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQPAR  :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","Paradroid");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQ4SHK :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","Sharks");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQ22:
+    //    fprintf(stderr, DEPMASK2,"DarkSqueezer","v2.2",Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQBB1 :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","ByteBonker");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_DARKSQBB2 :
+    //    sprintf(appstr,"%s / %s","DarkSqueezer","ByteBonker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_DDINTROC :
+    //    fprintf(stderr, DEPMASK2,"DD Intro","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_DSCCOD :
+    //    fprintf(stderr, DEPMASK2,"DSCompware","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_EASTLINK :
+    //    fprintf(stderr, DEPMASK2,"East","Linker",Unp->DepAdr);
+    //    break;
+  case _I_ECA:
+    fprintf(stderr, DEPMASK2, "ECA", "Compacker", Unp->DepAdr);
+    break;
+  case _I_ECAOLD:
+    fprintf(stderr, DEPMASK2, "ECA", "/ old?", Unp->DepAdr);
+    break;
+    //    case _I_ENIGMAMFFL:
+    //    fprintf(stderr, DEPMASK,"Enigma MFFL",Unp->DepAdr);
+    //    break;
+    //    case _I_EQBYTEC12:
+    //    sprintf(appstr,"%s %s","Equal Byte","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.2",Unp->DepAdr);
+    //    break;
+    //    case _I_EQBYTEC14:
+    //    sprintf(appstr,"%s %s","Equal Byte","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.4",Unp->DepAdr);
+    //    break;
+    //    case _I_EQBYTEC17:
+    //    sprintf(appstr,"%s %s","Equal Byte","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.7",Unp->DepAdr);
+    //    break;
+    //    case _I_EQBYTEC19:
+    //    sprintf(appstr,"%s %s","Equal Byte","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.9",Unp->DepAdr);
+    //    break;
+    //    case _I_EQBYTEC19TAL:
+    //    sprintf(appstr,"%s %s","Equal Byte","Compressor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.9/TAL",Unp->DepAdr);
+    //    break;
+  case _I_EXOM:
+    fprintf(stderr, DEPMASK, "Exomizer", Unp->DepAdr);
+    break;
+  case _I_EXOM3:
+    fprintf(stderr, DEPMASK2, "Exomizer", "v3.0", Unp->DepAdr);
+    break;
+  case _I_EXOM302:
+    fprintf(stderr, DEPMASK2, "Exomizer", "v3.02+", Unp->DepAdr);
+    break;
+  case _I_EXPERT1X:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v1.x", Unp->DepAdr);
+    break;
+  case _I_EXPERT27:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.7", Unp->DepAdr);
+    break;
+  case _I_EXPERT29:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.9", Unp->DepAdr);
+    break;
+  case _I_EXPERT29EUC:
+    strcpy(appstr, "v2.9");
+    strcat(appstr, "a/EUC");
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", appstr, Unp->DepAdr);
+    break;
+  case _I_EXPERT2X:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.x", Unp->DepAdr);
+    break;
+  case _I_EXPERT20:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.0", Unp->DepAdr);
+    break;
+  case _I_EXPERT21:
+    strcpy(appstr, "v2.1");
+    strcat(appstr, "0MMC");
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", appstr, Unp->DepAdr);
+    break;
+  case _I_EXPERT4X:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v4.x", Unp->DepAdr);
+    break;
+  case _I_EXPERT3X:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v3.x", Unp->DepAdr);
+    break;
+  case _I_EXPERTASS:
+    sprintf(appstr, "%s / %s", "Trilogic Expert", "ASS");
+    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    break;
+  case _I_EXPERT211:
+    fprintf(stderr, DEPMASK2, "Trilogic Expert", "v2.11", Unp->DepAdr);
+    break;
+    //    case _I_EXPLCRUNCH1X:
+    //    sprintf(appstr,"%s %s","Exploding","CruelCrunch"); appstr[15]=0;
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.6",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPLCRUNCH2X:
+    //    sprintf(appstr,"%s %s","Exploding","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPLCRUNCH21:
+    //    sprintf(appstr,"%s %s","Exploding","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPLCRUNCH22:
+    //    sprintf(appstr,"%s %s","Exploding","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.2",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPLCOD:
+    //    fprintf(stderr, DEPMASK2,"Exploding","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPLFAC1    :
+    //    sprintf(appstr,"%s %s","Exploding","Faces");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPLFAC2    :
+    //    sprintf(appstr,"%s %s","Exploding","Faces");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_XRPOWC71    :
+    //    sprintf(appstr,"%s %s","PowerCrunch","v7.1");
+    //    fprintf(stderr, DEPMASK2,"X-Rated",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_XREXPLCR    :
+    //    sprintf(appstr,"%s %s","Exploding","Cruncher");
+    //    fprintf(stderr, DEPMASK2,"X-Rated",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_XRPOWC74    :
+    //    sprintf(appstr,"%s %s","PowerCrunch","v7.4");
+    //    fprintf(stderr, DEPMASK2,"X-Rated",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FACEPACK10:
+    //    strcpy(appstr,"Face");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_FACEPACK11:
+    //    strcpy(appstr,"Face");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_FC3PACK:
+    //    sprintf(appstr,"%s %s","FinalCart","III");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_FC3LD:
+    //    sprintf(appstr,"%s %s","FinalCart","III");
+    //    fprintf(stderr, DEPMASK2,appstr,"Split Freeze",Unp->DepAdr);
+    //    break;
+    //    case _I_FC2LD:
+    //    sprintf(appstr,"%s %s","FinalCart","II");
+    //    fprintf(stderr, DEPMASK2,appstr,"Split Freeze",Unp->DepAdr);
+    //    break;
+    //    case _I_FCU1LD:
+    //    sprintf(appstr,"%s %s","FinalCart","v1.?");
+    //    fprintf(stderr, DEPMASK2,appstr,"Split Freeze",Unp->DepAdr);
+    //    break;
+    //    case _I_FCULD:
+    //    sprintf(appstr,"%s %s","FinalCart","Unknown");
+    //    fprintf(stderr, DEPMASK2,appstr,"Split Freeze",Unp->DepAdr);
+    //    break;
+    //    case _I_FCGPACK10:
+    //    sprintf(appstr,"%s %s","FCG","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_FCGPACK30:
+    //    sprintf(appstr,"%s %s","FCG","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_FCGPACK12:
+    //    sprintf(appstr,"%s %s","FCG","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.2",Unp->DepAdr);
+    //    break;
+    //    case _I_FCGPACK13:
+    //    sprintf(appstr,"%s %s","FCG","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.3",Unp->DepAdr);
+    //    break;
+    //    case _I_FCGLINK:
+    //    fprintf(stderr, DEPMASK2,"FCG","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_TFGPACK:
+    //    fprintf(stderr, DEPMASK2,"TFG","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TFGCODE:
+    //    fprintf(stderr, DEPMASK2,"TFG","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_TMCULINK:
+    //    sprintf(appstr,"%s %s","Ultimate","Linker");
+    //    fprintf(stderr, DEPMASK2,"TMC",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FCGCODER:
+    //    fprintf(stderr, DEPMASK2,"FCG","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_HLEISEP:
+    //    fprintf(stderr, DEPMASK2,"H.Leise","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_FCGPROT:
+    //    fprintf(stderr, DEPMASK2,"FCG","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_EXPROT:
+    //    strcpy(appstr,"Ex");strcat(appstr,"Protector");appstr[9]=0;
+    //    fprintf(stderr, DEPMASK2,"FCG",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FLSPROT33:
+    //    sprintf(appstr,"%s %s","Flash","Protector");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.3",Unp->DepAdr);
+    //    break;
+    //    case _I_FCCPROT:
+    //    fprintf(stderr, DEPMASK2,"FCC","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_FDTCOD:
+    //    fprintf(stderr, DEPMASK2,"FDT","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_FCOMPMTB:
+    //    strcpy(appstr,"File");strcat(appstr,"Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"I/MTB",Unp->DepAdr);
+    //    break;
+    //    case _I_FCOMPTMC:
+    //    sprintf(appstr,"%s %s","/ Flexible"+2,"Code");
+    //    sprintf(appstr,"%s %s","/ Flexible","Code");
+    //    fprintf(stderr, DEPMASK2,appstr,"Compactor",Unp->DepAdr);
+    //    break;
+    //    case _I_FCOMPMTC:
+    //    fprintf(stderr, DEPMASK2,"MeanTeam","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_FCOMPK2:
+    //    sprintf(appstr,"%s %s","/ Flexible"+2,"Code");
+    //    sprintf(appstr,"%s %s","/ Flexible","Code");
+    //    strcat(appstr," "); strcat(appstr,"Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_FCOMPSYS3:
+    //    sprintf(appstr,"%s %s","/ Flexible"+2,"Code");
+    //    sprintf(appstr,"%s %s","/ Flexible","Code");
+    //    strcat(appstr," "); strcat(appstr,"Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    case _I_FINCOMP:
+    fprintf(stderr, DEPMASK2,"Final","Compactor",Unp->DepAdr);
+    break;
+        case _I_SUPCOMFLEX:
+        sprintf(appstr,"%s %s","Super","Compressor");
+        fprintf(stderr, DEPMASK2,appstr,"/ Flexible",Unp->DepAdr);
+        break;
+        case _I_SUPCOMEQSE:
+        sprintf(appstr,"%s %s","Super","Compressor");
+        fprintf(stderr, DEPMASK2,appstr,"/ Equal sequences",Unp->DepAdr);
+        break;
+        case _I_SUPCOMEQB9:
+        sprintf(appstr,"%s %s","Super","Compressor");
+        strcat(appstr," "); strcat(appstr,"/ Equal sequences");
+        fprintf(stderr, DEPMASK2,appstr,"Hack",Unp->DepAdr);
+        break;
+        case _I_SUPCOMEQCCS:
+        sprintf(appstr,"%s %s","Super","Compressor");
+        strcat(appstr," "); strcat(appstr,"/ Equal sequences");
+        fprintf(stderr, DEPMASK2,appstr,"CCS",Unp->DepAdr);
+        break;
+        case _I_SUPCOMEQC9:
+        sprintf(appstr,"%s %s","Super","Compressor");
+        strcat(appstr," "); strcat(appstr,"/ Equal chars");
+        fprintf(stderr, DEPMASK2,appstr,"Hack",Unp->DepAdr);
+        break;
+        case _I_SUPCOMEQCH:
+        sprintf(appstr,"%s %s","Super","Compressor");
+        fprintf(stderr, DEPMASK2,appstr,"/ Equal chars",Unp->DepAdr);
+        break;
+    //    case _I_SUPCOMFH11:
+    //    sprintf(appstr,"%s %s %s %c %s %c","Super","Compressor","Hack",
+    //    '1',"layer",'1'); fprintf(stderr, DEPMASK,appstr,Unp->DepAdr); break;
+    //    case _I_SUPCOMFH12:
+    //    sprintf(appstr,"%s %s %s %c %s %c","Super","Compressor","Hack",
+    //    '1',"layer",'2'); fprintf(stderr, DEPMASK,appstr,Unp->DepAdr); break;
+    //    case _I_SUPCOMFH13:
+    //    sprintf(appstr,"%s %s %s %c %s %c","Super","Compressor","Hack",
+    //    '1',"layer",'3'); fprintf(stderr, DEPMASK,appstr,Unp->DepAdr); break;
+    //    case _I_SUPCOMFH21:
+    //    sprintf(appstr,"%s %s %s %c %s %c","Super","Compressor","Hack",
+    //    '2',"layer",'1'); fprintf(stderr, DEPMASK,appstr,Unp->DepAdr); break;
+    //    case _I_SUPCOMHACK:
+    //    sprintf(appstr,"%s %s","Super","Compressor");
+    //    strcat(appstr," "); strcat(appstr,"/ Flexible");
+    //    fprintf(stderr, DEPMASK2,appstr,"Hack",Unp->DepAdr);
+    //    break;
+    //    case _I_FPCOD:
+    //    fprintf(stderr, DEPMASK2,"FP","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_FROGPACK:
+    //    fprintf(stderr, DEPMASK2,"Frog","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_FRONTPACK:
+    //    fprintf(stderr, DEPMASK2,"Front","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_FXBYTEP:
+    //    sprintf(appstr,"%s %s","FX","Bytepress");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FXBP_BBSP:
+    //    sprintf(appstr,"%s %s","/ BB","(Soundpacker)");
+    //    fprintf(stderr, DEPMASK2,"FX Bytepress",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FXBP_BB:
+    //    fprintf(stderr, DEPMASK2,"FX Bytepress","/ BB",Unp->DepAdr);
+    //    break;
+    //    case _I_FXBP_JW:
+    //    fprintf(stderr, DEPMASK2,"FX Bytepress","/ Jewels",Unp->DepAdr);
+    //    break;
+    //    case _I_FXBP_SN:
+    //    fprintf(stderr, DEPMASK2,"FX Bytepress","/ Seen",Unp->DepAdr);
+    //    break;
+    //    case _I_FXBITST:
+    //    fprintf(stderr, DEPMASK2,"FX","Bitstreamer",Unp->DepAdr);
+    //    break;
+    //    case _I_BITST11:
+    //    fprintf(stderr, DEPMASK2,"Bitstreamer","v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLEONEQ:
+    //    fprintf(stderr, DEPMASK2,"Galleon","/ Equal chars",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLCP35:
+    //    sprintf(appstr,"%s %s","Galleon","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.5",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLCP36:
+    //    sprintf(appstr,"%s %s","Galleon","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.6",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLCP37:
+    //    sprintf(appstr,"%s %s","Galleon","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.7",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLCP38:
+    //    sprintf(appstr,"%s %s","Galleon","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.8",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLCP39:
+    //    sprintf(appstr,"%s %s","Galleon","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.9",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLCP3X:
+    //    sprintf(appstr,"%s %s","Galleon","Compactor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLFW4C:
+    //    fprintf(stderr, DEPMASK2,"Galleon","FW4C",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLFW4C2:
+    //    sprintf(appstr,"%s %s","Galleon","FW4C");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLFW4C3:
+    //    sprintf(appstr,"%s %s","Galleon","FW4C");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLFW4C31:
+    //    sprintf(appstr,"%s %s","Galleon","FW4C");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.1",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLBRPR:
+    //    strcpy(appstr,"Byterapers");appstr[9]=0;
+    //    fprintf(stderr, DEPMASK2,"Galleon",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_GALLU02:
+    //    sprintf(appstr,"%s %s","Galleon","$02");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLU100:
+    //    sprintf(appstr,"%s %s","Galleon","$100");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLWHOM1:
+    //    sprintf(appstr,"%s %s","Galleon","Whom");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLWHOM11:
+    //    sprintf(appstr,"%s %s","Galleon","Whom");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLWHOM2:
+    //    sprintf(appstr,"%s %s","Galleon","Whom");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLWHOM4:
+    //    sprintf(appstr,"%s %s","Galleon","Whom");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v4.x",Unp->DepAdr);
+    //    break;
+    //    case _I_GALLWHOM4S:
+    //    sprintf(appstr,"%s %s","Galleon","Whom");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    strcat(appstr," ");strcat(appstr,"v4.x");strcat(appstr,"/sysless");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_GALLVEST:
+    //    fprintf(stderr, DEPMASK,"Alvesta Link",Unp->DepAdr);
+    //    break;
+    //    case _I_GANDALF:
+    //    fprintf(stderr, DEPMASK2,"Gandalf","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_GRAFFITY:
+    //    fprintf(stderr, DEPMASK2,"Graffity","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_HAWK:
+    //    fprintf(stderr, DEPMASK2,"Hawk","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_HTLCOD:
+    //    fprintf(stderr, DEPMASK2,"HTL","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_IDT10:
+    //    sprintf(appstr,"%s %s","Idiots","FX");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_IDTFX21:
+    //    sprintf(appstr,"%s %s","Idiots","FX");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_IDTFX20:
+    //    sprintf(appstr,"%s %s","Idiots","FX");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_GNTFX20:
+    //    sprintf(appstr,"%s %s","Gentlemen","FX");
+    //    strcat(appstr," ");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_GNTSTATP:
+    //    sprintf(appstr,"%s %s","Gentlemen","Stat");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_EXCELCOD:
+    //    fprintf(stderr, DEPMASK2,"Excell/Ikari","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_IKARICR:
+    //    fprintf(stderr, DEPMASK2,"Ikari","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_ILSCOD:
+    //    strcpy(appstr,"ILS");strcat(appstr,"/");strcat(appstr,"RND");
+    //    fprintf(stderr, DEPMASK2,appstr,"Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_IRELAX1:
+    //    sprintf(appstr,"%s %s","Intro:","Relax");
+    //    strcat(appstr,"-01");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IRELAX2:
+    //    sprintf(appstr,"%s %s","Intro:","Relax");
+    //    strcat(appstr,"-02");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IF4CG23:
+    //    sprintf(appstr,"%s %s","Intro:","F4CG");
+    //    strcat(appstr,"-23");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ITRIAD1:
+    //    sprintf(appstr,"%s %s","Intro:","Triad");
+    //    strcat(appstr,"-01");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ITRIAD2:
+    //    sprintf(appstr,"%s %s","Intro:","Triad");
+    //    strcat(appstr,"-02");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ITRIAD5:
+    //    sprintf(appstr,"%s %s","Intro:","Triad");
+    //    strcat(appstr,"-05");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IGP2:
+    //    sprintf(appstr,"%s %s","Intro:","G*P");
+    //    strcat(appstr,"-02");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_I711ID3:
+    //    sprintf(appstr,"%s %s","711","IntroDesigner3");
+    //    fprintf(stderr, DEPMASK2,"Intro:",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IBN1872:
+    //    fprintf(stderr, DEPMASK2,"Intro:","BN 1872",Unp->DepAdr);
+    //    break;
+    //    case _I_BN1872PK:
+    //    fprintf(stderr, DEPMASK2,"BN 1872","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_IEXIKARI:
+    //    sprintf(appstr,"%s %s","Intro:","Excell/Ikari");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IIKARI06:
+    //    sprintf(appstr,"%s %s","Intro:","Ikari");
+    //    strcat(appstr,"-06");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IFLT01:
+    //    sprintf(appstr,"%s %s","Intro:","FLT");
+    //    strcat(appstr,"-01");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_IS45109:
+    //    sprintf(appstr,"%s %s","Intro:","S451");
+    //    strcat(appstr,"-09");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISCN:
+    //    sprintf(appstr,"%s %s", "Normal","Cruncher");
+    //    fprintf(stderr, DEPMASK2,"ISC /",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISCP:
+    //    fprintf(stderr, DEPMASK2,"ISC /","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_ISCBS:
+    //    sprintf(appstr,"%s %s", "Bitstream","Cruncher");
+    //    fprintf(stderr, DEPMASK2,"ISC /",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPIC:
+    //    fprintf(stderr, DEPMASK,"IsePic",Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPDD:
+    //    sprintf(appstr,"%sker/DD","IsePic");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPCT1:
+    //    sprintf(appstr,"Why %s/CT","IsePic");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPCT2:
+    //    sprintf(appstr,"Why %s/CT","IsePic");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_ISEP7U1:
+    //    sprintf(appstr,"Anti-%s / %s %s","IsePic", "7up","v1.x");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEP7U2:
+    //    sprintf(appstr,"Anti-%s / %s %s","IsePic", "7up","v2.x");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPGS1:
+    //    sprintf(appstr,"Anti-%s / %s %s","IsePic", "GSS","v1.1");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPNC:
+    //    strcpy(appstr,"Defroster");strcat(appstr,"/");strcat(appstr,"NC");
+    //    fprintf(stderr, DEPMASK2,"IsePic",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPAMG:
+    //    strcpy(appstr,"Defroster");strcat(appstr,"/");strcat(appstr,"Amigo");
+    //    fprintf(stderr, DEPMASK2,"IsePic",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPGEN:
+    //    fprintf(stderr, DEPMASK2,"Generic","IsePic",Unp->DepAdr);
+    //    break;
+    //    case _I_JAZOOCOD:
+    //    fprintf(stderr, DEPMASK2,"Jazoo","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_JCTCR:
+    //    fprintf(stderr, DEPMASK2,"JCT","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_JCTPACK:
+    //    fprintf(stderr, DEPMASK2,"JCT","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_JOXCR:
+    //    fprintf(stderr, DEPMASK2,"J0xstrap","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_KOMPSP:
+    /* eq sequence 4.1A/4.3a */
+    //    fprintf(stderr, DEPMASK2,"Kompressmaster","/ special",Unp->DepAdr);
+    //    break;
+    //    case _I_KOMP711:
+    //    /* eq sequence 4.1B */
+    //    sprintf(appstr,"%s / %s","Kompressmaster","711");
+    //    fprintf(stderr, DEPMASK2,appstr,"Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_KOMPBB:
+    //    sprintf(appstr,"%s / %s","Kompressmaster","BB");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_KOMP71PS:
+    //    /* packer after 4.1a/4.3a */
+    //    sprintf(appstr,"%s %s","Kompressmaster","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ special",Unp->DepAdr);
+    //    break;
+    //    case _I_KOMP71P1:
+    //    /* packer 4.3a */
+    //    sprintf(appstr,"%s %s","Kompressmaster","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_KOMP71P2:
+    //    /* packer 4.1 */
+    //    sprintf(appstr,"%s %s","Kompressmaster","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_KONCINA:
+    //    fprintf(stderr, DEPMASK2,"Koncina","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_LIGHTM:
+    //    fprintf(stderr, DEPMASK,"Lightmizer",Unp->DepAdr);
+    //    break;
+    //    case _I_VISIOM63:
+    //    fprintf(stderr, DEPMASK2,"Visiomizer","v6.3",Unp->DepAdr);
+    //    break;
+    //    case _I_VISIOM62:
+    //    fprintf(stderr, DEPMASK2,"Visiomizer","v6.2",Unp->DepAdr);
+    //    break;
+    //    case _I_LSMODL:
+    //    sprintf(appstr,"%s %s","Loadstar","Mod");
+    //    fprintf(stderr, DEPMASK2,appstr,"Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_LSPACK:
+    //    fprintf(stderr, DEPMASK2,"Loadstar","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_LSLNK2:
+    //    sprintf(appstr,"%s %s","Loadstar","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_LOWCR:
+    //    fprintf(stderr, DEPMASK2,"Low","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_LSTCOD1:
+    //    sprintf(appstr,"%s %s","LST","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_LSTCOD2:
+    //    sprintf(appstr,"%s %s","LST","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_LTSPACK:
+    //    fprintf(stderr, DEPMASK2,"LTS","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_LZMPI1:
+    //    fprintf(stderr, DEPMASK2,"LZMPi/MartinPiper","v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_LZMPI2:
+    //    fprintf(stderr, DEPMASK2,"LZMPi/MartinPiper","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MASCHK:
+    //    fprintf(stderr, DEPMASK,"MaschinenSprache-Kompressor",Unp->DepAdr);
+    //    break;
+  case _I_MASTCOMP:
+    sprintf(appstr, "%s%s", "Master", "Compressor");
+    fprintf(stderr, DEPMASK, appstr, Unp->DepAdr);
+    break;
+  case _I_MASTCRLX:
+    sprintf(appstr, "%s%s", "Master", "Compressor");
+    strcat(appstr, " /");
+    fprintf(stderr, DEPMASK2, appstr, "Relax", Unp->DepAdr);
+    break;
+  case _I_MASTCAGL:
+    sprintf(appstr, "%s%s", "Master", "Compressor");
+    strcat(appstr, " /");
+    fprintf(stderr, DEPMASK2, appstr, "Agile", Unp->DepAdr);
+    break;
+  case _I_MASTCHF:
+    sprintf(appstr, "%s%s", "Master", "Compressor");
+    strcat(appstr, " ");
+    strcat(appstr, "v3.5");
+    strcat(appstr, " /");
+    fprintf(stderr, DEPMASK2, appstr, "Channel4", Unp->DepAdr);
+    break;
+    //    case _I_MATCHARP:
+    //    sprintf(appstr,"%s%s","Char","Packer");
+    //    fprintf(stderr, DEPMASK2,"Matcham",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_MATCBASP:
+    //    sprintf(appstr,"%s%s","Basic","Packer");
+    //    fprintf(stderr, DEPMASK2,"Matcham",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_MATCDNEQ:
+    //    sprintf(appstr,"%s %s","Matcham","Denser");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Equal chars",Unp->DepAdr);
+    //    break;
+    //    case _I_MATCDN25:
+    //    sprintf(appstr,"%s %s","Matcham","Denser");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ 251",Unp->DepAdr);
+    //    break;
+    //    case _I_MATCDNFL:
+    //    sprintf(appstr,"%s %s","Matcham","Denser");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Flexible",Unp->DepAdr);
+    //    break;
+    //    case _I_MATCLNK2:
+    //    sprintf(appstr,"%s %s","Matcham","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ 251",Unp->DepAdr);
+    //    break;
+    //    case _I_MATCFLEX:
+    //    fprintf(stderr, DEPMASK2,"Matcham","Flexer",Unp->DepAdr);
+    //    break;
+    //    case _I_MCCCOMP:
+    //    fprintf(stderr, DEPMASK2,"MC-Cracken","Compressor",Unp->DepAdr);
+    //    break;
+    //    case _I_MCTSS3  :
+    //    fprintf(stderr, DEPMASK2,"TSS v3","(MC-CC hack)",Unp->DepAdr);
+    //    break;
+    //    case _I_MCTSSIP :
+    //    fprintf(stderr, DEPMASK2,"TSS v3","IsePic",Unp->DepAdr);
+    //    break;
+    //    case _I_MCUNK   :
+    //    fprintf(stderr, DEPMASK2,"Unknown","(MC-CC hack)",Unp->DepAdr);
+    //    break;
+    //    case _I_MCCRUSH3:
+    //    fprintf(stderr, DEPMASK2,"Crusher v3.0","(MC-CC hack)",Unp->DepAdr);
+    //    break;
+    //    case _I_MCCOBRA :
+    //    fprintf(stderr, DEPMASK2,"Cobra","(MC-CC hack)",Unp->DepAdr);
+    //    break;
+    //    case _I_MCCSCC  :
+    //    fprintf(stderr, DEPMASK2,"SCC","(MC-CC hack)",Unp->DepAdr);
+    //    break;
+    //    case _I_MCCRYPT :
+    //    fprintf(stderr, DEPMASK2,"MC-Cracken","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_MDGPACK:
+    //    fprintf(stderr, DEPMASK2,"MDG","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_MBCR1:
+    //    sprintf(appstr,"%s%s","Mega","Byte");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MBCR2:
+    //    sprintf(appstr,"%s%s","Mega","Byte");
+    //    strcat(appstr," ");
+    //    strcat(appstr,"Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MEGCRBD:
+    //    sprintf(appstr,"%s%s","Mega","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ BlackDuke",Unp->DepAdr);
+    //    break;
+    //    case _I_MEGCR23:
+    //    sprintf(appstr,"%s%s","Mega","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.3",Unp->DepAdr);
+    //    break;
+    //    case _I_MRCROSS1:
+    //    fprintf(stderr, DEPMASK2,"Mr.Cross","v1.x",Unp->DepAdr);
+    //    break;
+        case _I_MRCROSS2:
+        fprintf(stderr, DEPMASK2,"Mr.Cross","v2.x",Unp->DepAdr);
+        break;
+    //    case _I_MRDCR1:
+    //    sprintf(appstr,"%s %s","Marauder","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MRDCRCOD1:
+    //    sprintf(appstr,"%s %s","Marauder","Cruncher");
+    //    strcat(appstr,"&");strcat(appstr,"Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MRDLNK2:
+    //    sprintf(appstr,"%s %s","Marauder","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_GSSCO12:
+    //    sprintf(appstr,"%s %s","GSS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.2",Unp->DepAdr);
+    //    break;
+        case _I_MRZPACK:
+        fprintf(stderr, DEPMASK2,"Mr.Z","Packer",Unp->DepAdr);
+        break;
+    //    case _I_MSICR2:
+    //    sprintf(appstr,"%s %s","MSI","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MSICR3:
+    //    sprintf(appstr,"%s %s","MSI","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_MSICOD:
+    //    fprintf(stderr, DEPMASK2,"MSI","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_NECPACK:
+    //    fprintf(stderr, DEPMASK2,"NEC","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTROV1:
+    //    fprintf(stderr, DEPMASK2,"Austro-Comp","v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTROV2:
+    //    fprintf(stderr, DEPMASK2,"Austro-Comp","v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTROE1:
+    //    fprintf(stderr, DEPMASK2,"Austro-Comp","E1-J/Simons",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTRO88:
+    //    fprintf(stderr, DEPMASK2,"AustroSpeed","88",Unp->DepAdr);
+    //    break;
+    //    case _I_BLITZCOM:
+    //    fprintf(stderr, DEPMASK2,"Blitz","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTRO_U:
+    //    fprintf(stderr, DEPMASK2,"Austro/Blitz","Unknown",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTROS1:
+    //    fprintf(stderr, DEPMASK2,"AustroSpeed","v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_AUSTROBL:
+    //    fprintf(stderr, DEPMASK2,"Austro/Blitz","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_PETSPEED:
+    //    fprintf(stderr, DEPMASK2,"PetSpeed","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_BASIC64 :
+    //    fprintf(stderr, DEPMASK2,"Basic64","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_BASICBS :
+    //    fprintf(stderr, DEPMASK2,"BasicBoss","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_SPEEDCM :
+    //    fprintf(stderr, DEPMASK2,"Speed","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_SPEEDY64:
+    //    fprintf(stderr, DEPMASK2,"Speedy 64","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_CC65    :
+    //    fprintf(stderr, DEPMASK2,"CC65","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_CC6522  :
+    //    sprintf(appstr,"%s %s","CC65","v2.2");strcat(appstr,"x.xx");
+    //    fprintf(stderr, DEPMASK2,appstr,"Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_DTL64   :
+    //    fprintf(stderr, DEPMASK2,"DTL-64","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_LASERBAS:
+    //    fprintf(stderr, DEPMASK2,"LaserBasic","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_HYPRA   :
+    //    fprintf(stderr, DEPMASK2,"Hypra","Compiler",Unp->DepAdr);
+    //    break;
+    //    case _I_ISEPICLD:
+    //    fprintf(stderr, DEPMASK2,"IsePic","Loader",Unp->DepAdr);
+    //    break;
+    //    case _I_NSUPACK10:
+    //    sprintf(appstr,"%s %s","NSU","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_NSUPACK11:
+    //    sprintf(appstr,"%s %s","NSU","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_ONSPACK:
+    //    fprintf(stderr, DEPMASK2,"ONS","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_OPTIMUS:
+    //    fprintf(stderr, DEPMASK2,"Optimus","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_OPTIMH:
+    //    fprintf(stderr, DEPMASK2,"Optimus","Hack",Unp->DepAdr);
+    //    break;
+    //    case _I_OUGCOD:
+    //    fprintf(stderr, DEPMASK2,"OUG","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_P100:
+    //    fprintf(stderr, DEPMASK2,"P100","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_PAKOPT:
+    //    fprintf(stderr, DEPMASK2,"Packer","Optimizer",Unp->DepAdr);
+    //    break;
+    //    case _I_PITCOD:
+    //    fprintf(stderr, DEPMASK2,"PIT","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_POLONCB:
+    //    fprintf(stderr, DEPMASK2,"Polonus","Charblaster",Unp->DepAdr);
+    //    break;
+    //    case _I_POLONKR:
+    //    sprintf(appstr,"%s %s","Krejzi","Packer");
+    //    fprintf(stderr, DEPMASK2,"Polonus",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_POLONAM:
+    //    sprintf(appstr,"%s %s","C64/+4/Amiga","Packer");
+    //    fprintf(stderr, DEPMASK2,"Polonus",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_POLONEQ:
+    //    fprintf(stderr, DEPMASK2,"Polonus","/ Equal chars",Unp->DepAdr);
+    //    break;
+    //    case _I_POLON4P:
+    //    sprintf(appstr,"%s %s","$45c","Packer");
+    //    fprintf(stderr, DEPMASK2,"Polonus",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_POLON101:
+    //    sprintf(appstr,"%s %s","$101","Packer");
+    //    fprintf(stderr, DEPMASK2,"Polonus",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_QRTPROT:
+    //    fprintf(stderr, DEPMASK2,"Quartet","Protector",Unp->DepAdr);
+    //    break;
+  case _I_PUCRUNCH:
+    fprintf(stderr, DEPMASK, "PUCrunch", Unp->DepAdr);
+    break;
+  case _I_PUCRUNCW:
+    fprintf(stderr, DEPMASK2, "PUCrunch", "/ wrap", Unp->DepAdr);
+    break;
+  case _I_PUCRUNCS:
+    fprintf(stderr, DEPMASK2, "PUCrunch", "/ short", Unp->DepAdr);
+    break;
+  case _I_PUCRUNCO:
+    fprintf(stderr, DEPMASK2, "PUCrunch", "/ old?", Unp->DepAdr);
+    break;
+  case _I_PUCRUNCG:
+    fprintf(stderr, DEPMASK2, "PUCrunch", "Generic Hack", Unp->DepAdr);
+    break;
+    //    case _I_PZWCOM:
+    //    fprintf(stderr, DEPMASK2,"PZW","Compactor",Unp->DepAdr);
+    //    break;
+    //    case _I_RAPEQC:
+    //    fprintf(stderr, DEPMASK2,"Rap","/ Equal chars",Unp->DepAdr);
+    //    break;
+  case _I_RLX3B:
+    fprintf(stderr, DEPMASK2, "Relax", "3-byter", Unp->DepAdr);
+    break;
+  case _I_RLXP2:
+    sprintf(appstr, "%s %s", "Relax", "Packer");
+    fprintf(stderr, DEPMASK2, appstr, "v2.x", Unp->DepAdr);
+    break;
+    //    case _I_SCRCR4:
+    //    sprintf(appstr,"%s / %s","ScreenCrunch","2064");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SCRCR6:
+    //    sprintf(appstr,"%s / %s","ScreenCrunch","2066");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SCRCRFCG:
+    //    sprintf(appstr,"%s / %s","ScreenCrunch","FCG");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+  case _I_S8PACK:
+    fprintf(stderr, DEPMASK2, "Section8", "Packer", Unp->DepAdr);
+    break;
+    //    case _I_CRMPACK:
+    //    fprintf(stderr, DEPMASK2,"CRM","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_SHRPACK:
+    //    fprintf(stderr, DEPMASK2,"Shurigen","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_SIRMPACK:
+    //    strcpy(appstr,"Mini");strcat(appstr,"Packer");
+    //    fprintf(stderr, DEPMASK2,"SIR",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SIRMLINK:
+    //    strcpy(appstr,"Master");strcat(appstr,"Linker");
+    //    fprintf(stderr, DEPMASK2,"SIR",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SIRCOMBIN1:
+    //    sprintf(appstr,"%s %s","SIR","Combine");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_SIRCOMBIN2:
+    //    sprintf(appstr,"%s %s","SIR","Combine");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_SIRCOMBIN3:
+    //    sprintf(appstr,"%s %s","SIR","Combine");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_SKLCOD:
+    //    fprintf(stderr, DEPMASK2,"Skylight","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE10:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE11:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE12:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v1.2",Unp->DepAdr);
+    //    break;
+    //    case _I_KREATOR:
+    //    strcpy(appstr,"v1.0");
+    //    strcat(appstr,"/");
+    //    strcat(appstr,"Kreator");
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE20:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE21:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE23:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v2.3",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE24:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v2.4",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE2C:
+    //    strcpy(appstr,"v2.2");
+    //    strcat(appstr,"/");
+    //    strcat(appstr,"CCS");
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGETRAP:
+    //    strcpy(appstr,"v2.x");
+    //    strcat(appstr,"/");
+    //    strcat(appstr,"Trap");
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE22:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v2.2",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE30:
+    //    fprintf(stderr, DEPMASK2,"SledgeHammer","v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_ULTIM8SH:
+    //    fprintf(stderr, DEPMASK2,"Ultimate","SledgeHammer",Unp->DepAdr);
+    //    break;
+    //    case _I_SLEDGE1DP:
+    //    sprintf(appstr,"%s %s","Packer","v2");
+    //    fprintf(stderr, DEPMASK2,"Dreamr",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_MWSPCOMP:
+    //    sprintf(appstr,"%s%s","Speedi","Compactor");
+    //    fprintf(stderr, DEPMASK2,"Winterberg",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_MWPACK:
+    //    fprintf(stderr, DEPMASK2,"Winterberg","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_MWSPCR1:
+    //    sprintf(appstr,"%s%s","Speedi","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"MW1",Unp->DepAdr);
+    //    break;
+    //    case _I_MWSPCR2:
+    //    sprintf(appstr,"%s%s","Speedi","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"MW2",Unp->DepAdr);
+    //    break;
+    //    case _I_SUPCRUNCH:
+    //    sprintf(appstr,"%s%s","Super","Cruncher");appstr[strlen(appstr)-2]=0;
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+  case _I_TBCMULTI:
+    fprintf(stderr, DEPMASK, "TBC Multicompactor", Unp->DepAdr);
+    break;
+  case _I_TBCMULT2:
+    fprintf(stderr, DEPMASK2, "TBC Multicompactor", "v2.x", Unp->DepAdr);
+    break;
+  case _I_TBCMULTMOW:
+    sprintf(appstr, "%s / %s", "AutoBreakSystem", "Manowar");
+    fprintf(stderr, DEPMASK2, "TBC Multicompactor", appstr, Unp->DepAdr);
+    break;
+    //    case _I_TCDLC1:
+    //    fprintf(stderr, DEPMASK2,"TCD Link&Crunch","v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TCDLC2:
+    //    fprintf(stderr, DEPMASK2,"TCD Link&Crunch","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TCSCR2:
+    //    sprintf(appstr,"%s %s","TCS","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TCSCR3:
+    //    sprintf(appstr,"%s %s","TCS","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TC40   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v4.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TC42H  :
+    //    sprintf(appstr,"%s / %s","v4.2","header");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC40HIL:
+    //    sprintf(appstr,"%s / %s","v4.2","header");
+    //    strcat(appstr," ");strcat(appstr,"ILS");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TCHVIK:
+    //    sprintf(appstr,"%s %s","Vikings","header");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC42   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v4.2",Unp->DepAdr);
+    //    break;
+    //    case _I_TC43   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v4.3",Unp->DepAdr);
+    //    break;
+    //    case _I_TC44   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v4.4",Unp->DepAdr);
+    //    break;
+    //    case _I_TC50   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v5.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TC51   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v5.1",Unp->DepAdr);
+    //    break;
+    //    case _I_TC52   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v5.2",Unp->DepAdr);
+    //    break;
+    //    case _I_TC53   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v5.3",Unp->DepAdr);
+    //    break;
+    //    case _I_TC5GEN:
+    //    sprintf(appstr,"%s / %s","v5.x","Generic Hack");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC30   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TC31   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v3.1",Unp->DepAdr);
+    //    break;
+    //    case _I_TC33   :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","v3.3",Unp->DepAdr);
+    //    break;
+    //    case _I_TC2MHZ1:
+    //    sprintf(appstr,"%s %s","2MHZ","v1.0");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC2MHZ2:
+    //    sprintf(appstr,"%s %s","2MHZ","v2.0");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC32061:
+    //    sprintf(appstr,"%s / %s","v3.x","2061");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TCMC4  :
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher","/
+    //    MegaCrunch 4.0",Unp->DepAdr); break; case _I_TC3RWE :
+    //    sprintf(appstr,"%s / %s","v3.x","RWE");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC32072:
+    //    sprintf(appstr,"%s / %s","v3.x","2072");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3RAD :
+    //    sprintf(appstr,"%s / %s","v3.x","Radical");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC32074:
+    //    sprintf(appstr,"%s / %s","v3.x","2074");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3FPE :
+    //    sprintf(appstr,"%s / %s","v3.x","Fast Pack'Em ");
+    //    strcat(appstr,"v2.1");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3FBI :
+    //    sprintf(appstr,"%s / %s","v3.x","FBI");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3TRI :
+    //    sprintf(appstr,"%s / %s","v3.x","Triumwyrat");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3HTL :
+    //    sprintf(appstr,"%s / %s","v3.x","HTL");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3ENT :
+    //    sprintf(appstr,"%s / %s","v3.x","Entropy");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TCGENH :
+    //    sprintf(appstr,"%s / %s","Time Cruncher","Generic Hack");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TCFPEX :
+    //    fprintf(stderr, DEPMASK,"File Press Expert",Unp->DepAdr);
+    //    break;
+    //    case _I_TCSIR1 :
+    //    fprintf(stderr, DEPMASK2,"SIR Compact","v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TCUNKH :
+    //    fprintf(stderr, DEPMASK2,"Unknown","TC hack",Unp->DepAdr);
+    //    break;
+    //    case _I_TCSIR4 :
+    //    fprintf(stderr, DEPMASK2,"SIR Compact","v4.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TCSIR3 :
+    //    fprintf(stderr, DEPMASK2,"SIR Compact","v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TCSIR2 :
+    //    fprintf(stderr, DEPMASK2,"SIR Compact","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TC5SC  :
+    //    sprintf(appstr,"%s / %s","v5.x","SupraCompactor");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3RLX :
+    //    sprintf(appstr,"%s / %s","v3.x","Relax");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC33AD :
+    //    sprintf(appstr,"%s / %s","v3.x","Triad");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3PC :
+    //    sprintf(appstr,"%s / %s","v3.x","PC");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC423AD:
+    //    sprintf(appstr,"%s / %s","v4.2","Triad");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC42GEN:
+    //    sprintf(appstr,"%s / %s","v4.2","Generic Hack");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3TDF :
+    //    sprintf(appstr,"%s / %s","v3.x","TDF");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3ATC :
+    //    sprintf(appstr,"%s / %s","v3.x","ATC");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3F4CG:
+    //    sprintf(appstr,"%s / %s","v3.x","F4CG");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3HSCG:
+    //    sprintf(appstr,"%s / %s","v3.x","HSCG");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3HSFE:
+    //    sprintf(appstr,"%s / %s","v3.x","HSCG");strcat(appstr,"+FE");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3TTN :
+    //    sprintf(appstr,"%s / %s","v3.x","Triton");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3MULE:
+    //    sprintf(appstr,"%s / %s","v3.x","Mule");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3AGILE:
+    //    sprintf(appstr,"%s / %s","v3.x","Agile");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3S451:
+    //    sprintf(appstr,"%s / %s","v3.1","S451");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3S451V2:
+    //    sprintf(appstr,"%s / %s","v3.2","S451");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3IKARI:
+    //    sprintf(appstr,"%s / %s","v3.x","Ikari");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TC3U   :
+    //    sprintf(appstr,"%s / %s","v3.x","Unknown");
+    //    fprintf(stderr, DEPMASK2,"Time Cruncher",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TMCCOD :
+    //    fprintf(stderr, DEPMASK2,"TMC","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_TMMPACK:
+    //    fprintf(stderr, DEPMASK2,"TMM","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TRASHC1:
+    //    fprintf(stderr, DEPMASK2,"Trashcan","v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TRASHC2:
+    //    fprintf(stderr, DEPMASK2,"Trashcan","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TRASHCU:
+    //    fprintf(stderr, DEPMASK2,"Trashcan","Unknown",Unp->DepAdr);
+    //    break;
+    //    case _I_TRIANP:
+    //    fprintf(stderr, DEPMASK2,"Trianon","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TRIAN2:
+    //    fprintf(stderr, DEPMASK2,"Trianon","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TRIAN3:
+    //    fprintf(stderr, DEPMASK2,"Trianon","v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TRIANC:
+    //    fprintf(stderr, DEPMASK2,"Trianon","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_TSBP1:
+    //    sprintf(appstr,"%s %s","TSB","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TSBP21:
+    //    sprintf(appstr,"%s %s","TSB","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.1",Unp->DepAdr);
+    //    break;
+    //    case _I_TSBP3:
+    //    sprintf(appstr,"%s %s","TSB","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TSMCOD:
+    //    fprintf(stderr, DEPMASK2,"TSM","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_TSMPACK:
+    //    fprintf(stderr, DEPMASK2,"TSM","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TURBOP:
+    //    fprintf(stderr, DEPMASK2,"Turbo","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_ULTRAC3:
+    //    fprintf(stderr, DEPMASK2,"UltraComp","v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_UNIPACK1:
+    //    sprintf(appstr,"%s%s","Uni","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_UNIPACK2:
+    //    sprintf(appstr,"%s%s","Uni","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_UNIPACK3:
+    //    sprintf(appstr,"%s%s","Uni","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_U_100_P2:
+    //    sprintf(appstr,"%s %s","$100","Packer");
+    //    strcat(appstr," ");strcat(appstr,"v2.x");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_100_P3:
+    //    sprintf(appstr,"%s %s","$100","Packer");
+    //    strcat(appstr," ");strcat(appstr,"v3.x");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_100_P4:
+    //    sprintf(appstr,"%s %s","$100","Packer");
+    //    strcat(appstr," ");strcat(appstr,"v4.x");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_100_P5:
+    //    sprintf(appstr,"%s %s","$100","Packer");
+    //    strcat(appstr," ");strcat(appstr,"v5.x");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_101:
+    //    sprintf(appstr,"%s %s","$101","Packer");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_111:
+    //    sprintf(appstr,"%s %s","$111","Packer");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ROWS:
+    //    fprintf(stderr, DEPMASK2,"Rows","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_FALCOP:
+    //    fprintf(stderr, DEPMASK2,"Falco Paul","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_PSQLINK1:
+    //    sprintf(appstr,"%s %s","PSQ","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.1",Unp->DepAdr);
+    //    break;
+    //    case _I_U_439:
+    //    sprintf(appstr,"%s %s","$439","Packer");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ENTROPYPK:
+    //    fprintf(stderr, DEPMASK2,"Entropy","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_U_8E:
+    //    sprintf(appstr,"%s %s","$8e","Packer");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_25:
+    //    sprintf(appstr,"%s %s","$25","Packer");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_DSCTITMK:
+    //    fprintf(stderr, DEPMASK2,"DSCompware","Super-TitleMaker",Unp->DepAdr);
+    //    break;
+    //    case _I_DSCCR:
+    //    fprintf(stderr, DEPMASK2,"DSCompware","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_DSCPK:
+    //    fprintf(stderr, DEPMASK2,"DSCompware","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_DSCPK2:
+    //    sprintf(appstr,"%s %s","DSCompware","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_KRESS:
+    //    fprintf(stderr, DEPMASK2,"Kress","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_U_1WF2:
+    //    sprintf(appstr,"%s %s","$f2","Packer");
+    //    fprintf(stderr, DEPMASK2,"Oneway",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_U_1WDA:
+    //    sprintf(appstr,"%s %s","$da","Packer");
+    //    fprintf(stderr, DEPMASK2,"Oneway",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_GENSYSL:
+    //    fprintf(stderr, "Generic SYS-less %s $%04x\n","Packer",Unp->Forced);
+    //    break;
+    //    case _I_U_P3:
+    //    fprintf(stderr, DEPMASK2,"Unknown","P3",Unp->DepAdr);
+    //    break;
+    //    case _I_U_3ADCR:
+    //    sprintf(appstr,"%s %s","Unknown","Triad");
+    //    fprintf(stderr, DEPMASK2,appstr,"Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_VIP1X:
+    //    fprintf(stderr, DEPMASK2,"VIP","v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_VIP20:
+    //    fprintf(stderr, DEPMASK2,"VIP","v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TOTP1X:
+    //    sprintf(appstr,"%s %s","Total","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_TOTP20:
+    //    sprintf(appstr,"%s %s","Total","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_VIP3X:
+    //    fprintf(stderr, DEPMASK2,"VIP","v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_HIT02:
+    //    sprintf(appstr,"%s %s","HitMen","$02");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_HIT20:
+    //    sprintf(appstr,"%s %s","HitMen","$20");
+    //    fprintf(stderr, DEPMASK2,appstr,"Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_AGNUS02:
+    //    sprintf(appstr,"%s %s","Agnus","$02");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_BUK02:
+    //    sprintf(appstr,"%s %s","Buraki","$02");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_WARLOCK:
+    //    fprintf(stderr, DEPMASK2,"Warlock","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_WCCMC:
+    //    fprintf(stderr, DEPMASK2,"WCC","Modem Converter",Unp->DepAdr);
+    //    break;
+    //    case _I_WDRPROT:
+    //    sprintf(appstr,"%s %s","Soft","Protector");
+    //    fprintf(stderr, DEPMASK2,"WDR",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_WDRLAMEK:
+    //    sprintf(appstr,"%s %s","Lamer","Killer");
+    //    fprintf(stderr, DEPMASK2,"WDR",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_WGICOD:
+    //    fprintf(stderr, DEPMASK2,"WGI","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_3CZIP:
+    //    fprintf(stderr, DEPMASK2,"3Code","Zipper",Unp->DepAdr);
+    //    break;
+    //    case _I_4CZIP:
+    //    sprintf(appstr,"%s %s","Zipper","v2.0");
+    //    fprintf(stderr, DEPMASK2,"4Code",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_4CZIP2S:
+    //    sprintf(appstr,"%s %s","Zipper","v2.S");
+    //    fprintf(stderr, DEPMASK2,"4Code",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_XTERM:
+    //    sprintf(appstr,"%s %s","X-Terminator","v2.0");strcat(appstr," /");
+    //    fprintf(stderr, DEPMASK2,appstr,"FLT",Unp->DepAdr);
+    //    break;
+    //    case _I_ILSCOMP3X:
+    //    sprintf(appstr,"%s %s","ILS","Compacker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.x",Unp->DepAdr);
+    //    break;
+    //    case _I_ILSCOMP2X:
+    //    sprintf(appstr,"%s %s","ILS","Compacker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_3CZIP2:
+    //    sprintf(appstr,"%s %s","Zipper","v2.0");
+    //    fprintf(stderr, DEPMASK2,"3Code",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_XDSV1:
+    //    sprintf(appstr,"%s %s","XDS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_XDSV2:
+    //    sprintf(appstr,"%s %s","XDS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_XDSV3:
+    //    sprintf(appstr,"%s %s","XDS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_XDSK1:
+    //    sprintf(appstr,"%s %s","XDS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"K1",Unp->DepAdr);
+    //    break;break;
+    //    case _I_XDSK2:
+    //    sprintf(appstr,"%s %s","XDS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"K2",Unp->DepAdr);
+    //    break;
+    //    case _I_XDSK3:
+    //    sprintf(appstr,"%s %s","XDS","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"K3",Unp->DepAdr);
+    //    break;
+    //    case _I_XIP:
+    //    fprintf(stderr, DEPMASK,"XIP",Unp->DepAdr);
+    //    break;
+        case _I_XTC10:
+        sprintf(appstr,"%s %s","XTC","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+        break;
+        case _I_XTC21:
+        sprintf(appstr,"%s %s","XTC","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v2.1",Unp->DepAdr);
+        break;
+        case _I_XTC22:
+        sprintf(appstr,"%s %s","XTC","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v2.2",Unp->DepAdr);
+        break;
+        case _I_XTC23:
+        sprintf(appstr,"%s %s","XTC","Packer");
+        fprintf(stderr, DEPMASK2,appstr,"v2.3",Unp->DepAdr);
+        break;
+        case _I_XTC23GP:
+        sprintf(appstr,"%s %s","XTC","Packer");
+        strcat(appstr," ");
+        strcat(appstr,"v2.3");
+        strcat(appstr," /");
+        fprintf(stderr, DEPMASK2,appstr,"G*P",Unp->DepAdr);
+        break;
+        case _I_XTC2XGP:
+        sprintf(appstr,"%s %s","XTC","Packer");
+        strcat(appstr," ");
+        strcat(appstr,"v2.x");
+        strcat(appstr," /");
+        fprintf(stderr, DEPMASK2,appstr,"G*P",Unp->DepAdr);
+        break;
+    //    case _I_ZIGAG:
+    //    fprintf(stderr, DEPMASK2,"Zigag","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP50C:
+    //    sprintf(appstr,"%s%s","v5.0","/Chromizer");
+    //    fprintf(stderr, DEPMASK2,"Zipper",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP50H:
+    //    sprintf(appstr,"%s %s","v5.0","Hack");
+    //    fprintf(stderr, DEPMASK2,"Zipper",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP511:
+    //    sprintf(appstr,"%s%s","v5.1","/1");
+    //    fprintf(stderr, DEPMASK2,"Zipper",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP512:
+    //    sprintf(appstr,"%s%s","v5.1","/2");
+    //    fprintf(stderr, DEPMASK2,"Zipper",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP513:
+    //    sprintf(appstr,"%s%s","v5.1","/3");
+    //    fprintf(stderr, DEPMASK2,"Zipper",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP51XEN:
+    //    sprintf(appstr,"%s%s","v5.1","/Xenon");
+    //    fprintf(stderr, DEPMASK2,"Zipper",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP3:
+    //    fprintf(stderr, DEPMASK2,"Zipper","v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_ZIP8:
+    //    fprintf(stderr, DEPMASK2,"Zipper","v8.x",Unp->DepAdr);
+    //    break;
+    //    case _I_STLPROT:
+    //    fprintf(stderr, DEPMASK2,"STL","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_GRFBIN:
+    //    fprintf(stderr, DEPMASK2,"GrafBinaer","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_ABYSSCOD1:
+    //    sprintf(appstr,"%s %s","Abyss","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_ABYSSCOD2:
+    //    sprintf(appstr,"%s %s","Abyss","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_SPCCOD:
+    //    fprintf(stderr, DEPMASK2,"SPC","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_SPCPROT:
+    //    fprintf(stderr, DEPMASK2,"SPC","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_COBRACOD:
+    //    fprintf(stderr, DEPMASK2,"Cobra","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_FSWPACK1:
+    //    sprintf(appstr,"%s %s","FSW","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_FSWPACK2:
+    //    sprintf(appstr,"%s %s","FSW","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_FSWPACK3:
+    //    sprintf(appstr,"%s %s","FSW","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_FSWPROT:
+    //    fprintf(stderr, DEPMASK2,"FSW","Protector",Unp->DepAdr);
+    //    break;
+    //    case _I_BAMCOD1:
+    //    fprintf(stderr, DEPMASK2,"BAM","Compacker",Unp->DepAdr);
+    //    break;
+    //    case _I_BAMCOD2:
+    //    sprintf(appstr,"%s %s","BAM","Reductor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.3",Unp->DepAdr);
+    //    break;
+    //    case _I_BAMCOD3:
+    //    sprintf(appstr,"%s %s","BAM","Reductor");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_BYTEBUST4L:
+    //    sprintf(appstr,"%s%s","Byte","Buster");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ Low",Unp->DepAdr);
+    //    break;
+    //    case _I_BYTEBUST4H:
+    //    sprintf(appstr,"%s%s","Byte","Buster");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ High",Unp->DepAdr);
+    //    break;
+    //    case _I_MEKKER:
+    //    fprintf(stderr, DEPMASK,"Mekker",Unp->DepAdr);
+    //    break;
+    //    case _I_BYTESTRN:
+    //    sprintf(appstr,"%s%s","Byte","Strainer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_JEDILINK1:
+    //    sprintf(appstr,"%s %s","Jedi","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_JEDILINK2:
+    //    sprintf(appstr,"%s %s","Jedi","Linker");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_JEDIPACK:
+    //    fprintf(stderr, DEPMASK2,"Jedi","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_PRIDE:
+    //    fprintf(stderr, DEPMASK2,"Pride","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_STARCRUNCH:
+    //    fprintf(stderr, DEPMASK,"StarCrunch",Unp->DepAdr);
+    //    break;
+    //    case _I_SPYPACK:
+    //    fprintf(stderr, DEPMASK2,"Spy","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_PETPACK:
+    //    fprintf(stderr, DEPMASK2,"PET","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_CADAVERPACK:
+    //    fprintf(stderr, DEPMASK2,"Cadaver","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_HELMET2:
+    //    fprintf(stderr, DEPMASK2,"Helmet","v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_ANTIRAM1:
+    //    sprintf(appstr,"%s %s","Antiram","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_ANTIRAM2:
+    //    sprintf(appstr,"%s %s","Antiram","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_ANTICOM:
+    //    fprintf(stderr, DEPMASK2,"Anticom","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_GCSAUTO:
+    //    fprintf(stderr, DEPMASK2,"GCS","Autostarter",Unp->DepAdr);
+    //    break;
+    //    case _I_AUTOFLG:
+    //    fprintf(stderr, DEPMASK2,"AFLG/M.Pall","Autostarter",Unp->DepAdr);
+    //    break;
+    //    case _I_EXCPACK:
+    //    fprintf(stderr, DEPMASK2,"Excalibur 666","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_EXCCOD:
+    //    fprintf(stderr, DEPMASK2,"Excalibur 666","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_CNCD:
+    //    sprintf(appstr,"%s %s","CNCD","Classic");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_4WD:
+    //    fprintf(stderr, DEPMASK2,"4WD-Soft","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_1WMKL2:
+    //    sprintf(appstr,"%s %s","Oneway","Makt-Link");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_EMUFUX1:
+    //    sprintf(appstr,"%s %s","Plush","Emu-Fuxx0r");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_EMUFUX2:
+    //    sprintf(appstr,"%s %s","Plush","Emu-Fuxx0r");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_HUFFER:
+    //    sprintf(appstr,"%s / %s","v1.0","FLT");
+    //    fprintf(stderr, DEPMASK2,"Huffer",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_HUFFERQC:
+    //    sprintf(appstr,"%s / %s","v1.1","Quick");strcat(appstr,"Cruncher");
+    //    fprintf(stderr, DEPMASK2,"Huffer",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_NM156PACK:
+    //    fprintf(stderr, DEPMASK2,"NM156","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_NM156LINK:
+    //    fprintf(stderr, DEPMASK2,"NM156","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_RATTPACK:
+    //    fprintf(stderr, DEPMASK2,"Ratt","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_RATTLINK:
+    //    fprintf(stderr, DEPMASK2,"Ratt","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_BYTERAPERS1:
+    //    sprintf(appstr,"%s %s","Byterapers","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BYTERAPERS2:
+    //    sprintf(appstr,"%s %s","Byterapers","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_CIACRP:
+    //    sprintf(appstr,"%s %s","CIA","Crypt");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_PANPACK:
+    //    sprintf(appstr,"%s %s","PAN","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_PANPACK2:
+    //    sprintf(appstr,"%s %s","PAN","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TKCEQB1:
+    //    sprintf(appstr,"%s %s","TKC","Bytepress");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TKCEQB2:
+    //    sprintf(appstr,"%s %s","TKC","Bytepress");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_UPROT420:
+    //    sprintf(appstr,"%s %s","$420","Coder");
+    //    fprintf(stderr, DEPMASK2,"Unknown",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_HIVIRUS:
+    //    fprintf(stderr, DEPMASK2,"HIV","Virus",Unp->DepAdr);
+    //    break;
+    //    case _I_BHPVIRUS:
+    //    fprintf(stderr, DEPMASK2,"BHP","Virus",Unp->DepAdr);
+    //    break;
+    //    case _I_BULAVIRUS:
+    //    fprintf(stderr, DEPMASK2,"Bula","Virus",Unp->DepAdr);
+    //    break;
+    //    case _I_CODERVIRUS:
+    //    fprintf(stderr, DEPMASK2,"Coder","Virus",Unp->DepAdr);
+    //    break;
+    //    case _I_BOAVIRUS:
+    //    fprintf(stderr, DEPMASK2,"Boa","Virus",Unp->DepAdr);
+    //    break;
+    //    case _I_PLUSHZ:
+    //    sprintf(appstr,"%s %s","Plush","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ fast",Unp->DepAdr);
+    //    break;
+    //    case _I_PLUSHZS:
+    //    sprintf(appstr,"%s %s","Plush","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"/ short",Unp->DepAdr);
+    //    break;
+    //    case _I_REBELP:
+    //    fprintf(stderr, DEPMASK2,"Rebels","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_YETICOD:
+    //    fprintf(stderr, DEPMASK2,"Yeti","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_ZEROCOD:
+    //    fprintf(stderr, DEPMASK2,"Zero","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_CHGPROT2:
+    //    sprintf(appstr,"%s %s","Change","Protector");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_PDPACK1:
+    //    sprintf(appstr,"%s %s","Panoramic","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_PDPACK2:
+    //    sprintf(appstr,"%s %s","Panoramic","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.0",Unp->DepAdr);
+    //    break;
+    //    case _I_PDPACK30:
+    //    sprintf(appstr,"%s %s","Panoramic","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.0",Unp->DepAdr);
+    //    break;
+    //    case _I_PDPACK31:
+    //    sprintf(appstr,"%s %s","Panoramic","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.1",Unp->DepAdr);
+    //    break;
+    //    case _I_PDPACK32:
+    //    sprintf(appstr,"%s %s","Panoramic","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v3.2",Unp->DepAdr);
+    //    break;
+    //    case _I_PDEQLZ15:
+    //    sprintf(appstr,"%s %s","Panoramic","Equalizer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.5",Unp->DepAdr);
+    //    break;
+    //    case _I_SUPERPACK4:
+    //    sprintf(appstr,"%s%s","Super","Packer");appstr[strlen(appstr)-2]=0;
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_THSCOD:
+    //    sprintf(appstr,"%s%s","Bit","Coder");
+    //    fprintf(stderr, DEPMASK2,"THS",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_PWCOPSH:
+    //    sprintf(appstr,"%s %s","Password","Protector");strcat(appstr,":");
+    //    fprintf(stderr, DEPMASK2,appstr,"Cop Shocker",Unp->DepAdr);
+    //    break;
+    //    case _I_PWTIMEC:
+    //    sprintf(appstr,"%s %s","Password","Protector");strcat(appstr,":");
+    //    fprintf(stderr, DEPMASK2,appstr,"Time Coder/Trap",Unp->DepAdr);
+    //    break;
+    //    case _I_PWSNACKY:
+    //    sprintf(appstr,"%s %s","Password","Protector");strcat(appstr,":");
+    //    fprintf(stderr, DEPMASK2,appstr,"Snacky",Unp->DepAdr);
+    //    break;
+    //    case _I_PWTCD:
+    //    sprintf(appstr,"%s %s","Password","Protector");strcat(appstr,":");
+    //    fprintf(stderr, DEPMASK2,appstr,"TCD",Unp->DepAdr);
+    //    break;
+    //    case _I_PWJCH:
+    //    sprintf(appstr,"%s %s","Password","Protector");strcat(appstr,":");
+    //    fprintf(stderr, DEPMASK2,appstr,"J-Coder v1.0/JCH",Unp->DepAdr);
+    //    break;
+    //    case _I_PWFILEPR:
+    //    sprintf(appstr,"%s %s","Password","Protector");strcat(appstr,":");
+    //    fprintf(stderr, DEPMASK2,appstr,"FileProtect
+    //    v1.0/Syncro",Unp->DepAdr); break; case _I_PWFLT: sprintf(appstr,"%s
+    //    %s","Password","Protector");strcat(appstr,":"); fprintf(stderr,
+    //    DEPMASK2,appstr,"Lamer-Protection/FLT",Unp->DepAdr); break; case
+    //    _I_WHO: fprintf(stderr, DEPMASK2,"WHO","Coder",Unp->DepAdr); break;
+    //    case _I_PYRACOD1:
+    //    sprintf(appstr,"%s %s","Pyra","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_PYRACOD2:
+    //    sprintf(appstr,"%s %s","Pyra","Coder");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_BFPACK:
+    //    fprintf(stderr, DEPMASK2,"BeyondForce","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_THUNCATSPK:
+    //    fprintf(stderr, DEPMASK2,"ThunderCats","Packer",Unp->DepAdr);
+    //    break;
+  case _I_ACTIONP:
+    fprintf(stderr, DEPMASK2, "Action", "Packer", Unp->DepAdr);
+    break;
+    //    case _I_KGBCOD:
+    //    fprintf(stderr, DEPMASK2,"KGB","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_CCRYPT:
+    //    fprintf(stderr, DEPMASK2,"C+C","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_TDT:
+    //    fprintf(stderr, DEPMASK2,"DreamTeam","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TDTPETC1:
+    //    sprintf(appstr,"%s %s","PET","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TDTPETC2:
+    //    sprintf(appstr,"%s %s","PET","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_TDTPETCU:
+    //    sprintf(appstr,"%s %s","PET","Cruncher");
+    //    fprintf(stderr, DEPMASK2,appstr,"Unknown",Unp->DepAdr);
+    //    break;
+    //    case _I_TDTPETL:
+    //    fprintf(stderr, DEPMASK2,"PET","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_CULT:
+    //    fprintf(stderr, DEPMASK2,"Cult","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_GIMZO:
+    //    fprintf(stderr, DEPMASK2,"Gimzo","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_BETASKIP:
+    //    fprintf(stderr, DEPMASK2,"BetasSkip","Autostarter",Unp->DepAdr);
+    //    break;
+    //    case _I_BLACKADDER:
+    //    fprintf(stderr, DEPMASK2,"BlackAdder","header",Unp->DepAdr);
+    //    break;
+    //    case _I_ICS8:
+    //    fprintf(stderr, DEPMASK2,"ICS Drive 8","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_PARADROID1:
+    //    sprintf(appstr,"%s %s","Paradroid","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.x",Unp->DepAdr);
+    //    break;
+    //    case _I_PARADROID2:
+    //    sprintf(appstr,"%s %s","Paradroid","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v2.x",Unp->DepAdr);
+    //    break;
+    //    case _I_PARADROIDL:
+    //    fprintf(stderr, DEPMASK2,"Paradroid","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_PLASMACOD:
+    //    fprintf(stderr, DEPMASK2,"Plasma","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_EXACTCOD:
+    //    fprintf(stderr, DEPMASK2,"Exact","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_DRZOOM:
+    //    sprintf(appstr,"%s %s","Dr Zoom","Packer");
+    //    fprintf(stderr, DEPMASK2,appstr,"v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_TIMCR:
+    //    strcpy(appstr,"Cruncher");appstr[6]=0;
+    //    fprintf(stderr, DEPMASK2,"Tim",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_CNETFIX:
+    //    fprintf(stderr, DEPMASK2,"CNET Fixer","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_TRIANGLECOD:
+    //    fprintf(stderr, DEPMASK2,"Triangle","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_SFLINK:
+    //    fprintf(stderr, DEPMASK2,"Super File","Linker",Unp->DepAdr);
+    //    break;
+    //    case _I_BONGO:
+    //    fprintf(stderr, DEPMASK2,"Bongo","Cruncher",Unp->DepAdr);
+    //    break;
+    //    case _I_JEMABASIC:
+    //    sprintf(appstr,"%s %s","Jemasoft","Basic");
+    //    fprintf(stderr, DEPMASK2,appstr,"Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_TATCOD:
+    //    fprintf(stderr, DEPMASK2,"TAT","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_RFOCOD:
+    //    fprintf(stderr, DEPMASK2,"RFO","Coder",Unp->DepAdr);
+    //    break;
+    //    case _I_DOYNAMITE:
+    //    fprintf(stderr, DEPMASK2,"Doynamite","v1.1",Unp->DepAdr);
+    //    break;
+    //    case _I_BITNAX:
+    //    fprintf(stderr, DEPMASK2,"Doynamite/Bitnax","v1.0",Unp->DepAdr);
+    //    break;
+    //    case _I_NIBBIT:
+    //    fprintf(stderr, DEPMASK,"Nibb-it",Unp->DepAdr);
+    //    break;
+    //    case _I_UAPACK:
+    //    fprintf(stderr, DEPMASK2,"UA","Packer",Unp->DepAdr);
+    //    break;
+    //    case _I_ADP4KBAR:
+    //    fprintf(stderr, DEPMASK,"Admiral P4Kbar/Ferris",Unp->DepAdr);
+    //    break;
+    //    case _I_NUCRUNCH:
+    //    sprintf(appstr,"%s%s/%s","Nu","Crunch","ChristopherJam");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TINYCRUN09:
+    //    sprintf(appstr,"%s%s %s/%s","Tiny","Crunch","v0.9","ChristopherJam");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_TINYCRUNCH:
+    //    sprintf(appstr,"%s%s %s/%s","Tiny","Crunch","v1.0","ChristopherJam");
+    //    fprintf(stderr, DEPMASK,appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_FLINKSDA:
+    //    sprintf(appstr,"%s / %s","Linker","Agony");
+    //    fprintf(stderr, DEPMASK2,"File",appstr,Unp->DepAdr);
+    //    break;
+    //    case _I_INCERIAPK:
+    //    fprintf(stderr, DEPMASK2,"Inceria","Packer",Unp->DepAdr);
+    //    break;
+  }
+}

--- a/terps/unp64/unp64.c
+++ b/terps/unp64/unp64.c
@@ -1,0 +1,1066 @@
+// This is a cut-down version of UNP64 with only the bare minimum
+// needed to decompress a number of Scott Adams Commodore 64 games
+// for the ScottFree interpreter.
+
+/*
+UNP64 - generic Commodore 64 prg unpacker
+(C) 2008-2019 iAN CooG/HVSC Crew^C64Intros
+original source and idea: testrun.c, taken from exo20b7
+
+Follows original disclaimer
+*/
+
+/*
+ * Copyright (c) 2002 - 2008 Magnus Lind.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software, alter it and re-
+ * distribute it freely for any non-commercial, non-profit purpose subject to
+ * the following restrictions:
+ *
+ *   1. The origin of this software must not be misrepresented; you must not
+ *   claim that you wrote the original software. If you use this software in a
+ *   product, an acknowledgment in the product documentation would be
+ *   appreciated but is not required.
+ *
+ *   2. Altered source versions must be plainly marked as such, and must not
+ *   be misrepresented as being the original software.
+ *
+ *   3. This notice may not be removed or altered from any distribution.
+ *
+ *   4. The names of this software and/or it's copyright holders may not be
+ *   used to endorse or promote products derived from this software without
+ *   specific prior written permission.
+ *
+ */
+
+#include "unp64.h"
+//#include "log.h"
+#include "exo_util.h"
+#include "6502emu.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/*****************************************************************************/
+
+char appstr[80];
+int iter = 0, parsepar = 1, debugprint = 0;
+
+unpstr Unp;
+
+/*****************************************************************************/
+int desledge(unsigned int p, unsigned int prle, unsigned int startm,
+    unsigned char *mem)
+{
+    if (mem[p] == mem[prle]) // starts with a rle?
+    {
+        p++;
+        if (mem[p] == 0) // 16bit length?
+        {
+            if (mem[p + 3] == 0) {
+                // {RLEbyte} 00 {hi} {lo} {byte}
+                // hibyte is +1
+                startm += ((mem[p + 1] - 1) << 8) | mem[p + 2];
+            }
+        } else {
+            if (mem[p + 1] == 0) {
+                // {RLEbyte} {lo} {byte}
+                startm += mem[p];
+            }
+        }
+        if (startm > 0x800) { // keep lower startm, if higher it's ok for me to keep
+            // mem from $0800
+            startm = 0x800;
+        }
+    }
+    return startm;
+}
+/*****************************************************************************/
+void printmsg(unsigned char *mem, int start, int num)
+{
+    int q, p;
+    for (q = 0, p = start; q < num; q++, p++) {
+        if (mem[p] == 0)
+            break;
+        appstr[q] = mem[p] & 0x7f;
+        if (appstr[q] < 0x20)
+            appstr[q] |= 0x40;
+    }
+    appstr[q] = 0;
+    fprintf(stderr, "\"%s\"\n", appstr);
+}
+
+/* the Isepic fill pattern
+        *=$200
+        sei
+        LDA #$34
+        LDY #$00
+        STA $01
+
+        STY $FE
+        LDA #$08
+        STA $FF
+loop
+        TYA
+        EOR $FF
+        STA ($FE),Y
+        TYA
+        EOR #$01
+        STA $0100,Y
+        LDA #$00
+        STA $FF00,Y
+        INY
+        BNE loop
+
+        INC $FF
+        BNE loop
+
+        lda #$37
+        sta $01
+        jmp reset
+*/
+/*****************************************************************************/
+void IseFill(unsigned char *oldb)
+{
+    unsigned short int wptr;
+    unsigned char a, y;
+    y = 0;
+    a = 0x8;
+    wptr = y | (a) << 8;
+
+    while (wptr >> 8) {
+        do {
+            a = y;
+            a ^= (wptr >> 8);
+            oldb[wptr + y] = a;
+            a = y;
+            a ^= 1;
+            oldb[0x100] = a;
+            oldb[0xff00] = 0;
+            y++;
+        } while (y);
+        wptr += 0x100;
+    }
+}
+/*****************************************************************************/
+void reinitUnp(void)
+{
+    Unp.IdFlag = 0;
+    Unp.Forced = 0;
+    Unp.StrMem = 0x800;
+    Unp.RetAdr = 0x800;
+    Unp.DepAdr = 0;
+    Unp.EndAdr = 0x10000;
+    Unp.RtAFrc = 0;
+    Unp.WrMemF = 0;
+    Unp.LfMemF = 0;
+    Unp.ExoFnd = 0;
+    Unp.ECAFlg = 0;
+    Unp.fEndBf = 0;
+    Unp.fEndAf = 0;
+    Unp.fStrAf = 0;
+    Unp.fStrBf = 0;
+    Unp.Mon1st = 0;
+}
+/*****************************************************************************/
+int xxOpenFile(FILE **hh, unpstr *Unpstring, int p)
+{
+    char *pp;
+    char *nfmask = "%s not found\n";
+    int retval = 0;
+    FILE *h;
+
+    h = fopen(appstr, "rb");
+    if (h == NULL) {
+        fprintf(stderr, nfmask, appstr);
+    retry:
+        strcat(appstr, ".prg");
+        h = fopen(appstr, "rb");
+    }
+    if (h == NULL) {
+        fprintf(stderr, nfmask, appstr);
+        appstr[p] = 0;
+        pp = strrchr(appstr, '.');
+        if (pp)
+            *pp = 0;
+        h = fopen(appstr, "rb");
+    }
+    if (h == NULL) {
+        if (strlen(appstr) == 17) {
+            fprintf(stderr, nfmask, appstr);
+            p = 16;
+            appstr[p] = 0;
+            goto retry;
+        }
+    }
+    if (h == NULL) {
+        fprintf(stderr, nfmask, appstr);
+        fprintf(stderr, "Can't proceed onefiling\n");
+        retval = 2;
+    } else {
+        fprintf(stderr, "Onefiling with %s\n", appstr);
+    }
+    *hh = h;
+    return retval;
+}
+/*****************************************************************************/
+int IsBasicRun1(int pc)
+{
+    if( pc==0xa7ae
+      ||pc==0xa7ea
+      ||pc==0xa7b1
+      ||pc==0xa474
+      ||pc==0xa533
+      ||pc==0xa871
+      ||pc==0xa888
+      ||pc==0xa8bc
+      )
+        return 1;
+    else
+        return 0;
+}
+/*****************************************************************************/
+int IsBasicRun2(int pc)
+{
+    if(IsBasicRun1(pc)
+      ||((pc>=0xA57C)&&(pc<=0xA659)) /* Tokenise Input Buffer, happens we get here in some freezed programs, freezed after giving the sys from immediate mode :D */
+      ||pc==0xa660
+      ||pc==0xa68e
+      )
+        return 1;
+    else
+        return 0;
+}
+/*****************************************************************************/
+char *normalizechar(char *app, unsigned char *m, int *ps)
+{
+    int i, s = *ps;
+    memset(app, 0, 0x20);
+    for(i=0;m[s]&&i<16;i++)
+    {
+        if( (m[s]=='<') ||
+            (m[s]=='|') ||
+            (m[s]=='>') ||
+            (m[s]==' ') ||
+            (m[s]=='?') ||
+            (m[s]=='\\')||
+            (m[s]=='/') ||
+            (m[s]=='*') )
+        {
+            m[s] = '_';
+        }
+        app[i] = m[s++] & 0x7f;
+    }
+    *ps = s;
+    strcat(app, ".prg");
+    return app;
+}
+/*****************************************************************************/
+// int main(int argc, char *argv[])
+int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
+    size_t *final_length, char *settings[], int numsettings)
+{
+    struct cpu_ctx r[1];
+    struct load_info info[1];
+    char name[260] = { 0 }, forcedname[260] = { 0 };
+    unsigned char mem[65536] = { 0 }, oldmem[65536] = { 0 },
+    vector[0x20]=
+    {0x31,0xEA,0x66,0xFE,0x47,0xFE,0x4A,0xF3,0x91,0xF2,0x0E,0xF2,0x50,0xF2,0x33,0xF3
+    ,0x57,0xF1,0xCA,0xF1,0xED,0xF6,0x3E,0xF1,0x2F,0xF3,0x66,0xFE,0xA5,0xF4,0xED,0xF5
+    },
+    stack[0x100]=
+    {0x33,0x38,0x39,0x31,0x31,0x00,0x30,0x30,0x30,0x30,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF
+    ,0xFF,0xFF,0xFF,0xFF,0xFF,0x7D,0xEA,0x00,0x00,0x82,0x22,0x0E,0xBC,0x81,0x64,0xB8
+    ,0x0C,0xBD,0xBA,0xB7,0xBC,0x03,0x00,0x46,0xE1,0xE9,0xA7,0xA7,0x79,0xA6,0x9C,0xE3
+                  };
+    int iter_max = ITERMAX;
+    int q, p;
+
+    memset(&Unp, 0, sizeof(Unp));
+    reinitUnp();
+    Unp.FStack = 1;
+    Unp.mem = mem;
+    Unp.r = r;
+    Unp.name = name;
+    Unp.info = info;
+
+    p = 0;
+    //    if(numsettings == 0)
+    //    {
+    // usage:
+    //        strcpy(name,__DATE__);
+    //        fprintf(stderr, "\nUNP64 v%s - Generic C64 prg unpacker - (C)2008-%s
+    //        iAN CooG [%s]\n",VERSION,name+7,name); fprintf(stderr, "Based on
+    //        Exomizer 2.0b7 sources by Magnus Lind.\n"
+    //               "usage: UNP64 <packed.prg>{[,|@]Addr} [-parameters]\n\n"
+    //               "-a       Save all mem instead of $0800-$ffff.\n"
+    //               "-t$Addr  Truncate mem at Addr before saving. ZP Addr used as
+    //               lo/hi pointer.\n"
+    //               "-e$Addr  Specify entry point address in case SYS detection
+    //               fails.\n"
+    //               "-d$Addr  Unpacker address = Addr; default: first address <
+    //               return address.\n"
+    //               "-r$Addr  Return address from unpacker must be >= Addr.
+    //               (default:$0800)\n"
+    //               "-R$Addr  Return address from unpacker must be == Addr.\n"
+    //               "-u       Clean unchanged memory.\n"
+    //               "-l       Clean leftover packed data copied at end of
+    //               memory.\n"
+    //               "-s       Use a zero-filled stack on loading + SP=$FF, else
+    //               like on C64.\n"
+    //               "-fXX     Fill memory with byte XX instead of 0, before
+    //               loading.\n"
+    //               "-i       Identify only.       -c      Continue unpacking
+    //               until error.\n"
+    //               "-v       Verbose output.      -x      Trace for Debug.\n"
+    //               "-B       Patch original Basic ROM at $a000, if prg is
+    //               shorter.\n"
+    //               "-K       Patch original Kernal ROM at $e000, if prg is
+    //               shorter.\n"
+    //               "-o Name  Force output filename as \"Name\"\n"
+    //               "Default output filename is packed.prg.XXXX where XXXX is the
+    //               hex JMP address.\n" "Use packed.prg,Addr to relocate loading
+    //               at Addr instead of .prg loadaddress.\n" "Use packed.bin@Addr
+    //               to load at Addr raw binaries without loadaddress.\n"
+    //               );
+    //        return 1;
+    //    }
+
+    if (numsettings != 0) {
+
+        if (settings[0][0] == '-' && parsepar && settings[0][1] == 'f') {
+            str_to_int(settings[p] + 2, (int *)&Unp.Filler);
+            if (Unp.Filler) {
+                memset(mem + (Unp.Filler >> 16), Unp.Filler & 0xff,
+                    0x10000 - (Unp.Filler >> 16));
+            }
+            p++;
+        }
+
+        //        p=0;
+        //        while((Unp.Recurs==0) && (p<numsettings))
+        //        {
+        //            if (settings[p][0]=='-'&&parsepar)
+        //            {
+        //                switch(settings[p][1])
+        //                {
+        //                    case '-':
+        //                        parsepar=0;
+        //                        break;
+        //                    case 'i':
+        //                        Unp.IdOnly=1;
+        //                        break;
+        //                    case 'f':
+        //                        str_to_int(settings[p]+2, (int *)&Unp.Filler);
+        //                        if(Unp.Filler)
+        //                        {
+        //                            memset(mem+(Unp.Filler>>16),Unp.Filler&0xff,0x10000-(Unp.Filler>>16));
+        //                        }
+        //                        break;
+        //                    case 'v':
+        //                        Unp.DebugP=1;
+        //                        debugprint=Unp.DebugP;
+        //                        break;
+        //                    case 'o':
+        //                        if (settings[p][2])
+        //                            strncpy(forcedname,settings[p]+2,sizeof(forcedname));
+        //                        else if (settings[p+1]&&settings[p+1][0])
+        //                        {
+        //                            p++;
+        //                            strncpy(forcedname,settings[p],sizeof(forcedname));
+        //                        }
+        //                }
+        //            }
+        //        }
+    }
+////                    else
+////                        goto usage;
+//
+//                    if(strlen(forcedname)>248)
+//                        forcedname[248]=0;
+//
+//                }
+//            }
+//            else
+//            {
+//                if(!*name)
+//                    strcpy((char*)name,settings[p]);
+//            }
+//            p++;
+//        }
+//    }
+//    if(!*name)
+//       goto usage;
+looprecurse:
+    /* init logging */
+    //    LOG_INIT_CONSOLE(LOG_BRIEF);
+
+    //    /*appl =*/ fixup_appl(argv[0]);
+
+    info->basic_txt_start = 0x801;
+    load_data(compressed, length, mem, info);
+
+    //    if(Unp.IdOnly)
+    //    {
+    //        fprintf(stderr, "%s : ",name);
+    //    }
+    //    else
+    //        fprintf(stderr, "\n");
+
+    /* no start address from load */
+    if (info->run == -1) {
+        /* look for sys line */
+        info->run = find_sys(mem + info->basic_txt_start, 0x9e);
+    }
+
+    Scanners(&Unp);
+    if (Unp.IdFlag == 2)
+        return 0;
+
+    if ((Unp.Recurs == 0) && (numsettings > 0)) {
+        //        p=0;
+        while (p < numsettings) {
+            if (settings && settings[p][0] == '-') {
+                switch (settings[p][1]) {
+                case '-':
+                    p = numsettings;
+                    break;
+                case 'e':
+                    str_to_int(settings[p] + 2, &Unp.Forced);
+                    Unp.Forced &= 0xffff;
+                    if (Unp.Forced < 0x1)
+                        Unp.Forced = 0;
+                    fprintf(stderr, "entry point forced to $%04x\n", Unp.Forced);
+                    break;
+                case 'a':
+                    Unp.StrMem = 2;
+                    Unp.EndAdr = 0x10001;
+                    Unp.fEndAf = 0;
+                    Unp.fStrAf = 0;
+                    Unp.StrAdC = 0;
+                    Unp.EndAdC = 0;
+                    Unp.MonEnd = 0;
+                    Unp.MonStr = 0;
+                    fprintf(stderr, "save all mem from $0002 to $ffff\n");
+                    break;
+                case 'r':
+                    str_to_int(settings[p] + 2, &Unp.RetAdr);
+                    Unp.RetAdr &= 0xffff;
+                    fprintf(stderr, "return >= $%04x\n", Unp.RetAdr);
+                    break;
+                case 'R':
+                    str_to_int(settings[p] + 2, &Unp.RetAdr);
+                    Unp.RetAdr &= 0xffff;
+                    fprintf(stderr, "return == $%04x\n", Unp.RetAdr);
+                    Unp.RtAFrc = 1;
+                    break;
+                case 'd':
+                    str_to_int(settings[p] + 2, &Unp.DepAdr);
+                    Unp.DepAdr &= 0xffff;
+                    fprintf(stderr, "unpacker = $%04x\n", Unp.DepAdr);
+                    break;
+                case 't':
+                    str_to_int(settings[p] + 2, &Unp.EndAdr);
+                    Unp.EndAdr &= 0xffff;
+                    if (Unp.EndAdr >= 0x100)
+                        Unp.EndAdr++;
+                    fprintf(stderr, "End Addr = $%04x\n", Unp.EndAdr);
+                    break;
+                case 'u':
+                    Unp.WrMemF = 1;
+                    fprintf(stderr, "Clean unwritten memory\n");
+                    break;
+                case 'l':
+                    Unp.LfMemF = info->end;
+                    fprintf(stderr, "Clean memory-end leftovers\n");
+                    break;
+                case 's':
+                    Unp.FStack = 0;
+                    break;
+                case 'x':
+                    //                    LOG_INIT_CONSOLE(LOG_DUMP);
+                    break;
+                case 'B':
+                    break;
+                case 'K':
+                    break;
+                case 'c':
+                    Unp.Recurs++;
+                    break;
+                case 'm': // keep undocumented for now
+                    str_to_int(settings[p] + 2, &iter_max);
+                    fprintf(stderr, "new itermax=0x%x\r\n", iter_max);
+                }
+            }
+            p++;
+        }
+    }
+
+    if (Unp.IdOnly) {
+        if (Unp.DepAdr == 0)
+            fprintf(stderr, " (Unknown)\n");
+        return 0;
+    }
+    if (Unp.WrMemF | Unp.LfMemF) {
+        memcpy(oldmem, mem, sizeof(oldmem));
+    }
+    if (Unp.Forced)
+        info->run = Unp.Forced;
+    if (info->run == -1) {
+        fprintf(stderr, "Error, can't find entry point.\n");
+        return 0;
+    }
+    if (Unp.StrMem > Unp.RetAdr)
+        Unp.StrMem = Unp.RetAdr;
+
+    fprintf(stderr, "Entry point: $%04x\n", info->run);
+    mem[0] = 0x60;
+    r->cycles = 0;
+    mem[1] = 0x37;
+    if (((Unp.Forced >= 0xa000) && (Unp.Forced < 0xc000)) || (Unp.Forced >= 0xd000))
+        mem[1] = 0x38;
+    /* some packers rely on basic pointers already set */
+    mem[0x2b] = info->basic_txt_start & 0xff;
+    mem[0x2c] = info->basic_txt_start >> 8;
+    if (info->basic_var_start == -1) {
+        mem[0x2d] = info->end & 0xff;
+        mem[0x2e] = info->end >> 8;
+    } else {
+        mem[0x2d] = info->basic_var_start & 0xff;
+        mem[0x2e] = info->basic_var_start >> 8;
+    }
+    mem[0x2f] = mem[0x2d];
+    mem[0x30] = mem[0x2e];
+    mem[0x31] = mem[0x2d];
+    mem[0x32] = mem[0x2e];
+    mem[0xae] = info->end & 0xff;
+    mem[0xaf] = info->end >> 8;
+    /* CCS unpacker requires $39/$3a (current basic line number) set */
+    mem[0x39] = mem[0x803];
+    mem[0x3a] = mem[0x804];
+    mem[0x52] = 0;
+    mem[0x53] = 3;
+
+    if (Unp.FStack) {
+        memcpy(mem + 0x100, stack,
+            sizeof(stack)); /* stack as found on clean start */
+        r->sp = 0xf6; /* sys from immediate mode leaves $f6 in stackptr */
+    } else {
+        r->sp = 0xff;
+    }
+
+    if (info->start > (0x314 + sizeof(vector))) {
+        /* some packers use values in irq pointers to decrypt themselves */
+        memcpy(mem + 0x314, vector, sizeof(vector));
+    }
+    mem[0x200] = 0x8a;
+    r->mem = mem;
+    r->pc = info->run;
+
+    r->flags = 0x20;
+    r->a = 0;
+    r->y = 0;
+    if (info->run > 0x351) /* temporary for XIP */
+    {
+        r->x = 0;
+    }
+
+    fprintf(stderr, "pass1, find unpacker: ");
+    iter = 0;
+    while( (Unp.DepAdr?r->pc!=Unp.DepAdr:r->pc>=Unp.RetAdr) )
+    {
+        if( (((mem[1]&0x7) >= 6) && (r->pc >= 0xe000)) ||
+            ((r->pc >= 0xa000) && (r->pc <= 0xbfff) && ((mem[1]&0x7) > 6) )
+           )
+        {
+            /* some packer relies on regs set at return from CLRSCR */
+            if((r->pc==0xe536)||
+               (r->pc==0xe544)||
+               (r->pc==0xff5b)||
+              ((r->pc==0xffd2)&&(r->a==0x93))
+              )
+            {
+                if(r->pc!=0xffd2)
+                {
+                    r->x=0x01;r->y=0x84;
+                    if (r->pc == 0xff5b)
+                        r->a = 0x97; /* actually depends on $d012 */
+                    else
+                        r->a = 0xd8;
+                    r->flags &= ~(128 | 2);
+                    r->flags |= (r->a == 0 ? 2 : 0) | (r->a & 128);
+                }
+                memset(mem + 0x400, 0x20, 1000);
+            }
+            /* intros */
+            if ((r->pc == 0xffe4) || (r->pc == 0xf13e)) {
+                static int flipspe4 = -1;
+                static unsigned char fpressedchars[] = {
+                    0x20, 0, 0x4e, 0, 3, 0, 0x5f, 0, 0x11, 00, 0x0d, 0, 0x31, 0
+                };
+                flipspe4++;
+                if (flipspe4 > (sizeof(fpressedchars) / sizeof(*fpressedchars)))
+                    flipspe4 = 0;
+                r->a = fpressedchars[flipspe4];
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\nJSR $FFE4-> char $%02x %s\n", r->a,
+                        (r->a ? "pressed" : "released"));
+                    fprintf(stderr, "pass1, find unpacker: ");
+                }
+                r->flags &= ~(128 | 2);
+                r->flags |= (r->a == 0 ? 2 : 0) | (r->a & 128);
+            }
+            if (r->pc == 0xfd15) {
+                r->a = 0x31;
+                r->x = 0x30;
+                r->y = 0xff;
+            }
+            if (r->pc == 0xfda3) {
+                mem[0x01] = 0xe7;
+                r->a = 0xd7;
+                r->x = 0xff;
+            }
+            if (r->pc == 0xffbd) {
+                mem[0xB7] = r->a;
+                mem[0xBB] = r->x;
+                mem[0xBC] = r->y;
+            }
+            if ((r->pc == 0xffd5) || (r->pc == 0xf4a2)) {
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\nJSR $FFD5->loads: ");
+                    q = mem[0xbb] | mem[0xbc] << 8;
+                    for (p = 0; p < mem[0xb7]; p++)
+                        fprintf(stderr, "%c", mem[q + p]);
+                    fprintf(stderr, "\n");
+                }
+                break;
+            }
+            if (IsBasicRun1(r->pc)) {
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\n$%04x -> forced %s\n", r->pc, "RUN");
+                }
+                info->run = find_sys(mem + info->basic_txt_start, 0x9e);
+                if (info->run > 0) {
+                    r->sp = 0xf6;
+                    r->pc = info->run;
+                } else {
+                    mem[0] = 0x60;
+                    r->pc = 0; /* force a RTS instead of executing ROM code */
+                }
+
+                // continue;
+            } else {
+                mem[0] = 0x60;
+                r->pc = 0; /* force a RTS instead of executing ROM code */
+            }
+        }
+        if (next_inst(r) == 1)
+            return 0;
+        iter++;
+        if (iter == iter_max) {
+            fprintf(stderr, "\nMax Iterations 0x%08x Reached, quitting...\n",
+                iter_max);
+            return 0;
+        }
+
+        if (Unp.ExoFnd && (Unp.EndAdr == 0x10000) && (r->pc >= 0x100) && (r->pc <= 0x200) && (Unp.StrMem != 2)) {
+            Unp.EndAdr = r->mem[0xfe] + (r->mem[0xff] << 8);
+            if ((Unp.ExoFnd & 0xff) == 0x30) { /* low byte of EndAdr, it's a lda $ff00,y */
+                Unp.EndAdr = (Unp.ExoFnd >> 8) + (r->mem[0xff] << 8);
+            } else if ((Unp.ExoFnd & 0xff) == 0x32) { /* add 1 */
+                Unp.EndAdr = 1 + ((Unp.ExoFnd >> 8) + (r->mem[0xff] << 8));
+            }
+
+            if (Unp.EndAdr == 0)
+                Unp.EndAdr = 0x10001;
+            if (Unp.DebugP)
+                fprintf(stderr, "\nexo endaddr=$%04x\n", Unp.EndAdr - 1);
+        }
+        if (Unp.fEndBf && (Unp.EndAdr == 0x10000) && (r->pc == Unp.DepAdr)) {
+            Unp.EndAdr = r->mem[Unp.fEndBf] | r->mem[Unp.fEndBf + 1] << 8;
+            Unp.EndAdr++;
+            if (Unp.EndAdr == 0)
+                Unp.EndAdr = 0x10001;
+            Unp.fEndBf = 0;
+        }
+        if (Unp.fStrBf && (Unp.StrMem != 0x2) && (r->pc == Unp.DepAdr)) {
+            Unp.StrMem = r->mem[Unp.fStrBf] | r->mem[Unp.fStrBf + 1] << 8;
+            Unp.fStrBf = 0;
+        }
+
+        if (Unp.DebugP) {
+            for (p = 0; p < 0x20; p += 2) {
+                if (*(unsigned short int *)(mem + 0x314 + p) != *(unsigned short int *)(vector + p)) {
+                    fprintf(stderr,
+                        "Warning! Vector $%04x-$%04x changed from $%04x to $%04x\n",
+                        0x314 + p, 0x314 + p + 1, *(unsigned short int *)(vector + p),
+                        *(unsigned short int *)(mem + 0x314 + p));
+                    fprintf(stderr, "pass1, find unpacker: ");
+                    *(unsigned short int *)(vector + p) = *(unsigned short int *)(mem + 0x314 + p);
+                }
+            }
+        }
+    }
+    fprintf(stderr, "$%04x\n", r->pc);
+    if (Unp.DebugP)
+        fprintf(stderr, "Iterations %d cycles %d\n", iter, r->cycles);
+
+    fprintf(stderr, "pass2, return to mem: ");
+    iter = 0;
+    while (Unp.RtAFrc ? r->pc != Unp.RetAdr : r->pc < Unp.RetAdr) {
+        if (Unp.MonEnd && r->pc == Unp.DepAdr) {
+            if (Unp.DebugP)
+                if (Unp.EndAdr == 0x10000)
+                    fprintf(stderr, "\n");
+            p = r->mem[Unp.MonEnd >> 16] | r->mem[Unp.MonEnd & 0xffff] << 8;
+            if (p > (Unp.EndAdr & 0xffff)) {
+                Unp.EndAdr = p;
+                if (Unp.DebugP) {
+                    if (Unp.fEndAf)
+                        fprintf(stderr, "\r");
+                    else
+                        fprintf(stderr, "\n");
+                    fprintf(stderr, "Monitored %s pointer $%04x+$%04x -> $%04x", "end",
+                        Unp.MonEnd >> 16, Unp.MonEnd & 0xffff, Unp.EndAdr);
+                }
+            }
+        }
+        if (Unp.MonStr && r->pc == Unp.DepAdr) {
+            p = r->mem[Unp.MonStr >> 16] | r->mem[Unp.MonStr & 0xffff] << 8;
+            if (p > 0) {
+                if (Unp.Mon1st == 0) {
+                    Unp.StrMem = p;
+                }
+                Unp.Mon1st = Unp.StrMem;
+                Unp.StrMem = (p < Unp.StrMem ? p : Unp.StrMem);
+                if (Unp.DebugP) {
+                    if (Unp.Mon1st != Unp.StrMem) {
+                        fprintf(stderr, "\n");
+                        fprintf(stderr, "Monitored %s pointer $%04x+$%04x -> $%04x",
+                            "start", Unp.MonStr >> 16, Unp.MonStr & 0xffff, Unp.StrMem);
+                    }
+                }
+            }
+        }
+
+        if (r->pc >= 0xe000) {
+            if (((mem[1] & 0x7) >= 6) && ((mem[1] & 0x7) <= 7)) {
+
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\n$%04x -> forced %s\n", r->pc, "RTS");
+                }
+                mem[0] = 0x60;
+                r->pc = 0;
+            }
+        }
+        if (next_inst(r) == 1)
+            return 0;
+        if ((mem[r->pc] == 0x40) && (Unp.RTIFrc == 1)) {
+            if (next_inst(r) == 1)
+                return 0;
+            Unp.RetAdr = r->pc;
+            Unp.RtAFrc = 1;
+            if (Unp.RetAdr < Unp.StrMem)
+                Unp.StrMem = 2;
+            break;
+        }
+        iter++;
+        if (iter == iter_max) {
+            fprintf(stderr, "\nMax Iterations 0x%08x Reached, quitting...\n",
+                iter_max);
+            return 0;
+        }
+        if ((r->pc >= 0xa000) && (r->pc <= 0xbfff) && ((mem[1] & 0x7) == 7)) {
+            if (IsBasicRun2(r->pc)) {
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\n$%04x -> forced %s\n", r->pc, "RUN");
+                }
+                r->pc = 0xa7ae;
+                break;
+            } else {
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\n$%04x -> forced %s\n", r->pc, "RTS");
+                }
+                mem[0] = 0x60;
+                r->pc = 0;
+            }
+        }
+        if (r->pc >= 0xe000) {
+            if (((mem[1] & 0x7) >= 6) && ((mem[1] & 0x7) <= 7)) {
+                if (r->pc == 0xffbd) {
+                    mem[0xB7] = r->a;
+                    mem[0xBB] = r->x;
+                    mem[0xBC] = r->y;
+                }
+                if (r->pc == 0xffd5) {
+                    if (Unp.DebugP) {
+                        fprintf(stderr, "\nJSR $FFD5->loads: ");
+                        q = mem[0xbb] | mem[0xbc] << 8;
+                        for (p = 0; p < mem[0xb7]; p++)
+                            fprintf(stderr, "%c", mem[q + p]);
+                        fprintf(stderr, "\n");
+                    }
+                }
+
+                /* return into IRQ handler, better stop here */
+                if (((r->pc >= 0xea31) && (r->pc <= 0xeb76)) || (r->pc == 0xffd5) || (r->pc == 0xfce2)) {
+                    if (Unp.DebugP) {
+                        fprintf(stderr, "\n$%04x -> forced %s\n", r->pc, "exit");
+                    }
+                    break;
+                }
+                if (r->pc == 0xfda3) {
+                    mem[0x01] = 0xe7;
+                    r->a = 0xd7;
+                    r->x = 0xff;
+                }
+
+                if (Unp.DebugP) {
+                    fprintf(stderr, "\n$%04x -> forced %s\n", r->pc, "RTS");
+                }
+                mem[0] = 0x60;
+                r->pc = 0;
+            }
+        }
+    }
+    if ((Unp.MonEnd | Unp.MonStr) && Unp.DebugP)
+        fprintf(stderr, "\n");
+    if (Unp.fEndAf && Unp.MonEnd) {
+        Unp.EndAdC = mem[Unp.fEndAf] | mem[Unp.fEndAf + 1] << 8;
+        if ((int)Unp.EndAdC > Unp.EndAdr)
+            Unp.EndAdr = Unp.EndAdC;
+        Unp.EndAdC = 0;
+        Unp.fEndAf = 0;
+    }
+    if (Unp.fEndAf && (Unp.EndAdr == 0x10000)) {
+        Unp.EndAdr = r->mem[Unp.fEndAf] | r->mem[Unp.fEndAf + 1] << 8;
+        if (Unp.EndAdr == 0)
+            Unp.EndAdr = 0x10000;
+        else
+            Unp.EndAdr++;
+        Unp.fEndAf = 0;
+    }
+    if (Unp.fStrAf /*&&(Unp.StrMem==0x800)*/) {
+        Unp.StrMem = r->mem[Unp.fStrAf] | r->mem[Unp.fStrAf + 1] << 8;
+        Unp.StrMem++;
+        Unp.fStrAf = 0;
+    }
+
+    if (Unp.ExoFnd && (Unp.StrMem != 2)) {
+        Unp.StrMem = r->mem[0xfe] + (r->mem[0xff] << 8);
+        if ((Unp.ExoFnd & 0xff) == 0x30) {
+            Unp.StrMem += r->y;
+        } else if ((Unp.ExoFnd & 0xff) == 0x32) {
+            Unp.StrMem += r->y + 1;
+        }
+
+        if (Unp.DebugP)
+            fprintf(stderr, "\nexo startaddr=$%04x\n", Unp.StrMem);
+    }
+    if (r->pc == 0xfce2) {
+        if ((*(unsigned int *)(mem + 0x8004) == 0x38cdc2c3) && (mem[0x8008] == 0x30)) {
+            fprintf(stderr, "CBM80($%04x)->", r->pc);
+            r->pc = r->mem[0x8000] + (r->mem[0x8001] << 8);
+        }
+    } else if (r->pc == 0xa7ae) {
+        fprintf(stderr, "($%04x)->", r->pc);
+        info->basic_txt_start = mem[0x2b] | mem[0x2c] << 8;
+        if (info->basic_txt_start != 0x801)
+            fprintf(stderr, "(new basic start $%04x)->", info->basic_txt_start);
+        else {
+            info->run = find_sys(mem + info->basic_txt_start, 0x9e);
+            if (info->run > 0)
+                r->pc = info->run;
+        }
+    }
+    if (r->pc == 0xa7ae)
+        fprintf(stderr, "RUN\n");
+    else
+        fprintf(stderr, "$%04x\n", r->pc);
+    if (Unp.DebugP)
+        fprintf(stderr, "Iterations %d cycles %d\n", iter, r->cycles);
+
+    if (Unp.WrMemF) {
+        Unp.WrMemF = 0;
+        for (p = 0x800; p < 0x10000; p += 4) {
+            if (*(unsigned int *)(oldmem + p) == *(unsigned int *)(mem + p)) {
+                *(unsigned int *)(mem + p) = 0;
+                Unp.WrMemF = 1;
+            }
+        }
+        /* clean also the $fd30 table copy in RAM */
+        if (memcmp(mem + 0xfd30, vector, sizeof(vector)) == 0) {
+            memset(mem + 0xfd30, 0, sizeof(vector));
+        }
+    }
+    if (Unp.LfMemF) {
+        for (p = 0xffff; p > 0x0800; p--) {
+            if (oldmem[--Unp.LfMemF] == mem[p])
+                mem[p] = 0x0;
+            else {
+                if (p < 0xffff)
+                    fprintf(stderr, "cleaned from $%04x to $ffff\n", p + 1);
+                else
+                    Unp.LfMemF = 0 | Unp.ECAFlg;
+                break;
+            }
+        }
+    }
+    if (*forcedname) {
+        strcpy(name, forcedname);
+    } else {
+        if (strlen(name) > 248) /* dirty hack in case name is REALLY long */
+            name[248] = 0;
+        sprintf(name + strlen(name), ".%04x%s", r->pc,
+            (Unp.WrMemF | Unp.LfMemF ? ".clean" : ""));
+    }
+    //    h=fopen(name,"wb");
+    /*  endadr is set to a ZP location? then use it as a pointer
+      todo: use fEndAf instead, it can be used for any location, not only ZP. */
+    if (Unp.EndAdr && (Unp.EndAdr < 0x100)) {
+        p = (mem[Unp.EndAdr] | mem[Unp.EndAdr + 1] << 8) & 0xffff;
+        Unp.EndAdr = p;
+    }
+    if (Unp.ECAFlg && (Unp.StrMem != 2)) /* checkme */
+    {
+        if (Unp.EndAdr >= ((Unp.ECAFlg >> 16) & 0xffff)) {
+            /* most of the times transfers $2000 byte from $d000-efff to $e000-ffff
+         but there are exceptions */
+            if (Unp.DebugP) {
+                fprintf(stderr, "ECA: endmem adjusted from $%04x to $%04x\n",
+                    Unp.EndAdr, (Unp.EndAdr + 0x1000));
+                if (Unp.LfMemF) {
+                    fprintf(stderr, "mem $%04x-$%04x cleaned\n",
+                        ((Unp.ECAFlg >> 16) & 0xffff),
+                        ((Unp.ECAFlg >> 16) & 0xffff) + 0x0fff);
+                }
+            }
+            if (Unp.LfMemF)
+                memset(mem + ((Unp.ECAFlg >> 16) & 0xffff), 0, 0x1000);
+            Unp.EndAdr += 0x1000;
+        }
+    }
+    if (Unp.EndAdr <= 0)
+        Unp.EndAdr = 0x10000;
+    if (Unp.EndAdr > 0x10000)
+        Unp.EndAdr = 0x10000;
+    if (Unp.EndAdr < Unp.StrMem)
+        Unp.EndAdr = 0x10000;
+
+    if (Unp.EndAdC & 0xffff) {
+        Unp.EndAdr += (Unp.EndAdC & 0xffff);
+        Unp.EndAdr &= 0xffff;
+    }
+    if (Unp.EndAdC & EA_USE_A) {
+        Unp.EndAdr += r->a;
+        Unp.EndAdr &= 0xffff;
+    }
+    if (Unp.EndAdC & EA_USE_X) {
+        Unp.EndAdr += r->x;
+        Unp.EndAdr &= 0xffff;
+    }
+    if (Unp.EndAdC & EA_USE_Y) {
+        Unp.EndAdr += r->y;
+        Unp.EndAdr &= 0xffff;
+    }
+    if (Unp.StrAdC & 0xffff) {
+        Unp.StrMem += (Unp.StrAdC & 0xffff);
+        Unp.StrMem &= 0xffff;
+        /* only if ea_addff, no reg involved */
+        if (((Unp.StrAdC & 0xffff0000) == EA_ADDFF) && ((Unp.StrMem & 0xff) == 0)) {
+            Unp.StrMem += 0x100;
+            Unp.StrMem &= 0xffff;
+            if (Unp.DebugP) {
+                fprintf(stderr, STRMEMAJ, Unp.StrMem, "(no reg)");
+            }
+        }
+    }
+    if (Unp.StrAdC & EA_USE_A) {
+        Unp.StrMem += r->a;
+        Unp.StrMem &= 0xffff;
+        if (Unp.StrAdC & EA_ADDFF) {
+            if ((Unp.StrMem & 0xff) == 0xff)
+                Unp.StrMem++;
+            if (r->a == 0) {
+                Unp.StrMem += 0x100;
+                Unp.StrMem &= 0xffff;
+                //                if(Unp.DebugP)
+                //                {
+                //                    fprintf(stderr,STRMEMAJ,Unp.StrMem,"(+A)");
+                //                }
+            }
+        }
+    }
+    if (Unp.StrAdC & EA_USE_X) {
+        Unp.StrMem += r->x;
+        Unp.StrMem &= 0xffff;
+        if (Unp.StrAdC & EA_ADDFF) {
+            if ((Unp.StrMem & 0xff) == 0xff)
+                Unp.StrMem++;
+            if (r->x == 0) {
+                Unp.StrMem += 0x100;
+                Unp.StrMem &= 0xffff;
+                //                if(Unp.DebugP)
+                //                {
+                //                    fprintf(stderr,STRMEMAJ,Unp.StrMem,"(+X)");
+                //                }
+            }
+        }
+    }
+    if (Unp.StrAdC & EA_USE_Y) {
+        Unp.StrMem += r->y;
+        Unp.StrMem &= 0xffff;
+        if (Unp.StrAdC & EA_ADDFF) {
+            if ((Unp.StrMem & 0xff) == 0xff)
+                Unp.StrMem++;
+            if (r->y == 0) {
+                Unp.StrMem += 0x100;
+                Unp.StrMem &= 0xffff;
+                //                if(Unp.DebugP)
+                //                {
+                //                    fprintf(stderr,STRMEMAJ,Unp.StrMem,"(+Y)");
+                //                }
+            }
+        }
+    }
+    if (Unp.EndAdr <= 0)
+        Unp.EndAdr = 0x10000;
+    if (Unp.EndAdr > 0x10000)
+        Unp.EndAdr = 0x10000;
+    if (Unp.EndAdr < Unp.StrMem)
+        Unp.EndAdr = 0x10000;
+
+    mem[Unp.StrMem - 2] = Unp.StrMem & 0xff;
+    mem[Unp.StrMem - 1] = Unp.StrMem >> 8;
+    //    fwrite(mem+(Unp.StrMem-2),Unp.EndAdr-Unp.StrMem+2,1,h);
+    memcpy(destination_buffer, mem + (Unp.StrMem - 2),
+        Unp.EndAdr - Unp.StrMem + 2);
+    *final_length = Unp.EndAdr - Unp.StrMem + 2;
+    fprintf(stderr, "saved $%04x-$%04x as %s\n", Unp.StrMem,
+        (Unp.EndAdr - 1) & 0xffff, name);
+    //    fclose(h);
+    if (Unp.Recurs) {
+        if (++Unp.Recurs > RECUMAX)
+            return 1;
+        reinitUnp();
+        goto looprecurse;
+    }
+    return 1;
+}

--- a/terps/unp64/unp64.h
+++ b/terps/unp64/unp64.h
@@ -71,7 +71,6 @@ extern char appstr[80];
 int desledge(unsigned int p, unsigned int prle, unsigned int startm,
              unsigned char *mem);
 int xxOpenFile(FILE **hh, unpstr *Unp, int p);
-char *normalizechar(char *app, unsigned char *m, int *ps);
 void printmsg(unsigned char *mem, int start, int num);
 void PrintInfo(unpstr *Unp, int id);
 void Scanners(unpstr *);

--- a/terps/unp64/unp64.h
+++ b/terps/unp64/unp64.h
@@ -1,0 +1,1020 @@
+#include "6502emu.h"
+#include "exo_util.h"
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int IdFlag; /* flag, 1=packer identified; 2=not a packer, stop scanning */
+  int Forced; /* forced entry point */
+  int StrMem; /* start of unpacked memory */
+  int RetAdr; /* return address after unpacking */
+  int DepAdr; /* unpacker entry point */
+  int EndAdr; /* end of unpacked memory */
+  int RtAFrc; /* flag, return address must be exactly RetAdr, else anything >=
+                 RetAdr */
+  int WrMemF; /* flag, clean unwritten memory */
+  int LfMemF; /* flag, clean end memory leftovers */
+  int ExoFnd; /* flag, Exomizer detected */
+              //             int IseFlg; /* flag, Isepic detected */
+  int FStack; /* flag, fill stack with 0 and SP=$ff, else as in C64 */
+  int ECAFlg; /* ECA found, holds relocated areas high bytes */
+  int fEndBf; /* End memory address pointer before unpacking, set when DepAdr is
+                 reached */
+  int fEndAf; /* End memory address pointer after  unpacking, set when RetAdr is
+                 reached */
+  int fStrBf; /* Start memory address pointer before unpacking, set when DepAdr
+                 is reached */
+  int fStrAf; /* Start memory address pointer after  unpacking, set when RetAdr
+                 is reached */
+  int IdOnly; /* flag, just identify packer and exit */
+  int DebugP; /* flag, verbosely emit various infos */
+  int RTIFrc; /* flag, RTI instruction forces return from unpacker */
+  int Recurs; /* recursion counter */
+  unsigned int MonEnd; /* End memory address pointers monitored during
+                          execution, updated every time DepAdr is reached */
+  unsigned int MonStr; /* Start memory address pointers monitored during
+                          execution, updated every time DepAdr is reached */
+  unsigned int
+      Mon1st; /* flag for forcingly assign monitored str/end ptr the 1st time */
+  unsigned int
+      EndAdC; /* add fixed values and/or registers AXY to End memory address */
+  unsigned int StrAdC; /* add fixed values and/or registers AXY to Start memory
+                          address */
+  unsigned int Filler; /* Memory filler byte*/
+  unsigned char *mem;  /* pointer to the memory array */
+  char *name;          /* name of the prg file */
+  struct load_info *info; /* pointer to the loaded prg info struct */
+  struct cpu_ctx *r;      /* pointer to the registers struct */
+} unpstr;
+
+typedef void (*Scnptr)(unpstr *);
+
+#define VERSION "2.35"
+
+#define EA_USE_A 0x01000000
+#define EA_USE_X 0x00100000
+#define EA_USE_Y 0x00010000
+#define EA_ADDFF 0x10000000
+/* worst case found so far: depacking an ALZ64 program $0801-$ffff
+Iterations 36260732 (0x02294B7C)
+*/
+#define ITERMAX 0x02000000
+#define RECUMAX 16
+
+#define DEPMASK "%s, unpacker=$%04x\n"
+#define DEPMASK2 "%s %s, unpacker=$%04x\n"
+#define STRMEMAJ "\nStart mem adjusted to $%04x %s\n"
+
+extern char appstr[80];
+// extern unsigned char roms[2][0x2000];
+
+int desledge(unsigned int p, unsigned int prle, unsigned int startm,
+             unsigned char *mem);
+int xxOpenFile(FILE **hh, unpstr *Unp, int p);
+char *normalizechar(char *app, unsigned char *m, int *ps);
+void printmsg(unsigned char *mem, int start, int num);
+void PrintInfo(unpstr *Unp, int id);
+void Scanners(unpstr *);
+void Scn_NotPackers(unpstr *);
+void Scn_Intros(unpstr *);
+void Scn_XIP(unpstr *);
+// void Scn_OUG                (unpstr*);
+// void Scn_IsePic             (unpstr*);
+void Scn_Optimus(unpstr *);
+void Scn_xCodeZippers(unpstr *);
+void Scn_Expert(unpstr *);
+void Scn_AR(unpstr *);
+void Scn_BitImploder(unpstr *);
+void Scn_Jox(unpstr *);
+void Scn_ExplCrunch(unpstr *);
+void Scn_ExplFaces(unpstr *);
+void Scn_Facepacker(unpstr *);
+// void Scn_ABCruncher         (unpstr*);
+void Scn_BYG(unpstr *);
+void Scn_FilecompactorTMC(unpstr *);
+// void Scn_ASCprot            (unpstr*);
+void Scn_CFB(unpstr *);
+// void Scn_Zipper             (unpstr*);
+void Scn_ECA(unpstr *);
+void Scn_NSU(unpstr *);
+void Scn_IDT(unpstr *);
+void Scn_Cruel(unpstr *);
+void Scn_PuCrunch(unpstr *);
+void Scn_MDG(unpstr *);
+void Scn_AbuzeCrunch        (unpstr*);
+void Scn_SledgeHammer(unpstr *);
+void Scn_TimCrunch(unpstr *);
+void Scn_TimeCruncher(unpstr *);
+void Scn_BetaDynamic(unpstr *);
+void Scn_DarkSqueezer(unpstr *);
+void Scn_ByteBoiler(unpstr *);
+void Scn_MrCross(unpstr *);
+// void Scn_1001card           (unpstr*);
+void Scn_WDRsoftp(unpstr *);
+void Scn_DSCcoder(unpstr *);
+void Scn_BonanzaBros(unpstr *);
+// void Scn_Agony              (unpstr*);
+void Scn_ExplXRated(unpstr *);
+void Scn_MasterCompressor(unpstr *);
+void Scn_ScreenCrunch(unpstr *);
+void Scn_MCCrackenComp(unpstr *);
+void Scn_FinalSuperComp(unpstr *);
+// void Scn_4cPack             (unpstr*);
+void Scn_FXbytepress(unpstr *);
+void Scn_FXbitstream(unpstr *);
+void Scn_Trianon(unpstr *);
+void Scn_KompressMaster711(unpstr *);
+void Scn_TurboPacker(unpstr *);
+void Scn_TCScrunch(unpstr *);
+void Scn_TBCMultiComp(unpstr *);
+void Scn_ByteBoozer(unpstr *);
+void Scn_ALZ64(unpstr *);
+void Scn_XTC(unpstr *);
+void Scn_UniPacker(unpstr *);
+void Scn_TCD(unpstr *);
+void Scn_Matcham(unpstr *);
+void Scn_Supercrunch(unpstr *);
+void Scn_Superpack(unpstr *);
+void Scn_BeefTrucker(unpstr *);
+void Scn_TSB(unpstr *);
+void Scn_ISC(unpstr *);
+void Scn_TMM(unpstr *);
+void Scn_FilecompactorMTB(unpstr *);
+//void Scn_EqByteComp(unpstr *);
+void Scn_Galleon(unpstr *);
+void Scn_BeastLink(unpstr *);
+void Scn_BronxPacker(unpstr *);
+void Scn_Oneway(unpstr *);
+void Scn_CeleriPack(unpstr *);
+void Scn_CadgersPacker(unpstr *);
+void Scn_Crush(unpstr *);
+void Scn_Lightmizer(unpstr *);
+void Scn_Frog(unpstr *);
+void Scn_FrontPacker(unpstr *);
+void Scn_MartinPiper(unpstr *);
+// void Scn_Apack              (unpstr*);
+void Scn_ONS(unpstr *);
+void Scn_FC3pack(unpstr *);
+void Scn_Amnesia(unpstr *);
+void Scn_Polonus(unpstr *);
+void Scn_KressCrunch(unpstr *);
+void Scn_SirMiniPack(unpstr *);
+void Scn_MRD(unpstr *);
+void Scn_CCS(unpstr *);
+void Scn_PZW(unpstr *);
+void Scn_C4MRP(unpstr *);
+void Scn_ILSCoder(unpstr *);
+void Scn_MSI(unpstr *);
+void Scn_U_111pack(unpstr *);
+void Scn_Hawk(unpstr *);
+void Scn_TSMcoder(unpstr *);
+void Scn_Ikari(unpstr *);
+void Scn_WGIcoder(unpstr *);
+void Scn_HTLcoder(unpstr *);
+void Scn_XDScoder(unpstr *);
+void Scn_FDTcoder(unpstr *);
+void Scn_SKLcoder(unpstr *);
+void Scn_SpeediComp(unpstr *);
+void Scn_U_DSC_MA(unpstr *);
+void Scn_P100(unpstr *);
+void Scn_MaschSprache(unpstr *);
+void Scn_MegaCruncher(unpstr *);
+void Scn_VIP(unpstr *);
+void Scn_Gandalf(unpstr *);
+void Scn_AEKcoder(unpstr *);
+void Scn_LSTcoder(unpstr *);
+void Scn_Eastlinker(unpstr *);
+void Scn_Jazzcat(unpstr *);
+void Scn_PITcoder(unpstr *);
+void Scn_BitPacker(unpstr *);
+void Scn_ByteCompactor(unpstr *);
+void Scn_Rows(unpstr *);
+void Scn_U_400All(unpstr *);
+void Scn_U_439pack(unpstr *);
+// void Scn_64er               (unpstr*);
+void Scn_TMCcoder(unpstr *);
+void Scn_ALScoder(unpstr *);
+void Scn_UltraComp(unpstr *);
+void Scn_FCG(unpstr *);
+void Scn_Megabyte(unpstr *);
+// void Scn_Zigag              (unpstr*);
+void Scn_Brains(unpstr *);
+void Scn_Graffity(unpstr *);
+void Scn_Section8(unpstr *);
+void Scn_MrZ(unpstr *);
+void Scn_DD(unpstr *);
+void Scn_PackOpt(unpstr *);
+void Scn_Warlock(unpstr *);
+void Scn_U_100pack(unpstr *);
+void Scn_U_101pack(unpstr *);
+void Scn_SyncroPack(unpstr *);
+void Scn_Relax(unpstr *);
+void Scn_Jazoo(unpstr *);
+void Scn_WCC(unpstr *);
+void Scn_LTS(unpstr *);
+void Scn_Low(unpstr *);
+void Scn_C_Noack(unpstr *);
+void Scn_Koncina(unpstr *);
+void Scn_U_Triad(unpstr *);
+void Scn_RapEq(unpstr *);
+void Scn_ByteKiller(unpstr *);
+void Scn_Loadstar(unpstr *);
+void Scn_Trashcan(unpstr *);
+void Scn_Caution(unpstr *);
+void Scn_U_25_pack(unpstr *);
+void Scn_U_8e_pack(unpstr *);
+void Scn_U_P3_pack(unpstr *);
+void Scn_FalcoPack(unpstr *);
+//void Scn_FP(unpstr *);
+//void Scn_FinalCompactor(unpstr *);
+void Scn_NEC(unpstr *);
+void Scn_EnigmaMFFL(unpstr *);
+void Scn_Shurigen(unpstr *);
+void Scn_U_Generic801(unpstr *);
+void Scn_Exomizer(unpstr *);
+void Scn_STL(unpstr *);
+void Scn_SPC(unpstr *);
+void Scn_FSW(unpstr *);
+void Scn_BAM(unpstr *);
+void Scn_Cobra(unpstr *);
+// void Scn_GrafBinaer         (unpstr*);
+// void Scn_AbyssCoder         (unpstr*);
+void Scn_ByteBuster(unpstr *);
+void Scn_Mekker(unpstr *);
+void Scn_ByteStrainer(unpstr *);
+// void Scn_Jedi               (unpstr*);
+void Scn_Pride(unpstr *);
+void Scn_Autostarters(unpstr *);
+void Scn_StarCrunch(unpstr *);
+void Scn_SpyPack(unpstr *);
+void Scn_GPacker(unpstr *);
+void Scn_Cadaver(unpstr *);
+void Scn_Helmet(unpstr *);
+// void Scn_Anticom            (unpstr*);
+// void Scn_Antiram            (unpstr*);
+void Scn_Excalibur(unpstr *);
+void Scn_CNCD(unpstr *);
+void Scn_BN1872(unpstr *);
+// void Scn_4wd                (unpstr*);
+void Scn_Huffer(unpstr *);
+void Scn_NM156(unpstr *);
+void Scn_Ratt(unpstr *);
+void Scn_Byterapers(unpstr *);
+void Scn_CIACrypt(unpstr *);
+void Scn_PAN(unpstr *);
+void Scn_TKC(unpstr *);
+// void Scn_THS                (unpstr*);
+void Scn_UProt(unpstr *);
+void Scn_YetiCoder(unpstr *);
+void Scn_Panoramic(unpstr *);
+void Scn_WHO(unpstr *);
+void Scn_KGBcoder(unpstr *);
+// void Scn_Pyra               (unpstr*);
+void Scn_ActionPacker(unpstr *);
+void Scn_CCrypt(unpstr *);
+void Scn_TDT(unpstr *);
+void Scn_Cult(unpstr *);
+void Scn_Gimzo(unpstr *);
+void Scn_BlackAdder(unpstr *);
+void Scn_ICS8(unpstr *);
+void Scn_Paradroid(unpstr *);
+void Scn_Plasma(unpstr *);
+void Scn_DrZoom(unpstr *);
+void Scn_ExactCoder(unpstr *);
+void Scn_CNETFixer(unpstr *);
+// void Scn_Triangle           (unpstr*);
+void Scn_SFLinker(unpstr *);
+void Scn_Bongo(unpstr *);
+void Scn_Jemasoft(unpstr *);
+void Scn_TATCoder(unpstr *);
+void Scn_RFOCoder(unpstr *);
+void Scn_Doynamite(unpstr *);
+void Scn_Nibbit(unpstr *);
+void Scn_TLRLinker(unpstr *);
+void Scn_TLRSubsizer(unpstr *);
+// void Scn_AdmiralP4kbar      (unpstr*);
+// void Scn_ZeroCoder          (unpstr*);
+void Scn_NuCrunch(unpstr *);
+void Scn_TinyCrunch(unpstr *);
+void Scn_FileLinkerSDA(unpstr *);
+void Scn_Inceria(unpstr *);
+
+enum stringpool_id {
+  _I_1001_4,
+  _I_1001_NEWPACK,
+  _I_1001_OLDPACK,
+  _I_1001_CRAM,
+  _I_1001_ACM,
+  _I_1001_HTL,
+  _I_DATELUC,
+  _I_DATELUCP,
+  _I_DATELUCC
+  //                   , _I_4CPACK
+  ,
+  _I_64ER_SP22,
+  _I_64ER_SP23,
+  _I_64ER_SP2U,
+  _I_64ER_SP12,
+  _I_64ER_SP13,
+  _I_64ER_SP14,
+  _I_64ER_SP15,
+  _I_64ER_SP1U,
+  _I_64ERBITP,
+  _I_64ERBITP1,
+  _I_64ERS41A,
+  _I_64ERS41B,
+  _I_64ERS41C,
+  _I_64ERS40A,
+  _I_64ERS40B,
+  _I_64ERS40C,
+  _I_64ERS40D,
+  _I_64ERS40DB,
+  _I_64ER_15,
+  _I_64ERS40F,
+  _I_64ER_21,
+  _I_HAPPYS32,
+  _I_HAPPYS22,
+  _I_64ERAUTO,
+  _I_AB_CRUNCH
+, _I_ABUZECRUNCH
+, _I_ABUZECR37
+, _I_ABUZECR50,
+  _I_AEKCOD20,
+  _I_AEKCOD11,
+  _I_SYNCRO13,
+  _I_SYNCRO14,
+  _I_SYNCRO155,
+  _I_SYNCRO12,
+  _I_TLRPACK,
+  _I_TLRPROT1,
+  _I_TLRPROT2,
+  _I_TLRLINK,
+  _I_TLRLINKFM,
+  _I_TLRSSIZER,
+  _I_TLRSSIZD5,
+  _I_TLRSSIZD6
+  //                   , _I_AGONYPACK
+  ,
+  _I_DARKP20,
+  _I_DARKP21,
+  _I_DARKP31,
+  _I_JAP2,
+  _I_ALSCODER,
+  _I_ALZ64
+  //                   , _I_AMNESIA1
+  //                   , _I_AMNESIA2
+  //                   , _I_APACK
+  //                   , _I_AR4
+  //                   , _I_AR3
+  //                   , _I_ARU
+  //                   , _I_AR42F
+  ,
+  _I_SSNAP,
+  _I_FRZMACH,
+  _I_FRZMACH2F
+  //                   , _I_ASCPROT
+  ,
+  _I_BEASTLINK,
+  _I_BEEFTR54,
+  _I_BEEFTR56,
+  _I_BEEFTR2,
+  _I_BEEFTLB,
+  _I_BETADYN3,
+  _I_BETADYN3FX,
+  _I_BETADYN3CCS,
+  _I_BETADYN2,
+  _I_BITIMP,
+  _I_BITPACK2,
+  _I_BONANZA,
+  _I_BRAINS,
+  _I_BRONX,
+  _I_BYG1,
+  _I_BYG2,
+  _I_BYGBB,
+  _I_BYTEBOILER,
+  _I_BYTEBOICPX,
+  _I_BYTEBOISCS,
+  _I_BYTEBOOZER,
+  _I_BYTEBOOZ20,
+  _I_BYTEBOOZ11C,
+  _I_BYTEBOOZ11E,
+  _I_LAMEBOOZER,
+  _I_BYTECOMP,
+  _I_BYTEKILL,
+  _I_C4MRP,
+  _I_CADGERS,
+  _I_CAUTION10,
+  _I_CAUTION25,
+  _I_CAUTION25SS,
+  _I_CAUTION20,
+  _I_CAUTION20SS,
+  _I_CAUTIONHP,
+  _I_CCSMAXS,
+  _I_CCSPACK,
+  _I_CCSCRUNCH1,
+  _I_CCSCRUNCH2,
+  _I_CCSSCRE,
+  _I_CCSSPEC,
+  _I_CCSEXEC,
+  _I_CCSUNKN,
+  _I_CCSHACK,
+  _I_CELERIP,
+  _I_CFBCOD1,
+  _I_CFBCOD2,
+  _I_CRUEL22,
+  _I_CRUELFAST2,
+  _I_CRUEL2MHZ,
+  _I_CRUEL_X,
+  _I_CRUELMS15,
+  _I_CRUELMS10,
+  _I_CRUELMS1X,
+  _I_CRUELMS_U,
+  _I_CRUMSABS,
+  _I_CRUELFAST4,
+  _I_CRUEL_HDR,
+  _I_CRUEL_H22,
+  _I_CRUEL_H20,
+  _I_CRUEL_HTC,
+  _I_CRUEL20,
+  _I_CRUEL21,
+  _I_CRUEL_ILS,
+  _I_CRUEL_RND,
+  _I_CRUEL_TKC,
+  _I_CRUEL12,
+  _I_CRUEL10,
+  _I_CRUEL14,
+  _I_TABOOCRUSH,
+  _I_TABOOCRNCH,
+  _I_TABOOPACK,
+  _I_TABOOPACK64,
+  _I_CNOACK,
+  _I_CNOACKLXT,
+  _I_DARKSQ08,
+  _I_DARKSQ21,
+  _I_DARKSQ2X,
+  _I_DARKSQ4,
+  _I_DARKSQF4,
+  _I_DARKSQXTC,
+  _I_DARKSQWOW,
+  _I_DARKSQGP,
+  _I_DARKSQDOM,
+  _I_DARKSQPAR,
+  _I_DARKSQ4SHK,
+  _I_DARKSQ22,
+  _I_DARKSQBB1,
+  _I_DARKSQBB2,
+  _I_DDINTROC,
+  _I_DSCCOD,
+  _I_EASTLINK,
+  _I_ECA,
+  _I_ECAOLD,
+  _I_ENIGMAMFFL,
+  _I_EQBYTEC12,
+  _I_EQBYTEC14,
+  _I_EQBYTEC17,
+  _I_EQBYTEC19,
+  _I_EQBYTEC19TAL,
+  _I_EXOM,
+  _I_EXOM3,
+  _I_EXOM302,
+  _I_EXPERT27,
+  _I_EXPERT29,
+  _I_EXPERT29EUC,
+  _I_EXPERT2X,
+  _I_EXPERT20,
+  _I_EXPERT21,
+  _I_EXPERT4X,
+  _I_EXPERT3X,
+  _I_EXPERTASS,
+  _I_EXPERT1X,
+  _I_EXPERT211,
+  _I_EXPLCRUNCH1X,
+  _I_EXPLCRUNCH2X,
+  _I_EXPLCRUNCH21,
+  _I_EXPLCRUNCH22,
+  _I_EXPLCOD,
+  _I_EXPLFAC1,
+  _I_EXPLFAC2,
+  _I_XRPOWC71,
+  _I_XREXPLCR,
+  _I_XRPOWC74,
+  _I_FACEPACK10,
+  _I_FACEPACK11,
+  _I_FC3PACK,
+  _I_FC3LD,
+  _I_FC2LD,
+  _I_FCU1LD,
+  _I_FCULD,
+  _I_FCGPACK10,
+  _I_FCGPACK30,
+  _I_FCGPACK12,
+  _I_FCGPACK13,
+  _I_FCGLINK,
+  _I_TFGPACK,
+  _I_TFGCODE,
+  _I_TMCULINK,
+  _I_FCGCODER,
+  _I_HLEISEP,
+  _I_FCGPROT,
+  _I_EXPROT,
+  _I_FLSPROT33,
+  _I_FCCPROT,
+  _I_FDTCOD,
+  _I_FCOMPMTB,
+  _I_FCOMPTMC,
+  _I_FCOMPMTC,
+  _I_FCOMPK2,
+  _I_FCOMPSYS3,
+  _I_FINCOMP,
+  _I_SUPCOMFLEX,
+  _I_SUPCOMEQSE,
+  _I_SUPCOMEQB9,
+  _I_SUPCOMEQCCS,
+  _I_SUPCOMEQC9,
+  _I_SUPCOMEQCH,
+  _I_SUPCOMFH11,
+  _I_SUPCOMFH12,
+  _I_SUPCOMFH13,
+  _I_SUPCOMFH21,
+  _I_SUPCOMHACK,
+  _I_FPCOD,
+  _I_FROGPACK,
+  _I_FRONTPACK,
+  _I_FXBYTEP,
+  _I_FXBP_BBSP,
+  _I_FXBP_BB,
+  _I_FXBP_JW,
+  _I_FXBP_SN,
+  _I_FXBITST,
+  _I_BITST11,
+  _I_GALLEONEQ,
+  _I_GALLCP35,
+  _I_GALLCP36,
+  _I_GALLCP37,
+  _I_GALLCP38,
+  _I_GALLCP39,
+  _I_GALLCP3X,
+  _I_GALLFW4C,
+  _I_GALLFW4C2,
+  _I_GALLFW4C3,
+  _I_GALLFW4C31,
+  _I_GALLBRPR,
+  _I_GALLU02,
+  _I_GALLU100,
+  _I_GALLWHOM1,
+  _I_GALLWHOM11,
+  _I_GALLWHOM2,
+  _I_GALLWHOM4,
+  _I_GALLWHOM4S,
+  _I_GALLVEST,
+  _I_GANDALF,
+  _I_GRAFFITY,
+  _I_HAWK,
+  _I_HTLCOD,
+  _I_IDT10,
+  _I_IDTFX21,
+  _I_IDTFX20,
+  _I_GNTFX20,
+  _I_GNTSTATP,
+  _I_EXCELCOD,
+  _I_IKARICR,
+  _I_ILSCOD,
+  _I_IRELAX1,
+  _I_IRELAX2,
+  _I_IF4CG23,
+  _I_ITRIAD1,
+  _I_ITRIAD2,
+  _I_ITRIAD5,
+  _I_IGP2,
+  _I_I711ID3,
+  _I_IBN1872,
+  _I_IEXIKARI,
+  _I_IIKARI06,
+  _I_IFLT01,
+  _I_IS45109,
+  _I_BN1872PK,
+  _I_ISCN,
+  _I_ISCP,
+  _I_ISCBS
+  //                   , _I_ISEPIC
+  ,
+  _I_ISEPDD,
+  _I_ISEPCT1,
+  _I_ISEPCT2,
+  _I_ISEP7U1,
+  _I_ISEP7U2,
+  _I_ISEPGS1,
+  _I_ISEPNC,
+  _I_ISEPAMG,
+  _I_ISEPGEN,
+  _I_JAZOOCOD,
+  _I_JCTCR,
+  _I_JCTPACK,
+  _I_JOXCR,
+  _I_KOMPSP,
+  _I_KOMP711,
+  _I_KOMPBB,
+  _I_KOMP71PS,
+  _I_KOMP71P1,
+  _I_KOMP71P2,
+  _I_KONCINA,
+  _I_LIGHTM,
+  _I_VISIOM62,
+  _I_VISIOM63,
+  _I_LSMODL,
+  _I_LSPACK,
+  _I_LSLNK2,
+  _I_LOWCR,
+  _I_LSTCOD1,
+  _I_LSTCOD2,
+  _I_LTSPACK,
+  _I_LZMPI1,
+  _I_LZMPI2,
+  _I_MASCHK,
+  _I_MASTCOMP,
+  _I_MASTCRLX,
+  _I_MASTCAGL,
+  _I_MASTCHF,
+  _I_MATCHARP,
+  _I_MATCBASP,
+  _I_MATCDNEQ,
+  _I_MATCDN25,
+  _I_MATCDNFL,
+  _I_MATCLNK2,
+  _I_MATCFLEX,
+  _I_MCCCOMP,
+  _I_MCTSS3,
+  _I_MCTSSIP,
+  _I_MCUNK,
+  _I_MCCRUSH3,
+  _I_MCCOBRA,
+  _I_MCCSCC,
+  _I_MCCRYPT,
+  _I_MDGPACK,
+  _I_MBCR1,
+  _I_MBCR2,
+  _I_MEGCRBD,
+  _I_MEGCR23,
+  _I_MRCROSS1,
+  _I_MRCROSS2,
+  _I_MRDCR1,
+  _I_MRDCRCOD1,
+  _I_MRDLNK2,
+  _I_GSSCO12,
+  _I_MRZPACK,
+  _I_MSICR2,
+  _I_MSICR3,
+  _I_MSICOD,
+  _I_NECPACK,
+  _I_AUSTROV1,
+  _I_AUSTROV2,
+  _I_AUSTROE1,
+  _I_AUSTRO88,
+  _I_BLITZCOM,
+  _I_AUSTRO_U,
+  _I_AUSTROS1,
+  _I_AUSTROBL,
+  _I_PETSPEED,
+  _I_BASIC64,
+  _I_BASICBS,
+  _I_SPEEDCM,
+  _I_SPEEDY64,
+  _I_CC65,
+  _I_CC6522,
+  _I_DTL64,
+  _I_LASERBAS,
+  _I_HYPRA,
+  _I_ISEPICLD,
+  _I_NSUPACK10,
+  _I_NSUPACK11,
+  _I_ONSPACK,
+  _I_OPTIMUS,
+  _I_OPTIMH
+  //                   , _I_OUGCOD
+  ,
+  _I_P100,
+  _I_PAKOPT,
+  _I_PITCOD,
+  _I_POLONCB,
+  _I_POLONKR,
+  _I_POLONAM,
+  _I_POLONEQ,
+  _I_POLON4P,
+  _I_POLON101,
+  _I_QRTPROT,
+  _I_PUCRUNCH,
+  _I_PUCRUNCW,
+  _I_PUCRUNCS,
+  _I_PUCRUNCO,
+  _I_PUCRUNCG,
+  _I_PZWCOM,
+  _I_RAPEQC,
+  _I_RLX3B,
+  _I_RLXP2,
+  _I_SCRCR4,
+  _I_SCRCR6,
+  _I_SCRCRFCG,
+  _I_S8PACK,
+  _I_CRMPACK,
+  _I_SHRPACK,
+  _I_SIRMPACK,
+  _I_SIRMLINK,
+  _I_SIRCOMBIN1,
+  _I_SIRCOMBIN2,
+  _I_SIRCOMBIN3,
+  _I_SKLCOD,
+  _I_SLEDGE10,
+  _I_SLEDGE11,
+  _I_SLEDGE12,
+  _I_SLEDGE1DP,
+  _I_SLEDGE20,
+  _I_SLEDGE21,
+  _I_SLEDGE22,
+  _I_SLEDGE23,
+  _I_SLEDGE24,
+  _I_SLEDGE2C,
+  _I_SLEDGE30,
+  _I_SLEDGETRAP,
+  _I_ULTIM8SH,
+  _I_MWSPCOMP,
+  _I_MWPACK,
+  _I_MWSPCR1,
+  _I_MWSPCR2,
+  _I_SUPCRUNCH,
+  _I_SUPERPACK4,
+  _I_TBCMULTI,
+  _I_TBCMULT2,
+  _I_TBCMULTMOW,
+  _I_TCDLC1,
+  _I_TCDLC2,
+  _I_TCSCR2,
+  _I_TCSCR3,
+  _I_TC40,
+  _I_TC42H,
+  _I_TC40HIL,
+  _I_TCHVIK,
+  _I_TC42,
+  _I_TC43,
+  _I_TC44,
+  _I_TC50,
+  _I_TC51,
+  _I_TC52,
+  _I_TC53,
+  _I_TC5GEN,
+  _I_TC30,
+  _I_TC31,
+  _I_TC33,
+  _I_TC2MHZ1,
+  _I_TC2MHZ2,
+  _I_TC32061,
+  _I_TCMC4,
+  _I_TC3RWE,
+  _I_TC32072,
+  _I_TC3RAD,
+  _I_TC32074,
+  _I_TC3FPE,
+  _I_TC3FBI,
+  _I_TC3TRI,
+  _I_TC3HTL,
+  _I_TC3ENT,
+  _I_TCGENH,
+  _I_TCFPEX,
+  _I_TCSIR1,
+  _I_TCUNKH,
+  _I_TCSIR4,
+  _I_TCSIR3,
+  _I_TCSIR2,
+  _I_TC5SC,
+  _I_TC3RLX,
+  _I_TC33AD,
+  _I_TC3PC,
+  _I_TC423AD,
+  _I_TC42GEN,
+  _I_TC3TDF,
+  _I_TC3ATC,
+  _I_TC3F4CG,
+  _I_TC3HSCG,
+  _I_TC3HSFE,
+  _I_TC3TTN,
+  _I_TC3MULE,
+  _I_TC3AGILE,
+  _I_TC3S451,
+  _I_TC3S451V2,
+  _I_TC3IKARI,
+  _I_TC3U,
+  _I_TMCCOD,
+  _I_TMMPACK,
+  _I_TRASHC1,
+  _I_TRASHC2,
+  _I_TRASHCU,
+  _I_TRIANP,
+  _I_TRIAN2,
+  _I_TRIAN3,
+  _I_TRIANC,
+  _I_TSBP1,
+  _I_TSBP21,
+  _I_TSBP3,
+  _I_TSMCOD,
+  _I_TSMPACK,
+  _I_TURBOP,
+  _I_ULTRAC3,
+  _I_UNIPACK1,
+  _I_UNIPACK2,
+  _I_UNIPACK3,
+  _I_U_100_P2,
+  _I_U_100_P3,
+  _I_U_100_P4,
+  _I_U_100_P5,
+  _I_U_101,
+  _I_U_111,
+  _I_ROWS,
+  _I_FALCOP,
+  _I_PSQLINK1,
+  _I_U_439,
+  _I_ENTROPYPK,
+  _I_U_8E,
+  _I_U_25,
+  _I_DSCCR,
+  _I_DSCPK,
+  _I_DSCPK2,
+  _I_KRESS,
+  _I_U_1WF2,
+  _I_U_1WDA,
+  _I_GENSYSL,
+  _I_U_P3,
+  _I_U_3ADCR,
+  _I_VIP1X,
+  _I_VIP20,
+  _I_VIP3X,
+  _I_TOTP1X,
+  _I_TOTP20,
+  _I_HIT02,
+  _I_HIT20,
+  _I_AGNUS02,
+  _I_BUK02,
+  _I_WARLOCK,
+  _I_WCCMC,
+  _I_WDRPROT,
+  _I_WDRLAMEK,
+  _I_WGICOD,
+  _I_3CZIP,
+  _I_4CZIP,
+  _I_4CZIP2S,
+  _I_XTERM,
+  _I_ILSCOMP2X,
+  _I_ILSCOMP3X,
+  _I_3CZIP2,
+  _I_XDSV1,
+  _I_XDSV2,
+  _I_XDSV3,
+  _I_XDSK1,
+  _I_XDSK2,
+  _I_XDSK3,
+  _I_XIP,
+  _I_XTC10,
+  _I_XTC21,
+  _I_XTC22,
+  _I_XTC23,
+  _I_XTC23GP,
+  _I_XTC2XGP,
+  _I_ZIGAG,
+  _I_ZIP50C,
+  _I_ZIP50H,
+  _I_ZIP511,
+  _I_ZIP512,
+  _I_ZIP513,
+  _I_ZIP51XEN,
+  _I_ZIP3,
+  _I_ZIP8,
+  _I_STLPROT
+  //                   , _I_GRFBIN
+  ,
+  _I_ABYSSCOD1,
+  _I_ABYSSCOD2,
+  _I_SPCCOD,
+  _I_SPCPROT,
+  _I_COBRACOD,
+  _I_FSWPACK1,
+  _I_FSWPACK2,
+  _I_FSWPACK3,
+  _I_FSWPROT,
+  _I_BAMCOD1,
+  _I_BAMCOD2,
+  _I_BAMCOD3,
+  _I_BYTEBUST4L,
+  _I_BYTEBUST4H,
+  _I_MEKKER,
+  _I_BYTESTRN
+  //                   , _I_JEDILINK1
+  //                   , _I_JEDILINK2
+  //                   , _I_JEDIPACK
+  ,
+  _I_PRIDE,
+  _I_STARCRUNCH,
+  _I_SPYPACK,
+  _I_PETPACK,
+  _I_GPACK,
+  _I_CADAVERPACK,
+  _I_HELMET2
+  //                   , _I_ANTICOM
+  //                   , _I_ANTIRAM1
+  //                   , _I_ANTIRAM2
+  ,
+  _I_GCSAUTO,
+  _I_AUTOFLG,
+  _I_EXCPACK,
+  _I_EXCCOD,
+  _I_CNCD,
+  _I_4WD,
+  _I_1WMKL2,
+  _I_EMUFUX1,
+  _I_EMUFUX2,
+  _I_HUFFER,
+  _I_HUFFERQC,
+  _I_NM156PACK,
+  _I_NM156LINK,
+  _I_RATTPACK,
+  _I_RATTLINK,
+  _I_BYTERAPERS1,
+  _I_BYTERAPERS2,
+  _I_CIACRP,
+  _I_PANPACK,
+  _I_PANPACK2,
+  _I_TKCEQB1,
+  _I_TKCEQB2,
+  _I_UPROT420,
+  _I_HIVIRUS,
+  _I_BHPVIRUS,
+  _I_BULAVIRUS,
+  _I_CODERVIRUS,
+  _I_BOAVIRUS,
+  _I_PLUSHZ,
+  _I_PLUSHZS,
+  _I_REBELP,
+  _I_YETICOD,
+  _I_CHGPROT2,
+  _I_PDPACK1,
+  _I_PDPACK2,
+  _I_PDPACK30,
+  _I_PDPACK31,
+  _I_PDPACK32,
+  _I_PDEQLZ15
+  //                   , _I_THSCOD
+  ,
+  _I_PWCOPSH,
+  _I_PWTIMEC,
+  _I_PWSNACKY,
+  _I_PWTCD,
+  _I_PWJCH,
+  _I_PWFILEPR,
+  _I_PWFLT,
+  _I_WHO
+  //                   , _I_PYRACOD1
+  //                   , _I_PYRACOD2
+  ,
+  _I_BFPACK,
+  _I_THUNCATSPK,
+  _I_ACTIONP,
+  _I_KGBCOD,
+  _I_CCRYPT,
+  _I_TDT,
+  _I_TDTPETC1,
+  _I_TDTPETC2,
+  _I_TDTPETCU,
+  _I_TDTPETL,
+  _I_CULT,
+  _I_GIMZO,
+  _I_BETASKIP,
+  _I_BLACKADDER,
+  _I_ICS8,
+  _I_PARADROID1,
+  _I_PARADROID2,
+  _I_PARADROIDL,
+  _I_PLASMACOD,
+  _I_DRZOOM,
+  _I_TIMCR,
+  _I_EXACTCOD,
+  _I_CNETFIX
+  //                   , _I_TRIANGLECOD
+  ,
+  _I_SFLINK,
+  _I_BONGO,
+  _I_JEMABASIC,
+  _I_TATCOD,
+  _I_RFOCOD,
+  _I_DOYNAMITE,
+  _I_BITNAX,
+  _I_NIBBIT,
+  _I_UAPACK,
+  _I_KREATOR,
+  _I_ADP4KBAR,
+  _I_ZIPLINK21,
+  _I_ZIPLINK25,
+  _I_ZEROCOD,
+  _I_NUCRUNCH,
+  _I_TINYCRUN09,
+  _I_TINYCRUNCH,
+  _I_FLINKSDA,
+  _I_DSCTITMK,
+  _I_INCERIAPK
+};

--- a/terps/unp64/unp64_interface.h
+++ b/terps/unp64/unp64_interface.h
@@ -1,0 +1,15 @@
+//
+//  unp64_interface.h
+//
+//  Created by Petter Sjölund on 2022-01-31.
+//
+
+#ifndef unp64_interface_h
+#define unp64_interface_h
+
+#include <stdint.h>
+
+int unp64(uint8_t *compressed, size_t length, uint8_t *destination_buffer,
+          size_t *final_length, char *settings[], int numsettings);
+
+#endif /* unp64_interface_h */


### PR DESCRIPTION
I finally got a reply from Magnus Lind, author of the Exomizer tool, which Unp64 borrows a lot of code from. He agrees to let us distribute his code under the zlib license, but it turns out neither of us is sure how to best do this formally. He supplied this statement:

>The copyright holder of the Exomizer code, Magnus Lind, hereby dual licenses the code from Exomizer used in unp64. It is now also available under the Zlib-license which makes it compatible with the GPL. (https://en.wikipedia.org/wiki/Zlib_License).

I've tried to update the copyright text in the source and updated our version of Unp64 to work with the latest TaylorMade and ScottFree changes. There is probably still too much code left in there that just prints information to the console and can't be switched off.