### PR TITLE
Fix/work around non-prototype declarations

### DIFF
--- a/terps/CMakeLists.txt
+++ b/terps/CMakeLists.txt
@@ -269,6 +269,12 @@ if(WITH_JACL)
     if(CMAKE_C_COMPILER_ID MATCHES "Clang$")
         # This is a style choice in the code.
         target_compile_options(jacl PRIVATE "-Wno-parentheses-equality")
+
+        # Non-prototype (K&R) declarations have been fixed in JACL's Git
+        # repository, but there hasn't been a release yet since then, so
+        # just ignore the warnings here; remove in the future when a new
+        # JACL is upstreamed.
+        target_compile_options(jacl PRIVATE "-Wno-deprecated-non-prototype")
     endif()
 endif()
 

--- a/terps/advsys/advjunk.c
+++ b/terps/advsys/advjunk.c
@@ -38,8 +38,7 @@ void waitch()
 #endif
 }
 
-void putch(ch,fp)
-  int ch; FILE *fp;
+void putch(int ch, FILE *fp)
 {
 #ifdef UNIX
     putc(ch,fp);


### PR DESCRIPTION
Clang now warns about K&R-style declarations, so either fix them (where feasible) or hide them (where necessary). JACL's next release should include fixes, so just hiding the warnings here is fine (there's nothing "wrong" technically with K&R-style declarations).