### PR TITLE
Prevent distorted image on Mac by forcing window width to even

### DIFF
--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -613,6 +613,12 @@ static BOOL isTextbufferEvent(NSEvent *evt)
     return self;
 }
 
+- (NSSize)windowWillResize:(NSWindow *)sender
+                    toSize:(NSSize)frameSize {
+    frameSize.width += (NSUInteger)frameSize.width & 1;
+    return frameSize;
+}
+
 - (BOOL) initWindow: (pid_t) processID
               width: (unsigned int) width
              height: (unsigned int) height

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -405,6 +405,7 @@ void winopen()
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
     unsigned int defw = gli_wmarginx * 2 + gli_cellw * gli_cols / BACKING_SCALE_FACTOR;
+    defw += defw & 1;
     unsigned int defh = gli_wmarginy * 2 + gli_cellh * gli_rows / BACKING_SCALE_FACTOR;
     NSColor *windowColor = [NSColor colorWithCalibratedRed: (float) gli_window_color[0] / 255.0f
                                                      green: (float) gli_window_color[1] / 255.0f


### PR DESCRIPTION
~~It feels a little silly to make a pull request for such a tiny change, but this is meant as a starting point for finding a fix for #679. This one-liner seems to prevent the shearing from happening at startup if `cols` is set to an odd value, but it will still occur if the window is resized manually to an odd width. I tried adding a similar line to the `winresize()`, but it didn't help.~~

Edit: Adding a delegate method that makes sure that all window size changes end up with an even width fixes it completely for me. Of course, there is probably some deeper cause of this that we should fix instead.