### PR TITLE
Reduce usage of std::map where possible

### DIFF
--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -22,10 +22,10 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
-#include <map>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -78,11 +78,11 @@ public:
 private:
     FontFace m_fontface;
     FT_Face m_face = nullptr;
-    std::map<glui32, FontEntry> m_entries;
+    std::unordered_map<glui32, FontEntry> m_entries;
     bool m_make_bold = false;
     bool m_make_oblique = false;
     bool m_kerned = false;
-    std::map<std::pair<glui32, glui32>, int> m_kerncache;
+    std::unordered_map<unsigned long long, int> m_kerncache;
 };
 
 //
@@ -554,7 +554,7 @@ int Font::charkern(glui32 c0, glui32 c1)
         return 0;
     }
 
-    auto key = std::make_pair(c0, c1);
+    unsigned long long key = (static_cast<unsigned long long>(c0) << 32) | c1;
     try {
         return m_kerncache.at(key);
     } catch (const std::out_of_range &) {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -36,9 +36,9 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -355,7 +355,7 @@ public:
     std::vector<std::uint8_t> &at(int number);
 
 private:
-    std::map<int, nonstd::optional<std::vector<std::uint8_t>>> m_bleeps = {
+    std::unordered_map<int, nonstd::optional<std::vector<std::uint8_t>>> m_bleeps = {
         {1, nonstd::nullopt},
         {2, nonstd::nullopt},
     };

--- a/garglk/imgload.cpp
+++ b/garglk/imgload.cpp
@@ -20,10 +20,10 @@
 #include <array>
 #include <cstdio>
 #include <functional>
-#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <jpeglib.h>
@@ -44,7 +44,7 @@ struct PicturePair {
     std::shared_ptr<picture_t> scaled;
 };
 
-std::map<unsigned long, PicturePair> picstore;
+static std::unordered_map<unsigned long, PicturePair> picstore;
 
 static int gli_piclist_refcount = 0; // count references to loaded pictures
 
@@ -144,7 +144,7 @@ std::shared_ptr<picture_t> gli_picture_load(unsigned long id)
         std::fseek(fl.get(), pos, SEEK_SET);
     }
 
-    const std::map<int, std::function<std::shared_ptr<picture_t>(FILE *, unsigned long)>> loaders = {
+    const std::unordered_map<int, std::function<std::shared_ptr<picture_t>(FILE *, unsigned long)>> loaders = {
         {giblorb_ID_PNG, load_image_png},
         {giblorb_ID_JPEG, load_image_jpeg},
     };

--- a/garglk/launcher.cpp
+++ b/garglk/launcher.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <fstream>
 #include <iomanip>
-#include <map>
 #include <memory>
 #include <regex>
 #include <set>
@@ -29,6 +28,7 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -98,7 +98,7 @@ enum class Format {
 
 static nonstd::optional<Format> probe(const std::vector<char> &header)
 {
-    std::map<std::string, Format> magic = {
+    std::vector<std::pair<std::string, Format>> magic = {
         {R"(^[\x01\x02\x03\x04\x05\x07\x08][\s\S]{17}\d{6})", Format::ZCode},
         {R"(^\x06[\s\S]{17}\d{6})", Format::ZCode6},
         {R"(^TADS2 bin\x0a\x0d\x1a)", Format::TADS2},
@@ -125,7 +125,7 @@ static nonstd::optional<Format> probe(const std::vector<char> &header)
 }
 
 // Map extensions to formats
-static const std::map<std::string, Format> extensions = {
+static const std::unordered_map<std::string, Format> extensions = {
     {"taf", Format::Adrift},
     {"agx", Format::AGT},
     {"d$$", Format::AGT},
@@ -155,7 +155,7 @@ static const std::map<std::string, Format> extensions = {
 };
 
 // Map formats to default interpreters
-static const std::map<Format, Interpreter> interpreters = {
+static const std::unordered_map<Format, Interpreter> interpreters = {
     {Format::Adrift, Interpreter(T_ADRIFT)},
     {Format::AdvSys, Interpreter(T_ADVSYS)},
     {Format::AGT, Interpreter(T_AGT, "-gl")},

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -21,9 +21,9 @@
 #include "launcher.h"
 
 #include <cstdlib>
-#include <map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 #import <Cocoa/Cocoa.h>
 #import <OpenGL/gl.h>
@@ -37,7 +37,7 @@ static const char *AppName = GARGOYLE_NAME " " GARGOYLE_VERSION;
 
 static std::string winpath();
 
-static const std::map<FileFilter, std::string> winfilters = {
+static const std::unordered_map<FileFilter, std::string> winfilters = {
     {FileFilter::Save, "glksave"},
     {FileFilter::Text, "txt"},
     {FileFilter::Data, "glkdata"},

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -72,6 +72,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -90,7 +91,7 @@
 static QString cliptext;
 
 // filters and extensions for file dialogs
-static const std::map<FileFilter, std::pair<QString, QString>> filters = {
+static const std::unordered_map<FileFilter, std::pair<QString, QString>> filters = {
     {FileFilter::Save, std::make_pair("Saved game files (*.glksave *.sav)", "glksave")},
     {FileFilter::Text, std::make_pair("Text files (*.txt)", "txt")},
     {FileFilter::Data, std::make_pair("Data files (*.glkdata)", "glkdata")},


### PR DESCRIPTION
In general this means going to std::unordered_map, though in one case a switch to std::vector made sense.