### PR TITLE
TAYLOR: Don't print unit separators

### DIFF
--- a/terps/plus/animations.c
+++ b/terps/plus/animations.c
@@ -7,10 +7,12 @@
 
 #include <stdlib.h>
 #include <string.h>
+
+#include "common.h"
 #include "definitions.h"
 #include "glk.h"
-#include "common.h"
 #include "graphics.h"
+
 #include "animations.h"
 
 #define ANIMATION_RATE 200
@@ -28,7 +30,6 @@ static int AnimationStage = 0;
 static int StopNext = 0;
 static int ImgTail = 0;
 static int FramesTail = 0;
-
 
 static char *AnimationFilenames[MAX_ANIM_FRAMES];
 static int AnimationFrames[MAX_ANIM_FRAMES];
@@ -50,7 +51,8 @@ static int CannonAnimationPause = 0;
 int STWebAnimation = 0;
 int STWebAnimationFinished = 1;
 
-void AddImageToBuffer(char *basename) {
+void AddImageToBuffer(char *basename)
+{
     if (ImgTail >= MAX_ANIM_FRAMES - 1)
         return;
     size_t len = strlen(basename) + 1;
@@ -62,7 +64,8 @@ void AddImageToBuffer(char *basename) {
     AnimationFilenames[ImgTail] = NULL;
 }
 
-void AddFrameToBuffer(int frameidx) {
+void AddFrameToBuffer(int frameidx)
+{
     if (FramesTail >= MAX_ANIM_FRAMES - 1)
         return;
     debug_print("AddFrameToBuffer: Setting AnimationFrames[%d] to %d\n", FramesTail, frameidx);
@@ -70,21 +73,24 @@ void AddFrameToBuffer(int frameidx) {
     AnimationFrames[FramesTail] = -1;
 }
 
-void AddRoomImage(int image) {
+void AddRoomImage(int image)
+{
     char *shortname = ShortNameFromType('R', image);
     AddImageToBuffer(shortname);
     free(shortname);
     STWebAnimation = 0;
 }
 
-void AddItemImage(int image) {
+void AddItemImage(int image)
+{
     char *shortname = ShortNameFromType('B', image);
     AddImageToBuffer(shortname);
     free(shortname);
     STWebAnimation = 0;
 }
 
-void AddSpecialImage(int image) {
+void AddSpecialImage(int image)
+{
 
     if (CurrentSys == SYS_ST && CurrentGame == SPIDERMAN) {
         if (image == 14) {
@@ -103,7 +109,8 @@ void AddSpecialImage(int image) {
     free(shortname);
 }
 
-void SetAnimationTimer(glui32 milliseconds) {
+void SetAnimationTimer(glui32 milliseconds)
+{
     debug_print("SetAnimationTimer %d\n", milliseconds);
     AnimTimerRate = milliseconds;
     if (milliseconds == 0 && ColorCyclingRunning)
@@ -114,7 +121,8 @@ void SetAnimationTimer(glui32 milliseconds) {
     }
 }
 
-void Animate(int frame) {
+void Animate(int frame)
+{
 
     if (Images[0].Filename == NULL)
         return;
@@ -149,7 +157,8 @@ void Animate(int frame) {
         PostCannonAnimationSeam = 1;
 }
 
-void ClearAnimationBuffer(void) {
+void ClearAnimationBuffer(void)
+{
 
     if (PostCannonAnimationSeam)
         return;
@@ -163,21 +172,24 @@ void ClearAnimationBuffer(void) {
     FramesTail = 0;
 }
 
-void ClearFrames(void) {
+void ClearFrames(void)
+{
     for (int i = 0; i < FramesTail; i++) {
         AnimationFrames[i] = -1;
     }
     FramesTail = 0;
 }
 
-void InitAnimationBuffer(void) {
+void InitAnimationBuffer(void)
+{
     for (int i = 0; i < MAX_ANIM_FRAMES; i++) {
         AnimationFilenames[i] = NULL;
         AnimationFrames[i] = -1;
     }
 }
 
-void StopAnimation(void) {
+void StopAnimation(void)
+{
     SetAnimationTimer(0);
     debug_print("StopAnimation: stopped timer\n");
     AnimationStage = 0;

--- a/terps/plus/animations.h
+++ b/terps/plus/animations.h
@@ -29,5 +29,4 @@ extern int ColorCyclingRunning;
 extern int AnimationBackground;
 extern int LastAnimationBackground;
 
-
 #endif /* animations_h */

--- a/terps/plus/apple2detect.c
+++ b/terps/plus/apple2detect.c
@@ -9,9 +9,9 @@
 #include <string.h>
 
 #include "common.h"
+#include "companionfile.h"
 #include "definitions.h"
 #include "graphics.h"
-#include "companionfile.h"
 
 #include "apple2detect.h"
 
@@ -23,7 +23,7 @@ typedef struct imglist {
 static const imglist a2listFantastic[] = {
     { "R001", 0x1e800 },
     { "R002", 0x1df00 },
-    { "R004", 0x1db00},
+    { "R004", 0x1db00 },
     { "R005", 0x1cb00 },
     { "R006", 0x1c200 },
     { "R007", 0x1bb00 },
@@ -102,7 +102,7 @@ static const imglist a2listSpidey[] = {
     { "R017", 0x16100 },
     { "R018", 0xce00 },
     { "R019", 0x13400 },
-    { "R022", 0x12400},
+    { "R022", 0x12400 },
     { "R024", 0x10000 },
     { "R025", 0x15700 },
     { "R034", 0x14f00 },
@@ -281,25 +281,26 @@ int DetectApple2(uint8_t **sf, size_t *extent)
     return 0;
 }
 
-void LookForApple2Images(void) {
+void LookForApple2Images(void)
+{
     if (new == NULL)
         return;
 
     const struct imglist *list = a2listSpidey;
 
-    switch(CurrentGame) {
-        case SPIDERMAN:
-            list = a2listSpidey;
-            break;
-        case BANZAI:
-            list = a2listBanzai;
-            break;
-        case FANTASTIC4:
-            list = a2listFantastic;
-            break;
-        default:
-            Fatal("Unknown game!");
-            break;
+    switch (CurrentGame) {
+    case SPIDERMAN:
+        list = a2listSpidey;
+        break;
+    case BANZAI:
+        list = a2listBanzai;
+        break;
+    case FANTASTIC4:
+        list = a2listFantastic;
+        break;
+    default:
+        Fatal("Unknown game!");
+        break;
     }
 
     int count = Game->no_of_room_images + Game->no_of_item_images + Game->no_of_special_images;
@@ -428,4 +429,3 @@ void LookForApple2Images(void) {
     Images[created].Filename = NULL;
     free(new);
 }
-

--- a/terps/plus/apple2draw.c
+++ b/terps/plus/apple2draw.c
@@ -9,15 +9,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common.h"
 #include "definitions.h"
 #include "glk.h"
 #include "graphics.h"
-#include "common.h"
 
 static uint8_t *screenmem = NULL;
 static uint8_t lobyte = 0, hibyte = 0;
 
-void ClearApple2ScreenMem(void) {
+void ClearApple2ScreenMem(void)
+{
     if (screenmem)
         memset(screenmem, 0, 0x2000);
 }
@@ -50,7 +51,7 @@ void DrawApple2ImageFromVideoMem(void);
 
 int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
 {
-    int work,work2;
+    int work, work2;
     int c;
     int i;
     size_t size;
@@ -62,7 +63,8 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
         ClearApple2ScreenMem();
     }
 
-    x = 0; y = 0;
+    x = 0;
+    y = 0;
 
     work = *ptr++;
     size = work + (*ptr++ * 256);
@@ -92,23 +94,19 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
         winid_t parent = glk_window_get_parent(Graphics);
         if (parent) {
             glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                   optimal_height, NULL);
+                optimal_height, NULL);
         }
     }
 
-
-    while (ptr - origptr < size)
-    {
+    while (ptr - origptr < size) {
         // First get count
         c = *ptr++;
 
-        if ((c & 0x80) == 0x80)
-        { // is a counter
+        if ((c & 0x80) == 0x80) { // is a counter
             c &= 0x7f;
-            work=*ptr++;
-            work2=*ptr++;
-            for (i = 0; i < c + 1 && ptr - origptr < size; i++)
-            {
+            work = *ptr++;
+            work2 = *ptr++;
+            for (i = 0; i < c + 1 && ptr - origptr < size; i++) {
                 if (hibyte * 0x100 + lobyte + x > 0x1fff)
                     return 0;
                 PutByte(work, work2);
@@ -116,15 +114,12 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
                     return 1;
                 }
             }
-        }
-        else
-        {
+        } else {
             // Don't count on the next j characters
 
-            for (i = 0; i < c + 1 && ptr - origptr < size; i++)
-            {
+            for (i = 0; i < c + 1 && ptr - origptr < size; i++) {
                 work = *ptr++;
-                work2=*ptr++;
+                work2 = *ptr++;
                 if (hibyte * 0x100 + lobyte + x > 0x1fff)
                     return 0;
                 PutByte(work, work2);
@@ -155,9 +150,10 @@ static void PutApplePixel(glsi32 xpos, glsi32 ypos, glui32 color)
     ypos += y_offset;
 
     glk_window_fill_rect(Graphics, color, xpos,
-                         ypos, pixel_size, pixel_size);
+        ypos, pixel_size, pixel_size);
 }
 
+// clang-format off
 #define BLACK   0
 #define PURPLE  0xd53ef9
 #define BLUE    0x458ff7
@@ -170,13 +166,15 @@ static const int32_t hires_artifact_color_table[] =
     BLACK,  PURPLE, GREEN,  WHITE,
     BLACK,  BLUE,   ORANGE, WHITE
 };
+// clang-format on
 
 static int32_t *m_hires_artifact_map = NULL;
 
 // This function and the one below are adapted from MAME
 
-static void generate_artifact_map(void) {
-// generate hi-res artifact data
+static void generate_artifact_map(void)
+{
+    // generate hi-res artifact data
     int i, j;
     uint16_t c;
 
@@ -184,26 +182,21 @@ static void generate_artifact_map(void) {
     m_hires_artifact_map = MemAlloc(sizeof(int32_t) * 8 * 2 * 2);
 
     /* build hires artifact map */
-    for (i = 0; i < 8; i++)
-    {
-        for (j = 0; j < 2; j++)
-        {
-            if (i & 0x02)
-            {
+    for (i = 0; i < 8; i++) {
+        for (j = 0; j < 2; j++) {
+            if (i & 0x02) {
                 if ((i & 0x05) != 0)
                     c = 3;
                 else
                     c = j ? 2 : 1;
-            }
-            else
-            {
+            } else {
                 if ((i & 0x05) == 0x05)
                     c = j ? 1 : 2;
                 else
                     c = 0;
             }
-            m_hires_artifact_map[ 0 + j*8 + i] = hires_artifact_color_table[(c + 0) % 8];
-            m_hires_artifact_map[16 + j*8 + i] = hires_artifact_color_table[(c + 4) % 8];
+            m_hires_artifact_map[0 + j * 8 + i] = hires_artifact_color_table[(c + 0) % 8];
+            m_hires_artifact_map[16 + j * 8 + i] = hires_artifact_color_table[(c + 4) % 8];
         }
     }
 }
@@ -220,30 +213,25 @@ void DrawApple2ImageFromVideoMem(void)
     vram_row[0] = 0;
     vram_row[41] = 0;
 
-    for (int row = 0; row < 192; row++)
-    {
-        for (int col = 0; col < 40; col++)
-        {
-            int const offset = ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5 + col)) | ((row & 7) << 10);
-            vram_row[1+col] = vram[offset];
+    for (int row = 0; row < 192; row++) {
+        for (int col = 0; col < 40; col++) {
+            int const offset = ((((row / 8) & 0x07) << 7) | (((row / 8) & 0x18) * 5 + col)) | ((row & 7) << 10);
+            vram_row[1 + col] = vram[offset];
         }
 
         int pixpos = 0;
 
-        for (int col = 0; col < 40; col++)
-        {
-            uint32_t w =    (((uint32_t) vram_row[col+0] & 0x7f) <<  0)
-            |   (((uint32_t) vram_row[col+1] & 0x7f) <<  7)
-            |   (((uint32_t) vram_row[col+2] & 0x7f) << 14);
+        for (int col = 0; col < 40; col++) {
+            uint32_t w = (((uint32_t)vram_row[col + 0] & 0x7f) << 0)
+                | (((uint32_t)vram_row[col + 1] & 0x7f) << 7)
+                | (((uint32_t)vram_row[col + 2] & 0x7f) << 14);
 
             artifact_map_ptr = &m_hires_artifact_map[((vram_row[col + 1] & 0x80) >> 7) * 16];
 
-            for (int b = 0; b < 7; b++)
-            {
-                int32_t const v = artifact_map_ptr[((w >> (b + 7-1)) & 0x07) | (((b ^ col) & 0x01) << 3)];
+            for (int b = 0; b < 7; b++) {
+                int32_t const v = artifact_map_ptr[((w >> (b + 7 - 1)) & 0x07) | (((b ^ col) & 0x01) << 3)];
                 PutApplePixel(pixpos++, row, v);
             }
         }
     }
 }
-

--- a/terps/plus/atari8c64draw.c
+++ b/terps/plus/atari8c64draw.c
@@ -13,42 +13,49 @@
 
 #include "common.h"
 #include "definitions.h"
-#include "graphics.h"
 #include "glk.h"
+#include "graphics.h"
 
 static void DrawA8C64Pixels(int pattern, int pattern2)
 {
-    int pix1,pix2,pix3,pix4;
+    int pix1, pix2, pix3, pix4;
 
-    if (x>(xlen - 3)*8)
-      return;
+    if (x > (xlen - 3) * 8)
+        return;
 
-    pix1 = (pattern & 0xc0)>>6;
-    pix2 = (pattern & 0x30)>>4;
-    pix3 = (pattern & 0x0c)>>2;
+    pix1 = (pattern & 0xc0) >> 6;
+    pix2 = (pattern & 0x30) >> 4;
+    pix3 = (pattern & 0x0c) >> 2;
     pix4 = (pattern & 0x03);
 
-    PutDoublePixel(x,y, pix1); x += 2;
-    PutDoublePixel(x,y, pix2); x += 2;
-    PutDoublePixel(x,y, pix3); x += 2;
-    PutDoublePixel(x,y, pix4); x += 2;
-    y++;
-    x-=8;
-
-    pix1=(pattern2 & 0xc0)>>6;
-    pix2=(pattern2 & 0x30)>>4;
-    pix3=(pattern2 & 0x0c)>>2;
-    pix4=(pattern2 & 0x03);
-
-    PutDoublePixel(x,y, pix1); x += 2;
-    PutDoublePixel(x,y, pix2); x += 2;
-    PutDoublePixel(x,y, pix3); x += 2;
-    PutDoublePixel(x,y, pix4); x += 2;
+    PutDoublePixel(x, y, pix1);
+    x += 2;
+    PutDoublePixel(x, y, pix2);
+    x += 2;
+    PutDoublePixel(x, y, pix3);
+    x += 2;
+    PutDoublePixel(x, y, pix4);
+    x += 2;
     y++;
     x -= 8;
 
-    if (y > ylen)
-    {
+    pix1 = (pattern2 & 0xc0) >> 6;
+    pix2 = (pattern2 & 0x30) >> 4;
+    pix3 = (pattern2 & 0x0c) >> 2;
+    pix4 = (pattern2 & 0x03);
+
+    PutDoublePixel(x, y, pix1);
+    x += 2;
+    PutDoublePixel(x, y, pix2);
+    x += 2;
+    PutDoublePixel(x, y, pix3);
+    x += 2;
+    PutDoublePixel(x, y, pix4);
+    x += 2;
+    y++;
+    x -= 8;
+
+    if (y > ylen) {
         x += 8;
         y = yoff;
     }
@@ -70,7 +77,6 @@ static const RGB lred = { 231, 154, 132 };
 static const RGB grey = { 167, 167, 167 };
 static const RGB lgreen = { 192, 255, 185 };
 static const RGB lblue = { 162, 143, 255 };
-
 
 /* Atari 8-bit colors */
 static const RGB cyan = { 0x9c, 0xe2, 0xc5 };
@@ -95,107 +101,108 @@ static const RGB algreen = { 0x5f, 0x8f, 0x00 };
 static const RGB tan = { 0xaf, 0x99, 0x3a };
 static const RGB lilac = { 0x83, 0x58, 0xee };
 
-static void TranslateAtariColor(int index, uint8_t value) {
-    switch(value) {
-        case 0:
-        case 224:
-            SetColor(index,&black);
-            break;
-        case 5:
-        case 7:
-            SetColor(index,&agrey);
-            break;
-        case 6:
-        case 8:
-            SetColor(index,&ablue);
-            break;
-        case 9:
-        case 10:
-        case 12:
-            SetColor(index,&lgrey);
-            break;
-        case 14:
-            SetColor(index,&white);
-            break;
-        case 17:
-        case 32:
-        case 36:
-            SetColor(index,&dbrown);
-            break;
-        case 40:
+static void TranslateAtariColor(int index, uint8_t value)
+{
+    switch (value) {
+    case 0:
+    case 224:
+        SetColor(index, &black);
+        break;
+    case 5:
+    case 7:
+        SetColor(index, &agrey);
+        break;
+    case 6:
+    case 8:
+        SetColor(index, &ablue);
+        break;
+    case 9:
+    case 10:
+    case 12:
+        SetColor(index, &lgrey);
+        break;
+    case 14:
+        SetColor(index, &white);
+        break;
+    case 17:
+    case 32:
+    case 36:
+        SetColor(index, &dbrown);
+        break;
+    case 40:
+        SetColor(index, &aorange);
+        break;
+    case 54:
+        if (CurrentGame == FANTASTIC4)
             SetColor(index, &aorange);
-            break;
-        case 54:
-            if (CurrentGame == FANTASTIC4)
-                SetColor(index, &aorange);
-            else
-                SetColor(index,&dred);
-            break;
-        case 56:
-            SetColor(index,&alred);
-            break;
-        case 58:
-        case 60:
-            SetColor(index,&beige);
-            break;
-        case 69:
-        case 71:
-            SetColor(index,&deeppurple);
-            break;
-        case 68:
-        case 103:
-            SetColor(index,&apurple);
-            break;
-        case 89:
-            SetColor(index,&lilac);
-            break;
-        case 85:
-        case 101:
-            SetColor(index,&dblue);
-            break;
-        case 110:
-            SetColor(index,&lpurple);
-            break;
-        case 135:
-            SetColor(index,&ablue);
-            break;
-        case 174:
-            SetColor(index,&cyan);
-            break;
-        case 182:
-        case 196:
-        case 214:
-        case 198:
-        case 200:
-            SetColor(index,&agreen);
-            break;
-        case 194:
-            SetColor(index,&darkergreen);
-            break;
-        case 212:
-            SetColor(index,&dgreen);
-            break;
-        case 199:
-        case 215:
-        case 201:
-            SetColor(index,&algreen);
-            break;
-        case 230:
-            SetColor(index,&tan);
-            break;
-        case 237:
-            SetColor(index,&ayellow);
-            break;
-        case 244:
-            SetColor(index,&abrown);
-            break;
-        case 246:
-        case 248:
-            SetColor(index,&aorange);
-            break;
-        default:
-            fprintf(stderr, "Unknown color %d ", value);
-            break;
+        else
+            SetColor(index, &dred);
+        break;
+    case 56:
+        SetColor(index, &alred);
+        break;
+    case 58:
+    case 60:
+        SetColor(index, &beige);
+        break;
+    case 69:
+    case 71:
+        SetColor(index, &deeppurple);
+        break;
+    case 68:
+    case 103:
+        SetColor(index, &apurple);
+        break;
+    case 89:
+        SetColor(index, &lilac);
+        break;
+    case 85:
+    case 101:
+        SetColor(index, &dblue);
+        break;
+    case 110:
+        SetColor(index, &lpurple);
+        break;
+    case 135:
+        SetColor(index, &ablue);
+        break;
+    case 174:
+        SetColor(index, &cyan);
+        break;
+    case 182:
+    case 196:
+    case 214:
+    case 198:
+    case 200:
+        SetColor(index, &agreen);
+        break;
+    case 194:
+        SetColor(index, &darkergreen);
+        break;
+    case 212:
+        SetColor(index, &dgreen);
+        break;
+    case 199:
+    case 215:
+    case 201:
+        SetColor(index, &algreen);
+        break;
+    case 230:
+        SetColor(index, &tan);
+        break;
+    case 237:
+        SetColor(index, &ayellow);
+        break;
+    case 244:
+        SetColor(index, &abrown);
+        break;
+    case 246:
+    case 248:
+        SetColor(index, &aorange);
+        break;
+    default:
+        fprintf(stderr, "Unknown color %d ", value);
+        break;
     }
 }
 
@@ -205,126 +212,128 @@ static void TranslateAtariColor(int index, uint8_t value) {
  I have no idea how the original interpreter calculates
  them. I might have made some mistakes. */
 
-static void TranslateC64Color(int index, uint8_t value) {
-    switch(value) {
-        case 0:
-            SetColor(index,&purple);
-            break;
-        case 1:
-            SetColor(index,&blue);
-            break;
-        case 3:
-            SetColor(index,&white);
-            break;
-        case 7:
-        case 8:
-            SetColor(index,&blue);
-            break;
-        case 9:
-        case 10:
-        case 12:
-        case 14:
-        case 15:
-            SetColor(index,&white);
-            break;
-        case 17:
-            SetColor(index,&green);
-            break;
-        case 36:
-        case 40:
-            SetColor(index,&brown);
-            break;
-        case 46:
-            SetColor(index,&yellow);
-            break;
-        case 52:
-        case 54:
-        case 56:
-        case 60:
-            SetColor(index,&orange);
-            break;
-        case 68:
-        case 69:
-        case 71:
-            SetColor(index,&red);
-            break;
-        case 77:
-        case 85:
-        case 87:
-            SetColor(index,&purple);
-            break;
-        case 89:
-            SetColor(index,&lred);
-            break;
-        case 101:
-        case 103:
-            SetColor(index,&purple);
-            break;
-        case 110:
-            SetColor(index,&lblue);
-            break;
-        case 135:
-        case 137:
-            SetColor(index,&blue);
-            break;
-        case 157:
-            SetColor(index,&lblue);
-            break;
-        case 161:
-            SetColor(index,&grey);
-            break;
-        case 179:
-        case 182:
-        case 194:
-        case 196:
-        case 198:
-        case 199:
-        case 200:
-            SetColor(index,&green);
-            break;
-        case 201:
-            SetColor(index,&lgreen);
-            break;
-        case 212:
-        case 214:
-        case 215:
-            SetColor(index,&green);
-            break;
-        case 224:
-            SetColor(index,&purple);
-            break;
-        case 230:
-        case 237:
-            SetColor(index,&yellow);
-            break;
-        case 244:
-        case 246:
-            SetColor(index,&brown);
-            break;
-        case 248:
-            if (CurrentGame == FANTASTIC4)
-                SetColor(index,&orange);
-            else
-                SetColor(index,&brown);
-            break;
-        case 252:
-            SetColor(index,&yellow);
-            break;
-        default:
-            fprintf(stderr, "Unknown color %d ", value);
-            break;
+static void TranslateC64Color(int index, uint8_t value)
+{
+    switch (value) {
+    case 0:
+        SetColor(index, &purple);
+        break;
+    case 1:
+        SetColor(index, &blue);
+        break;
+    case 3:
+        SetColor(index, &white);
+        break;
+    case 7:
+    case 8:
+        SetColor(index, &blue);
+        break;
+    case 9:
+    case 10:
+    case 12:
+    case 14:
+    case 15:
+        SetColor(index, &white);
+        break;
+    case 17:
+        SetColor(index, &green);
+        break;
+    case 36:
+    case 40:
+        SetColor(index, &brown);
+        break;
+    case 46:
+        SetColor(index, &yellow);
+        break;
+    case 52:
+    case 54:
+    case 56:
+    case 60:
+        SetColor(index, &orange);
+        break;
+    case 68:
+    case 69:
+    case 71:
+        SetColor(index, &red);
+        break;
+    case 77:
+    case 85:
+    case 87:
+        SetColor(index, &purple);
+        break;
+    case 89:
+        SetColor(index, &lred);
+        break;
+    case 101:
+    case 103:
+        SetColor(index, &purple);
+        break;
+    case 110:
+        SetColor(index, &lblue);
+        break;
+    case 135:
+    case 137:
+        SetColor(index, &blue);
+        break;
+    case 157:
+        SetColor(index, &lblue);
+        break;
+    case 161:
+        SetColor(index, &grey);
+        break;
+    case 179:
+    case 182:
+    case 194:
+    case 196:
+    case 198:
+    case 199:
+    case 200:
+        SetColor(index, &green);
+        break;
+    case 201:
+        SetColor(index, &lgreen);
+        break;
+    case 212:
+    case 214:
+    case 215:
+        SetColor(index, &green);
+        break;
+    case 224:
+        SetColor(index, &purple);
+        break;
+    case 230:
+    case 237:
+        SetColor(index, &yellow);
+        break;
+    case 244:
+    case 246:
+        SetColor(index, &brown);
+        break;
+    case 248:
+        if (CurrentGame == FANTASTIC4)
+            SetColor(index, &orange);
+        else
+            SetColor(index, &brown);
+        break;
+    case 252:
+        SetColor(index, &yellow);
+        break;
+    default:
+        fprintf(stderr, "Unknown color %d ", value);
+        break;
     }
 }
 
 int DrawAtariC64ImageFromData(uint8_t *ptr, size_t datasize)
 {
-    int work,work2;
+    int work, work2;
     int c;
     int i;
 
     uint8_t *origptr = ptr;
 
-    x = 0; y = 0;
+    x = 0;
+    y = 0;
 
     ptr += 2;
 
@@ -339,7 +348,8 @@ int DrawAtariC64ImageFromData(uint8_t *ptr, size_t datasize)
 
     // Get the offset
     xoff = *ptr++ - 3;
-    if (xoff < 0) xoff = 0;
+    if (xoff < 0)
+        xoff = 0;
     yoff = *ptr++;
     x = xoff * 8;
     y = yoff;
@@ -367,16 +377,15 @@ int DrawAtariC64ImageFromData(uint8_t *ptr, size_t datasize)
             winid_t parent = glk_window_get_parent(Graphics);
             if (parent)
                 glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                           optimal_height, NULL);
+                    optimal_height, NULL);
         }
     }
 
-    SetColor(0,&black);
+    SetColor(0, &black);
 
     // Get the palette
     debug_print("Colors: ");
-    for (i = 1; i < 5; i++)
-    {
+    for (i = 1; i < 5; i++) {
         work = *ptr++;
         if (CurrentSys == SYS_C64)
             TranslateC64Color(i, work);
@@ -386,29 +395,23 @@ int DrawAtariC64ImageFromData(uint8_t *ptr, size_t datasize)
     }
     debug_print("\n");
 
-    while (ptr - origptr < datasize - 2)
-    {
+    while (ptr - origptr < datasize - 2) {
         // First get count
         c = *ptr++;
 
-        if ((c & 0x80) == 0x80)
-        { // is a counter
+        if ((c & 0x80) == 0x80) { // is a counter
             c &= 0x7f;
             work = *ptr++;
             work2 = *ptr++;
-            for (i = 0; i < c + 1; i++)
-            {
-                DrawA8C64Pixels(work,work2);
+            for (i = 0; i < c + 1; i++) {
+                DrawA8C64Pixels(work, work2);
             }
-        }
-        else
-        {
+        } else {
             // Don't count on the next c characters
-            for (i = 0; i < c + 1 && ptr - origptr < datasize - 1; i++)
-            {
-                work=*ptr++;
-                work2=*ptr++;
-                DrawA8C64Pixels(work,work2);
+            for (i = 0; i < c + 1 && ptr - origptr < datasize - 1; i++) {
+                work = *ptr++;
+                work2 = *ptr++;
+                DrawA8C64Pixels(work, work2);
             }
         }
     }

--- a/terps/plus/atari8detect.c
+++ b/terps/plus/atari8detect.c
@@ -11,21 +11,18 @@
 #include <string.h>
 
 #include "common.h"
-#include "graphics.h"
-#include "definitions.h"
-#include "loaddatabase.h"
 #include "companionfile.h"
-
+#include "definitions.h"
 #include "gameinfo.h"
+#include "graphics.h"
+#include "loaddatabase.h"
 
 #include "atari8detect.h"
-
 
 typedef struct imglist {
     char *filename;
     size_t offset;
 } imglist;
-
 
 static const struct imglist listFantastic[] = {
     { "R001", 0x0297 },
@@ -93,7 +90,7 @@ static const struct imglist listFantastic[] = {
     { "S018", 0x12617 },
     { "S019", 0x1263a },
     { "S020", 0x126c1 },
-    { NULL, 0, }
+    { NULL, 0 }
 };
 
 static const struct imglist listSpidey[] = {
@@ -161,7 +158,7 @@ static const struct imglist listSpidey[] = {
     { "S021", 0x15687 },
     { "S022", 0x15b64 },
     { "S023", 0x16179 },
-//    { "S024", 0x16682 },
+//  { "S024", 0x16682 },
     { "S026", 0x16179 },
     { NULL, 0 }
 };
@@ -235,11 +232,12 @@ static const struct imglist listBanzai[] = {
     { "S015", 0x1176b },
     { "S016", 0x11841 },
     { "S017", 0x118e4 },
-    { NULL, 0, }
+
+    { NULL, 0 }
 };
 
-
-static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, uint8_t *otherdisk, size_t othersize) {
+static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, uint8_t *otherdisk, size_t othersize)
+{
     size_t size;
 
     const struct imglist *list = listSpidey;
@@ -256,8 +254,7 @@ static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, u
     int outpic;
 
     // Now loop round for each image
-    for (outpic = 0; outpic < count; outpic++)
-    {
+    for (outpic = 0; outpic < count; outpic++) {
         uint8_t *ptr = data + list[outpic].offset;
 
         size = *ptr++;
@@ -279,7 +276,6 @@ static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, u
         if (list[outpic].offset < 0xb390 && list[outpic].offset + Images[outpic].Size > 0xb390) {
             memcpy(Images[outpic].Data + 0xb390 - list[outpic].offset + 2, data + 0xb410, size - 0xb390 + list[outpic].offset - 2);
         }
-
     }
 
     Images[outpic].Filename = NULL;
@@ -294,8 +290,7 @@ static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, u
     return 1;
 }
 
-
-static const uint8_t atrheader[6] = { 0x96 , 0x02, 0x80, 0x16, 0x80, 0x00 };
+static const uint8_t atrheader[6] = { 0x96, 0x02, 0x80, 0x16, 0x80, 0x00 };
 
 int DetectAtari8(uint8_t **sf, size_t *extent)
 {
@@ -318,11 +313,13 @@ int DetectAtari8(uint8_t **sf, size_t *extent)
 
     ImageWidth = 280;
     ImageHeight = 158;
-    mem = main_disk + data_start; memlen = main_size - data_start;
+    mem = main_disk + data_start;
+    memlen = main_size - data_start;
     result = LoadDatabaseBinary();
     if (!result && companionfile != NULL && companionsize > data_start) {
         debug_print("Could not find database in this file, trying the companion file\n");
-        mem = companionfile + data_start; memlen = companionsize - data_start;
+        mem = companionfile + data_start;
+        memlen = companionsize - data_start;
         result = LoadDatabaseBinary();
         if (result) {
             debug_print("Found database in companion file. Switching files.\n");
@@ -346,4 +343,3 @@ int DetectAtari8(uint8_t **sf, size_t *extent)
 
     return result;
 }
-

--- a/terps/plus/c64detect.c
+++ b/terps/plus/c64detect.c
@@ -10,18 +10,18 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "c64diskimage.h"
 #include "common.h"
 #include "gameinfo.h"
 #include "graphics.h"
 
 #include "c64detect.h"
-#include "c64diskimage.h"
 
 #define MAX_LENGTH 300000
 #define MIN_LENGTH 24
 
-
-int issagaimg(const char *name) {
+int issagaimg(const char *name)
+{
     if (name == NULL)
         return 0;
     size_t len = strlen(name);
@@ -29,7 +29,7 @@ int issagaimg(const char *name) {
         return 0;
     char c = name[0];
     if (c == 'R' || c == 'B' || c == 'S') {
-        for(int i = 1; i < 4; i++)
+        for (int i = 1; i < 4; i++)
             if (!isdigit(name[i]))
                 return 0;
         return 1;
@@ -38,7 +38,7 @@ int issagaimg(const char *name) {
 }
 
 static uint8_t *get_file_named(uint8_t *data, size_t length, size_t *newlength,
-                               const char *name)
+    const char *name)
 {
     uint8_t *file = NULL;
     *newlength = 0;

--- a/terps/plus/common.h
+++ b/terps/plus/common.h
@@ -8,8 +8,8 @@
 #ifndef common_h
 #define common_h
 
-#include "glk.h"
 #include "definitions.h"
+#include "glk.h"
 
 void *MemAlloc(size_t size);
 void Fatal(const char *x);
@@ -20,9 +20,9 @@ void PrintDictWord(int idx, DictWord *dict);
 void Updates(event_t ev);
 void Display(winid_t w, const char *fmt, ...)
 #ifdef __GNUC__
-__attribute__((__format__(__printf__, 2, 3)))
+    __attribute__((__format__(__printf__, 2, 3)))
 #endif
-;
+    ;
 
 void SetBit(int bit);
 void ResetBit(int bit);

--- a/terps/plus/companionfile.c
+++ b/terps/plus/companionfile.c
@@ -8,7 +8,9 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include "common.h"
+
 #include "companionfile.h"
 
 typedef enum {
@@ -21,11 +23,12 @@ typedef enum {
     TYPE_2,
 } CompanionNameType;
 
-static int StripBrackets(char sideB[], size_t length) {
+static int StripBrackets(char sideB[], size_t length)
+{
     int left_bracket = 0;
     int right_bracket = 0;
     size_t ppos = length - 1;
-    while(sideB[ppos] != '.' && ppos > 0)
+    while (sideB[ppos] != '.' && ppos > 0)
         ppos--;
     size_t extlen = length - ppos;
     if (length > extlen) {
@@ -71,7 +74,6 @@ size_t GetFileLength(FILE *in)
     return length;
 }
 
-
 uint8_t *ReadFileIfExists(const char *name, size_t *size)
 {
     FILE *fptr = fopen(name, "r");
@@ -97,37 +99,38 @@ uint8_t *ReadFileIfExists(const char *name, size_t *size)
     return result;
 }
 
-static uint8_t *LookForCompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize) {
+static uint8_t *LookForCompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize)
+{
 
     char sideB[stringlen + 10];
     uint8_t *result = NULL;
 
     memcpy(sideB, game_file, stringlen + 1);
-    switch(type) {
-        case TYPE_A:
-            sideB[index] = 'A';
-            break;
-        case TYPE_B:
-            sideB[index] = 'B';
-            break;
-        case TYPE_1:
-            sideB[index] = '1';
-            break;
-        case TYPE_2:
-            sideB[index] = '2';
-            break;
-        case TYPE_ONE:
-            sideB[index] = 'o';
-            sideB[index + 1] = 'n';
-            sideB[index + 2] = 'e';
-            break;
-        case TYPE_TWO:
-            sideB[index] = 't';
-            sideB[index + 1] = 'w';
-            sideB[index + 2] = 'o';
-            break;
-        case TYPE_NONE:
-            break;
+    switch (type) {
+    case TYPE_A:
+        sideB[index] = 'A';
+        break;
+    case TYPE_B:
+        sideB[index] = 'B';
+        break;
+    case TYPE_1:
+        sideB[index] = '1';
+        break;
+    case TYPE_2:
+        sideB[index] = '2';
+        break;
+    case TYPE_ONE:
+        sideB[index] = 'o';
+        sideB[index + 1] = 'n';
+        sideB[index + 2] = 'e';
+        break;
+    case TYPE_TWO:
+        sideB[index] = 't';
+        sideB[index + 1] = 'w';
+        sideB[index + 2] = 'o';
+        break;
+    case TYPE_NONE:
+        break;
     }
 
     debug_print("looking for companion file \"%s\"\n", sideB);
@@ -141,7 +144,7 @@ static uint8_t *LookForCompanionFilename(int index, CompanionNameType type, size
         } else if (type == TYPE_A) {
             // First we look for the period before the file extension
             size_t ppos = stringlen - 1;
-            while(sideB[ppos] != '.' && ppos > 0)
+            while (sideB[ppos] != '.' && ppos > 0)
                 ppos--;
             if (ppos < 1)
                 return NULL;
@@ -165,8 +168,8 @@ static uint8_t *LookForCompanionFilename(int index, CompanionNameType type, size
     return result;
 }
 
-
-uint8_t *GetCompanionFile(size_t *size) {
+uint8_t *GetCompanionFile(size_t *size)
+{
 
     size_t gamefilelen = strlen(game_file);
     uint8_t *result = NULL;
@@ -177,10 +180,10 @@ uint8_t *GetCompanionFile(size_t *size) {
         char cminus1 = tolower(game_file[i - 1]);
         /* Pairs like side 1.dsk, side 2.dsk */
         if (i > 3 && ((c == 'e' && cminus1 == 'd' && tolower(game_file[i - 2]) == 'i' && tolower(game_file[i - 3]) == 's') ||
-                      /* Pairs like disk 1.dsk, disk 2.dsk */
-                      (c == 'k' && cminus1 && tolower(game_file[i - 2] == 'i') && tolower(game_file[i - 3]) == 'd') ||
-                      /* Pairs like hulk1.dsk, hulk2.dsk */
-                      (c == '.' && (cminus1 == '1' || cminus1 == '2' || cminus1 == 'a' || cminus1 == 'b')) )) {
+                /* Pairs like disk 1.dsk, disk 2.dsk */
+                (c == 'k' && cminus1 && tolower(game_file[i - 2] == 'i') && tolower(game_file[i - 3]) == 'd') ||
+                /* Pairs like hulk1.dsk, hulk2.dsk */
+                (c == '.' && (cminus1 == '1' || cminus1 == '2' || cminus1 == 'a' || cminus1 == 'b')))) {
             if (gamefilelen > i + 2) {
                 if (c != '.')
                     c = game_file[i + 1];
@@ -192,28 +195,28 @@ uint8_t *GetCompanionFile(size_t *size) {
                         c = tolower(game_file[i + 2]);
                     CompanionNameType type = TYPE_NONE;
                     switch (c) {
-                        case 'a':
-                            type = TYPE_B;
-                            break;
-                        case 'b':
-                            type = TYPE_A;
-                            break;
-                        case 't':
-                            if (gamefilelen > i + 4 && game_file[i + 3] == 'w' && game_file[i + 4] == 'o') {
-                                type =  TYPE_ONE;
-                            }
-                            break;
-                        case 'o':
-                            if (gamefilelen > i + 4 && game_file[i + 3] == 'n' && game_file[i + 4] == 'e') {
-                                type = TYPE_TWO;
-                            }
-                            break;
-                        case '2':
-                            type= TYPE_1;
-                            break;
-                        case '1':
-                            type = TYPE_2;
-                            break;
+                    case 'a':
+                        type = TYPE_B;
+                        break;
+                    case 'b':
+                        type = TYPE_A;
+                        break;
+                    case 't':
+                        if (gamefilelen > i + 4 && game_file[i + 3] == 'w' && game_file[i + 4] == 'o') {
+                            type = TYPE_ONE;
+                        }
+                        break;
+                    case 'o':
+                        if (gamefilelen > i + 4 && game_file[i + 3] == 'n' && game_file[i + 4] == 'e') {
+                            type = TYPE_TWO;
+                        }
+                        break;
+                    case '2':
+                        type = TYPE_1;
+                        break;
+                    case '1':
+                        type = TYPE_2;
+                        break;
                     }
                     if (type != TYPE_NONE)
                         result = LookForCompanionFilename(i + 2, type, gamefilelen, size);
@@ -225,4 +228,3 @@ uint8_t *GetCompanionFile(size_t *size) {
     }
     return NULL;
 }
-

--- a/terps/plus/companionfile.h
+++ b/terps/plus/companionfile.h
@@ -8,8 +8,8 @@
 #ifndef companionfile_h
 #define companionfile_h
 
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 uint8_t *GetCompanionFile(size_t *size);
 
 #endif /* companionfile_h */

--- a/terps/plus/definitions.h
+++ b/terps/plus/definitions.h
@@ -13,8 +13,11 @@
 
 #define DEBUG_ACTIONS 0
 
-#define debug_print(fmt, ...) \
-do { if (DEBUG_ACTIONS) fprintf(stderr, fmt, ##__VA_ARGS__); } while (0)
+#define debug_print(fmt, ...)                    \
+    do {                                         \
+        if (DEBUG_ACTIONS)                       \
+            fprintf(stderr, fmt, ##__VA_ARGS__); \
+    } while (0)
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -35,35 +38,35 @@ do { if (DEBUG_ACTIONS) fprintf(stderr, fmt, ##__VA_ARGS__); } while (0)
 
 #define MAX_BUFFER 512
 
-#define YOUARE        1    /* You are not I am */
-#define DEBUGGING    4    /* Info from database load */
-#define NO_DELAYS 128     /* Skip all pauses */
-#define FORCE_INVENTORY 1024     /* Inventory in upper window always on */
-#define FORCE_INVENTORY_OFF 2048     /* Inventory in upper window always off */
+#define YOUARE 1 /* You are not I am */
+#define DEBUGGING 4 /* Info from database load */
+#define NO_DELAYS 128 /* Skip all pauses */
+#define FORCE_INVENTORY 1024 /* Inventory in upper window always on */
+#define FORCE_INVENTORY_OFF 2048 /* Inventory in upper window always off */
 
 #define NounObject (Counters[30])
 #define Noun2Object (Counters[31])
 #define CurrentCounter (Counters[47])
 
-#define MyLoc     (Counters[32])
-#define CurVerb   (Counters[48])
-#define CurNoun   (Counters[49])
-#define CurPrep   (Counters[50])
+#define MyLoc (Counters[32])
+#define CurVerb (Counters[48])
+#define CurNoun (Counters[49])
+#define CurPrep (Counters[50])
 #define CurAdverb (Counters[51])
-#define CurPartp  (Counters[52])
-#define CurNoun2  (Counters[53])
+#define CurPartp (Counters[52])
+#define CurNoun2 (Counters[53])
 
-#define CARRIED           255
+#define CARRIED 255
 #define HELD_BY_OTHER_GUY 99
-#define DESTROYED         0
-#define HIDDEN            50
+#define DESTROYED 0
+#define HIDDEN 50
 
-#define DARKBIT      15
-#define MATCHBIT     33
-#define DRAWBIT      34
-#define GRAPHICSBIT  35
-#define ALWAYSMATCH  60
-#define STOPTIMEBIT  63
+#define DARKBIT 15
+#define MATCHBIT 33
+#define DRAWBIT 34
+#define GRAPHICSBIT 35
+#define ALWAYSMATCH 60
+#define STOPTIMEBIT 63
 
 #define CurrentGame (Game->gameID)
 
@@ -271,7 +274,13 @@ typedef enum {
 
 #define MAX_SYSMESS LAST_SYSTEM_MESSAGE
 
-typedef enum { NO_PALETTE, ZX, ZXOPT, C64A, C64B, VGA } palette_type;
+typedef enum {
+    NO_PALETTE,
+    ZX,
+    ZXOPT,
+    C64A,
+    C64B,
+    VGA } palette_type;
 
 struct GameInfo {
     const char *title;

--- a/terps/plus/extracommands.c
+++ b/terps/plus/extracommands.c
@@ -5,9 +5,10 @@
 //  Created by Petter Sjölund on 2022-06-28.
 //
 
-#include "glk.h"
 #include "common.h"
+#include "glk.h"
 #include "restorestate.h"
+
 #include "extracommands.h"
 
 DictWord ExtraWords[] = {
@@ -56,7 +57,7 @@ static void TranscriptOn(void)
     }
 
     ref = glk_fileref_create_by_prompt(fileusage_TextMode | fileusage_Transcript,
-                                       filemode_Write, 0);
+        filemode_Write, 0);
     if (ref == NULL)
         return;
 
@@ -70,7 +71,7 @@ static void TranscriptOn(void)
 
     glk_put_string_stream(Transcript, (char *)sys[TRANSCRIPT_START]);
     glk_put_string_stream(glk_window_get_stream(Bottom),
-                          (char *)sys[TRANSCRIPT_ON]);
+        (char *)sys[TRANSCRIPT_ON]);
 
     Look(1);
 }
@@ -89,56 +90,57 @@ static void TranscriptOff(void)
     SystemMessage(TRANSCRIPT_OFF);
 }
 
-ExtraCommandResult PerformExtraCommand(int command, int nextcommand) {
+ExtraCommandResult PerformExtraCommand(int command, int nextcommand)
+{
     switch (command) {
-        case COM_AGAIN:
-            CurVerb = LastVerb;
-            CurNoun = LastNoun;
-            CurPrep = LastPrep;
-            CurPartp = LastPartp;
-            CurNoun2 = LastNoun2;
-            CurAdverb = LastAdverb;
-            return RESULT_AGAIN;
-        case COM_UNDO:
-            RestoreUndo(1);
-            if (nextcommand == COM_MAND)
-                return RESULT_TWO_WORDS;
-            return RESULT_ONE_WORD;
-        case COM_RESTART:
-            SystemMessage(ARE_YOU_SURE);
-            if (YesOrNo())
-                should_restart = 1;
-            if (nextcommand == COM_GAME)
-                return RESULT_TWO_WORDS;
-            return RESULT_ONE_WORD;
-        case COM_TRANSCRIPT:
-            if (nextcommand == COM_OFF) {
-                TranscriptOff();
-                return RESULT_TWO_WORDS;
-            } else
-                TranscriptOn();
-            if (nextcommand == COM_ON)
-                return RESULT_TWO_WORDS;
-            return RESULT_ONE_WORD;
-        case COM_TRANSCRIPT_OFF:
+    case COM_AGAIN:
+        CurVerb = LastVerb;
+        CurNoun = LastNoun;
+        CurPrep = LastPrep;
+        CurPartp = LastPartp;
+        CurNoun2 = LastNoun2;
+        CurAdverb = LastAdverb;
+        return RESULT_AGAIN;
+    case COM_UNDO:
+        RestoreUndo(1);
+        if (nextcommand == COM_MAND)
+            return RESULT_TWO_WORDS;
+        return RESULT_ONE_WORD;
+    case COM_RESTART:
+        SystemMessage(ARE_YOU_SURE);
+        if (YesOrNo())
+            should_restart = 1;
+        if (nextcommand == COM_GAME)
+            return RESULT_TWO_WORDS;
+        return RESULT_ONE_WORD;
+    case COM_TRANSCRIPT:
+        if (nextcommand == COM_OFF) {
             TranscriptOff();
-            return RESULT_ONE_WORD;
-        case COM_RAM:
-            if (nextcommand == COM_LOAD) {
-                RamLoad();
-                return RESULT_TWO_WORDS;
-            } else if (nextcommand == COM_SAVE) {
-                RamSave(1);
-                return RESULT_TWO_WORDS;
-            } else return RESULT_NOT_UNDERSTOOD;
-        case COM_RAMSAVE:
-            RamSave(1);
-            return RESULT_ONE_WORD;
-        case COM_RAMRESTORE:
+            return RESULT_TWO_WORDS;
+        } else
+            TranscriptOn();
+        if (nextcommand == COM_ON)
+            return RESULT_TWO_WORDS;
+        return RESULT_ONE_WORD;
+    case COM_TRANSCRIPT_OFF:
+        TranscriptOff();
+        return RESULT_ONE_WORD;
+    case COM_RAM:
+        if (nextcommand == COM_LOAD) {
             RamLoad();
-            return RESULT_ONE_WORD;
-        default:
+            return RESULT_TWO_WORDS;
+        } else if (nextcommand == COM_SAVE) {
+            RamSave(1);
+            return RESULT_TWO_WORDS;
+        } else
             return RESULT_NOT_UNDERSTOOD;
+    case COM_RAMSAVE:
+        RamSave(1);
+        return RESULT_ONE_WORD;
+    case COM_RAMRESTORE:
+        RamLoad();
+        return RESULT_ONE_WORD;
+    default:
+        return RESULT_NOT_UNDERSTOOD;
     }
 }
-

--- a/terps/plus/gameinfo.c
+++ b/terps/plus/gameinfo.c
@@ -9,7 +9,6 @@
 
 #include "definitions.h"
 
-
 const struct GameInfo games[] = {
     {
         "Buckaroo Banzai",
@@ -31,7 +30,6 @@ const struct GameInfo games[] = {
         6, // special images
     },
 
-
     {
         "Questprobe 2: Spider-Man",
         "SPIDER-MAN (tm)",
@@ -45,7 +43,7 @@ const struct GameInfo games[] = {
     {
         "Questprobe 3: Fantastic Four",
         "FF #1 ",
-        FANTASTIC4,                  // game ID
+        FANTASTIC4, // game ID
 
         21, // room images
         22, // item images
@@ -62,9 +60,7 @@ const struct GameInfo games[] = {
         0, // special images
     },
 
-    {
-        NULL
-    }
+    { NULL }
 };
 
 /* This is supposed to be the original ScottFree system

--- a/terps/plus/graphics.c
+++ b/terps/plus/graphics.c
@@ -12,10 +12,10 @@
 #include "glkimp.h"
 #endif
 
+#include "animations.h"
 #include "common.h"
 #include "graphics.h"
 #include "loaddatabase.h"
-#include "animations.h"
 
 ImgType LastImgType;
 int LastImgIndex;
@@ -24,8 +24,8 @@ int upside_down = 0;
 
 int x = 0, y = 0, at_last_line = 0;
 
-int xlen=280, ylen=158;
-int xoff=0, yoff=0;
+int xlen = 280, ylen = 158;
+int xoff = 0, yoff = 0;
 
 int pixel_size;
 int x_offset, y_offset, right_margin;
@@ -44,11 +44,12 @@ void ClearApple2ScreenMem(void);
 void DrawBlack(void)
 {
     glk_window_fill_rect(Graphics, 0, x_offset, y_offset, (glui32)(ImageWidth * pixel_size),
-                         (glui32)(ImageHeight * pixel_size));
+        (glui32)(ImageHeight * pixel_size));
     LastImgType = NO_IMG;
 }
 
-char *ShortNameFromType(char type, int index) {
+char *ShortNameFromType(char type, int index)
+{
     char buf[5];
     int n = snprintf(buf, sizeof buf, "%c0%02d", type, index);
     if (n < 0)
@@ -58,7 +59,6 @@ char *ShortNameFromType(char type, int index) {
     memcpy(result, buf, len);
     return result;
 }
-
 
 void PutPixel(glsi32 xpos, glsi32 ypos, int32_t color)
 {
@@ -81,7 +81,7 @@ void PutPixel(glsi32 xpos, glsi32 ypos, int32_t color)
     ypos += y_offset;
 
     glk_window_fill_rect(Graphics, glk_color, xpos,
-                         ypos, pixel_size, pixel_size);
+        ypos, pixel_size, pixel_size);
 }
 
 void PutDoublePixel(glsi32 xpos, glsi32 ypos, int32_t color)
@@ -109,7 +109,7 @@ void PutDoublePixel(glsi32 xpos, glsi32 ypos, int32_t color)
     ypos += y_offset;
 
     glk_window_fill_rect(Graphics, glk_color, xpos,
-                         ypos, pixel_size * 2, pixel_size);
+        ypos, pixel_size * 2, pixel_size);
 }
 
 void SetColor(int32_t index, const RGB *color)
@@ -119,7 +119,8 @@ void SetColor(int32_t index, const RGB *color)
     pal[index][2] = (*color)[2];
 }
 
-void SetRGB(int32_t index, int red, int green, int blue) {
+void SetRGB(int32_t index, int red, int green, int blue)
+{
     red = red * 35.7;
     green = green * 35.7;
     blue = blue * 35.7;
@@ -134,7 +135,7 @@ int DrawImageWithName(char *filename)
     debug_print("DrawImageWithName %s\n", filename);
 
     int i;
-    for (i = 0; Images[i].Filename != NULL; i++ )
+    for (i = 0; Images[i].Filename != NULL; i++)
         if (strcmp(filename, Images[i].Filename) == 0)
             break;
 
@@ -153,18 +154,18 @@ int DrawImageWithName(char *filename)
     if (!IsSet(GRAPHICSBIT))
         return 0;
 
-    switch(Images[i].Filename[0]) {
-        case 'B':
-            LastImgType = IMG_OBJECT;
-            break;
-        case 'R':
-            LastImgType = IMG_ROOM;
-            break;
-        case 'S':
-            LastImgType = IMG_SPECIAL;
-            break;
-        default:
-            debug_print("DrawImageWithName: Unknown image type!\n");
+    switch (Images[i].Filename[0]) {
+    case 'B':
+        LastImgType = IMG_OBJECT;
+        break;
+    case 'R':
+        LastImgType = IMG_ROOM;
+        break;
+    case 'S':
+        LastImgType = IMG_SPECIAL;
+        break;
+    default:
+        debug_print("DrawImageWithName: Unknown image type!\n");
     }
 
     LastImgIndex = Images[i].Filename[3] - '0' + 10 * (Images[i].Filename[2] - '0');
@@ -179,7 +180,8 @@ int DrawImageWithName(char *filename)
         return DrawDOSImageFromData(Images[i].Data, Images[i].Size);
 }
 
-void DrawItemImage(int item) {
+void DrawItemImage(int item)
+{
     LastImgType = IMG_OBJECT;
     LastImgIndex = item;
     char buf[5];
@@ -193,7 +195,8 @@ void DrawItemImage(int item) {
     DrawImageWithName(buf);
 }
 
-int DrawCloseup(int img) {
+int DrawCloseup(int img)
+{
     LastImgType = IMG_SPECIAL;
     LastImgIndex = img;
     char buf[5];
@@ -219,7 +222,8 @@ int DrawCloseup(int img) {
 
 void ClearApple2ScreenMem(void);
 
-int DrawRoomImage(int roomimg) {
+int DrawRoomImage(int roomimg)
+{
     LastImgType = IMG_ROOM;
     LastImgIndex = roomimg;
 
@@ -263,7 +267,6 @@ void DrawCurrentRoom(void)
         }
     }
 
-
     if (Rooms[MyLoc].Image == 255) {
         CloseGraphicsWindow();
         return;
@@ -290,7 +293,7 @@ void DrawCurrentRoom(void)
     }
 
     for (int ct = 0; ct <= GameHeader.NumObjImg; ct++)
-        if (ObjectImages[ct].Room == MyLoc && Items[ObjectImages[ct].Object].Location == MyLoc ) {
+        if (ObjectImages[ct].Room == MyLoc && Items[ObjectImages[ct].Object].Location == MyLoc) {
             DrawItemImage(ObjectImages[ct].Image);
         }
 

--- a/terps/plus/graphics.h
+++ b/terps/plus/graphics.h
@@ -9,6 +9,7 @@
 #define graphics_h
 
 #include <stdio.h>
+
 #include "glk.h"
 
 typedef uint8_t RGB[3];

--- a/terps/plus/layouttext.c
+++ b/terps/plus/layouttext.c
@@ -15,7 +15,7 @@ static int FindBreak(const char *buf, int pos, int columns)
 {
     if (isspace((unsigned char)buf[pos]))
         return 0;
-    
+
     int diff = 0;
 
     while (diff < columns && !isspace((unsigned char)buf[pos])) {

--- a/terps/plus/loaddatabase.c
+++ b/terps/plus/loaddatabase.c
@@ -12,14 +12,13 @@
 
 #include "common.h"
 #include "gameinfo.h"
-#include "loaddatabase.h"
 #include "graphics.h"
+#include "loaddatabase.h"
 
 Synonym *Substitutions;
 uint8_t *MysteryValues;
 
-
-static const char *ConditionList[]={
+static const char *ConditionList[] = {
     "<ERROR>",
     "CARRIED",
     "HERE",
@@ -54,6 +53,8 @@ static const char *ConditionList[]={
     "MODE",
     "OUT OF RANGE",
 };
+
+// clang-format off
 
 struct Keyword
 {
@@ -144,6 +145,8 @@ static const struct Keyword CommandList[] =
     {"",             -1, 0 }
 };
 
+// clang-format on
+
 
 static const char *ReadWholeLine(FILE *f)
 {
@@ -176,7 +179,7 @@ static const char *ReadWholeLine(FILE *f)
             tmp[ct++] = '?';
         c = fgetc(f);
     } while (1);
-    
+
     for (int i = ct - 1; i > 0; i--) // Look for last hyphen
         if (tmp[i] == '\"') {
             ct = i + 1;
@@ -191,7 +194,6 @@ static const char *ReadWholeLine(FILE *f)
     memcpy(t, tmp, ct + 1);
     return (t);
 }
-
 
 static char *ReadString(FILE *f, size_t *length)
 {
@@ -219,7 +221,7 @@ lookdeeper:
         }
         if (c == '`')
             c = '"'; /* pdd */
-        
+
         /* Ensure a valid Glk newline is sent. */
         if (c == '\n')
             tmp[ct++] = 10;
@@ -244,7 +246,8 @@ lookdeeper:
     return (t);
 }
 
-static DictWord *ReadDictWordsPC(FILE *f, int numstrings, int loud) {
+static DictWord *ReadDictWordsPC(FILE *f, int numstrings, int loud)
+{
     DictWord dictionary[1024];
     DictWord *dw = &dictionary[0];
     char *str = NULL;
@@ -259,7 +262,7 @@ static DictWord *ReadDictWordsPC(FILE *f, int numstrings, int loud) {
         int commapos = 0;
         for (int j = 0; j < length && str[j] != '\0'; j++) {
             if (str[j] == ',') {
-                while(str[j] == ',') {
+                while (str[j] == ',') {
                     str[j] = '\0';
                     commapos = j;
                     j++;
@@ -288,10 +291,11 @@ static DictWord *ReadDictWordsPC(FILE *f, int numstrings, int loud) {
     return finaldict;
 }
 
-static Synonym *ReadSubstitutions(FILE *f, int numstrings, int loud) {
+static Synonym *ReadSubstitutions(FILE *f, int numstrings, int loud)
+{
     Synonym syn[1024];
     Synonym *s = &syn[0];
-    
+
     char *str = NULL;
     char *replace = NULL;
     int index = 0;
@@ -309,7 +313,7 @@ static Synonym *ReadSubstitutions(FILE *f, int numstrings, int loud) {
         int nextisrep = 0;
         for (int j = 0; j < length && str[j] != '\0'; j++) {
             if (str[j] == ',') {
-                while(str[j] == ',') {
+                while (str[j] == ',') {
                     str[j] = '\0';
                     commapos = j;
                     j++;
@@ -360,7 +364,7 @@ static Synonym *ReadSubstitutions(FILE *f, int numstrings, int loud) {
     syn[index].SynonymString = NULL;
     int synsize = (index + 1) * sizeof(Synonym);
     Synonym *finalsyns = (Synonym *)MemAlloc(synsize);
-    
+
     memcpy(finalsyns, syn, synsize);
     if (loud)
         for (int j = 0; syn[j].SynonymString != NULL; j++)
@@ -370,7 +374,8 @@ static Synonym *ReadSubstitutions(FILE *f, int numstrings, int loud) {
 
 static uint8_t *ReadPlusString(uint8_t *ptr, char **string, size_t *length);
 
-static Synonym *ReadSubstitutionsBinary(uint8_t **startpointer, int numstrings, int loud) {
+static Synonym *ReadSubstitutionsBinary(uint8_t **startpointer, int numstrings, int loud)
+{
     Synonym syn[1024];
     Synonym *s = &syn[0];
 
@@ -395,7 +400,7 @@ static Synonym *ReadSubstitutionsBinary(uint8_t **startpointer, int numstrings, 
         int nextisrep = 0;
         for (int j = 0; j < length && str[j] != '\0'; j++) {
             if (str[j] == ',') {
-                while(str[j] == ',') {
+                while (str[j] == ',') {
                     str[j] = '\0';
                     commapos = j;
                     j++;
@@ -457,7 +462,8 @@ static Synonym *ReadSubstitutionsBinary(uint8_t **startpointer, int numstrings, 
 
 char **Comments;
 
-static void ReadComments(FILE *f, int loud) {
+static void ReadComments(FILE *f, int loud)
+{
     const char *strings[1024];
     const char *comment;
     int index = 0;
@@ -480,7 +486,8 @@ static void ReadComments(FILE *f, int loud) {
     Comments[index] = NULL;
 }
 
-static int NumberOfArguments(int opcode) {
+static int NumberOfArguments(int opcode)
+{
     int i = 0;
     while (CommandList[i].opcode != -1) {
         if (CommandList[i].opcode == opcode)
@@ -490,7 +497,8 @@ static int NumberOfArguments(int opcode) {
     return 0;
 }
 
-void PrintDictWord(int idx, DictWord *dict) {
+void PrintDictWord(int idx, DictWord *dict)
+{
     for (int i = 0; dict->Word != NULL; i++) {
         if (dict->Group == idx) {
             debug_print("%s", dict->Word);
@@ -501,13 +509,14 @@ void PrintDictWord(int idx, DictWord *dict) {
     debug_print("%d", idx);
 }
 
-static void PrintCondition(uint8_t condition, uint16_t argument, int *negate, int *mult, int *or) {
+static void PrintCondition(uint8_t condition, uint16_t argument, int *negate, int *mult, int * or)
+{
     if (condition == 0) {
         debug_print(" %d", argument);
     } else if (condition == 31) {
         if (argument == 1) {
             debug_print(" OR(31) %d ", argument); // Arg 1 == OR
-            *or = 1;
+            * or = 1;
         } else if (argument == 3 || argument == 4) {
             debug_print(" NOT(31) %d ", argument);
             *negate = 1;
@@ -519,7 +528,7 @@ static void PrintCondition(uint8_t condition, uint16_t argument, int *negate, in
         } else {
             debug_print(" MOD(31) %d ", argument);
             if (argument == 0)
-                *or = 0;
+                * or = 0;
         }
     } else if (condition > 40) {
         debug_print(" Condition %d out of range! Arg:%d\n", condition, argument);
@@ -534,7 +543,6 @@ static void PrintCondition(uint8_t condition, uint16_t argument, int *negate, in
     }
 }
 
-
 static void PrintDebugMess(int index)
 {
     if (index > GameHeader.NumMessages)
@@ -545,21 +553,22 @@ static void PrintDebugMess(int index)
     }
 }
 
-static void PrintCommand(uint8_t opcode, uint8_t arg, uint8_t arg2, uint8_t arg3, int numargs) {
+static void PrintCommand(uint8_t opcode, uint8_t arg, uint8_t arg2, uint8_t arg3, int numargs)
+{
     if (opcode > 0 && opcode <= 51) {
         debug_print(" MESSAGE %d ", opcode);
         PrintDebugMess(opcode);
         debug_print("\n");
         return;
     }
-    
+
     int i = 0;
     int found = 0;
     while (CommandList[i].opcode != -1) {
         if (CommandList[i].opcode == opcode) {
             found = 1;
             debug_print(" %s(%d) ", CommandList[i].name, opcode);
-            
+
             if (opcode == 128) {
                 arg -= 76;
                 debug_print("%d ", arg);
@@ -573,7 +582,7 @@ static void PrintCommand(uint8_t opcode, uint8_t arg, uint8_t arg2, uint8_t arg3
                     }
                 }
             }
-            
+
             break;
         }
         i++;
@@ -585,7 +594,8 @@ static void PrintCommand(uint8_t opcode, uint8_t arg, uint8_t arg2, uint8_t arg3
     }
 }
 
-static void DumpActions(void) {
+static void DumpActions(void)
+{
     int negate_condition = 0;
     int negate_multiple = 0;
     int or_condition = 0;
@@ -598,7 +608,7 @@ static void DumpActions(void) {
             PrintDictWord(ap->NounOrChance, Nouns);
             debug_print("(%d)", ap->NounOrChance);
         } else {
-            debug_print("(%d)(%d)",ap->Verb, ap->NounOrChance);
+            debug_print("(%d)(%d)", ap->Verb, ap->NounOrChance);
         }
 
         if (Comments && Comments[ct][0] != 0)
@@ -615,19 +625,19 @@ static void DumpActions(void) {
                     isobject = 0;
                 } else {
                     switch (ap->Words[i] >> 6) {
-                        case 3:
-                            debug_print("(prep:) ");
-                            break;
-                        case 2:
-                            debug_print("(participle:) ");
-                            isobject = 1;
-                            break;
-                        case 1:
-                            debug_print("(adverb:) ");
-                            break;
-                        case 0:
-                            debug_print("(spare:) ");
-                            break;
+                    case 3:
+                        debug_print("(prep:) ");
+                        break;
+                    case 2:
+                        debug_print("(participle:) ");
+                        isobject = 1;
+                        break;
+                    case 1:
+                        debug_print("(adverb:) ");
+                        break;
+                    case 0:
+                        debug_print("(spare:) ");
+                        break;
                     }
                 }
                 if (ap->Words[i] <= GameHeader.NumNouns) {
@@ -651,17 +661,17 @@ static void DumpActions(void) {
         else {
             debug_print("Conditions:");
             for (int i = 0; ap->Conditions[i] != 255; i += 2) {
-                PrintCondition(ap->Conditions[i], ap->Conditions[i+1], &negate_condition, &negate_multiple, &or_condition);
+                PrintCondition(ap->Conditions[i], ap->Conditions[i + 1], &negate_condition, &negate_multiple, &or_condition);
             }
         }
         negate_condition = 0;
         negate_multiple = 0;
         debug_print("\n");
-        
+
         for (int i = 0; i <= ap->CommandLength; i++) {
             uint8_t command = ap->Commands[i];
             int numargs = NumberOfArguments(command);
-            
+
             if (numargs > 0 && i < ap->CommandLength - 2 && ap->Commands[i + 1] == 131 && ap->Commands[i + 2] == 230) {
                 numargs++;
             } else if (command == 99 && ap->Commands[i + 2] > 63) {
@@ -689,14 +699,16 @@ static void DumpActions(void) {
     }
 }
 
-static uint8_t ReadNum(FILE *f) {
+static uint8_t ReadNum(FILE *f)
+{
     int num;
     if (fscanf(f, "%d\n", &num) != 1)
         return 0;
     return num;
 }
 
-static void ReadAction(FILE *f, Action *ap) {
+static void ReadAction(FILE *f, Action *ap)
+{
     uint8_t length = ReadNum(f);
     int i;
     ap->NumWords = length >> 4;
@@ -710,11 +722,11 @@ static void ReadAction(FILE *f, Action *ap) {
         Fatal("2-byte nouns unimplemented\n");
     }
     ap->Words = MemAlloc(ap->NumWords);
-    
+
     for (i = 0; i < ap->NumWords; i++) {
         ap->Words[i] = ReadNum(f);
     }
-    
+
     int reading_conditions = 1;
     int conditions_read = 0;
     uint16_t conditions[1024];
@@ -739,7 +751,7 @@ static void ReadAction(FILE *f, Action *ap) {
     for (i = 0; i <= ap->CommandLength; i++) {
         commands[i] = ReadNum(f);
     }
-    
+
     ap->Commands = MemAlloc(i);
     memcpy(ap->Commands, commands, i);
 }
@@ -766,7 +778,8 @@ static void PrintHeaderInfo(Header h)
     debug_print("Unknown3 =\t%d\n", h.Unknown2);
 }
 
-static int SetGame(const char *id_string, size_t length) {
+static int SetGame(const char *id_string, size_t length)
+{
     for (int i = 0; games[i].title != NULL; i++)
         if (strncmp(id_string, games[i].ID_string, length) == 0) {
             Game = &games[i];
@@ -775,13 +788,14 @@ static int SetGame(const char *id_string, size_t length) {
     return 0;
 }
 
-int FindAndAddImageFile(char *shortname, struct imgrec *rec) {
+int FindAndAddImageFile(char *shortname, struct imgrec *rec)
+{
     int result = 0;
     size_t pathlen = DirPathLength + 9;
     char *filename = MemAlloc(pathlen);
     int n = snprintf(filename, pathlen, "%s%s.PAK", DirPath, shortname);
     if (n > 0) {
-        FILE *infile=fopen(filename,"rb");
+        FILE *infile = fopen(filename, "rb");
         if (infile) {
             fseek(infile, 0, SEEK_END);
             size_t length = ftell(infile);
@@ -808,7 +822,7 @@ int LoadDatabasePlaintext(FILE *f, int loud)
 {
     int ni, as, na, nv, nn, nr, mc, pr, tr, lt, mn, trm, adv, prp, ss, unk1, oi, unk2;
     int ct;
-    
+
     Action *ap;
     Room *rp;
     Item *ip;
@@ -821,9 +835,9 @@ int LoadDatabasePlaintext(FILE *f, int loud)
         free(title);
         return UNKNOWN_GAME;
     }
-    
+
     if (fscanf(f, ",%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n", &ni, &as, &nn, &nv, &nr, &mc, &pr,
-               &mn, &trm, &lt, &prp, &adv, &na, &tr, &ss, &unk1, &oi, &unk2)
+            &mn, &trm, &lt, &prp, &adv, &na, &tr, &ss, &unk1, &oi, &unk2)
         < 10) {
         if (loud)
             debug_print("Invalid database(bad header)\n");
@@ -864,9 +878,9 @@ int LoadDatabasePlaintext(FILE *f, int loud)
     if (loud) {
         PrintHeaderInfo(GameHeader);
     }
-    
+
     /* Load the actions */
-    
+
     ct = 0;
     ap = Actions;
     if (loud)
@@ -876,21 +890,21 @@ int LoadDatabasePlaintext(FILE *f, int loud)
         ap++;
         ct++;
     }
-    
+
     if (loud)
         debug_print("Reading %d verbs.\n", nv);
     Verbs = ReadDictWordsPC(f, GameHeader.NumVerbs + 1, loud);
     if (loud)
         debug_print("Reading %d nouns.\n", nn);
     Nouns = ReadDictWordsPC(f, GameHeader.NumNouns + 1, loud);
-    
+
     rp = Rooms;
     if (loud)
         debug_print("Reading %d rooms.\n", nr);
     for (ct = 0; ct < nr + 1; ct++) {
         if (fscanf(f, "%d,%d,%d,%d,%d,%d,%d,%d\n", &rp->Exits[0], &rp->Exits[1],
-                   &rp->Exits[2], &rp->Exits[3], &rp->Exits[4],
-                   &rp->Exits[5], &rp->Exits[6], &rp->Image)
+                &rp->Exits[2], &rp->Exits[3], &rp->Exits[4],
+                &rp->Exits[5], &rp->Exits[6], &rp->Image)
             != 8) {
             debug_print("Bad room line (%d)\n", ct);
             //            FreeDatabase();
@@ -898,8 +912,7 @@ int LoadDatabasePlaintext(FILE *f, int loud)
         }
         rp++;
     }
-    
-    
+
     if (loud)
         debug_print("Reading %d messages.\n", mn);
     for (ct = 0; ct < mn + 1; ct++) {
@@ -907,13 +920,13 @@ int LoadDatabasePlaintext(FILE *f, int loud)
         if (loud)
             debug_print("Message %d: \"%s\"\n", ct, Messages[ct]);
     }
-    
+
     for (ct = 0; ct < nr + 1; ct++) {
         Rooms[ct].Text = Messages[Rooms[ct].Exits[6] - 76];
         if (loud)
             debug_print("Room description of room %d: \"%s\"\n", ct, Rooms[ct].Text);
     }
-    
+
     ct = 0;
     if (loud)
         debug_print("Reading %d items.\n", ni);
@@ -933,21 +946,21 @@ int LoadDatabasePlaintext(FILE *f, int loud)
         ip->Flag = (uint8_t)flag;
         if (loud && (ip->Location == CARRIED || ip->Location <= GameHeader.NumRooms))
             debug_print("Location of item %d: %d, \"%s\"\n", ct, ip->Location,
-                    ip->Location == CARRIED ? "CARRIED" : Rooms[ip->Location].Text);
+                ip->Location == CARRIED ? "CARRIED" : Rooms[ip->Location].Text);
         ip->InitialLoc = ip->Location;
         ip++;
         ct++;
     }
-    
+
     if (loud)
         debug_print("Reading %d adverbs.\n", GameHeader.NumAdverbs);
     Adverbs = ReadDictWordsPC(f, GameHeader.NumAdverbs + 1, loud);
     if (loud)
-        debug_print("Reading %d prepositions.\n",  GameHeader.NumPreps);
+        debug_print("Reading %d prepositions.\n", GameHeader.NumPreps);
     Prepositions = ReadDictWordsPC(f, GameHeader.NumPreps + 1, loud);
-    
+
     Substitutions = ReadSubstitutions(f, GameHeader.NumSubStr + 1, loud);
-    
+
     ObjectImage *objimg = ObjectImages;
     if (loud)
         debug_print("Reading %d object image values.\n", oi + 1);
@@ -963,7 +976,7 @@ int LoadDatabasePlaintext(FILE *f, int loud)
         }
         objimg++;
     }
-    
+
     if (loud)
         debug_print("Reading %d unknown values.\n", unk2 + 1);
     for (ct = 0; ct < unk2 + 1; ct++) {
@@ -974,9 +987,9 @@ int LoadDatabasePlaintext(FILE *f, int loud)
             return UNKNOWN_GAME;
         }
     }
-    
+
     ReadComments(f, loud);
-    
+
     if (loud) {
         debug_print("\nLoad Complete.\n\n");
         DumpActions();
@@ -987,7 +1000,6 @@ int LoadDatabasePlaintext(FILE *f, int loud)
 
     Images = MemAlloc((numimages + 1) * sizeof(struct imgrec));
     debug_print("\nTotal number of images:%d\n", numimages);
-
 
     int i, recidx = 0, imgidx = 0;
     char type = 'R';
@@ -1009,7 +1021,7 @@ int LoadDatabasePlaintext(FILE *f, int loud)
     Images[recidx].Filename = NULL;
 
     CurrentSys = SYS_MSDOS;
-    
+
     return CurrentGame;
 }
 
@@ -1036,7 +1048,6 @@ static uint8_t *ReadPlusString(uint8_t *ptr, char **string, size_t *len)
     *len = length;
     return ptr;
 }
-
 
 char **LoadMessages(int numstrings, uint8_t **ptr)
 {
@@ -1079,7 +1090,7 @@ int SeekIfNeeded(int expected_start, int *offset, uint8_t **ptr)
     return 1;
 }
 
-void ParseHeader(uint16_t *h, int *ni, int *as, int *nn, int*nv, int *nr, int *mc, int *pr, int *mn, int *trm, int *lt, int *prp, int *adv, int *na, int *tr, int *ss, int *unk1, int *oi, int *unk2)
+void ParseHeader(uint16_t *h, int *ni, int *as, int *nn, int *nv, int *nr, int *mc, int *pr, int *mn, int *trm, int *lt, int *prp, int *adv, int *na, int *tr, int *ss, int *unk1, int *oi, int *unk2)
 {
     *ni = h[0];
     *as = h[1];
@@ -1116,7 +1127,8 @@ static uint8_t *ReadHeader(uint8_t *ptr)
     return ptr - 2;
 }
 
-DictWord *ReadDictWords(uint8_t **pointer, int numstrings, int loud) {
+DictWord *ReadDictWords(uint8_t **pointer, int numstrings, int loud)
+{
     uint8_t *ptr = *pointer;
     DictWord dictionary[1024];
     DictWord *dw = dictionary;
@@ -1133,7 +1145,7 @@ DictWord *ReadDictWords(uint8_t **pointer, int numstrings, int loud) {
         int commapos = 0;
         for (int j = 0; j <= strlength && str[j] != '\0'; j++) {
             if (str[j] == ',') {
-                while(str[j] == ',') {
+                while (str[j] == ',') {
                     str[j] = '\0';
                     commapos = j;
                     j++;
@@ -1207,7 +1219,7 @@ int LoadDatabaseBinary(void)
     ptr = ReadHeader(ptr);
 
     ParseHeader(header, &ni, &as, &nn, &nv, &nr, &mc, &pr,
-                    &mn, &trm, &lt, &prp, &adv, &na, &tr, &ss, &unk1, &oi, &unk2);
+        &mn, &trm, &lt, &prp, &adv, &na, &tr, &ss, &unk1, &oi, &unk2);
 
     if (CurrentSys == SYS_ST && as == 5159)
         isSTSpiderman = 1;
@@ -1244,7 +1256,6 @@ int LoadDatabaseBinary(void)
     Rooms = (Room *)MemAlloc(sizeof(Room) * (nr + 1));
     ObjectImages = (ObjectImage *)MemAlloc(sizeof(ObjectImage) * (oi + 1));
     Messages = MemAlloc(sizeof(char *) * (mn + 1));
-
 
     Counters[35] = nr;
     Counters[34] = trm;
@@ -1339,7 +1350,7 @@ int LoadDatabaseBinary(void)
                 int adr = rp->Exits[j] * 0x100;
                 adr += *ptr++ * 0x10;
                 adr *= 0x10;
-                debug_print("Room image %d address:%x\n",ct, adr);
+                debug_print("Room image %d address:%x\n", ct, adr);
                 rp->Exits[j] = adr;
             } else if (j > 5) {
                 rp->Exits[j] |= *ptr;
@@ -1390,10 +1401,10 @@ int LoadDatabaseBinary(void)
     }
 
 #pragma mark item locations
-    if (isSTSpiderman || isSTFF ) {
+    if (isSTSpiderman || isSTFF) {
         ptr++;
     }
-    
+
     for (ct = 0, ip = Items; ct <= ni; ct++, ip++) {
         ip->Location = *ptr++;
         ip->InitialLoc = ip->Location;
@@ -1419,7 +1430,6 @@ int LoadDatabaseBinary(void)
 
     Adverbs = ReadDictWords(&ptr, GameHeader.NumAdverbs + 1, 1);
     Prepositions = ReadDictWords(&ptr, GameHeader.NumPreps + 1, 1);
-
 
 #pragma mark substitutions
 
@@ -1458,7 +1468,7 @@ int LoadDatabaseBinary(void)
             int adr = ObjectImages[ct].Image * 0x100;
             adr += *ptr++ * 0x10;
             adr *= 0x10;
-            debug_print("Object image %d address:%x\n",ct, adr);
+            debug_print("Object image %d address:%x\n", ct, adr);
             ObjectImages[ct].Image = adr;
         } else
             ptr++;

--- a/terps/plus/parseinput.c
+++ b/terps/plus/parseinput.c
@@ -5,17 +5,17 @@
 //  Created by Petter Sjölund on 2022-06-04.
 //
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "glk.h"
 
 #include "common.h"
 #include "definitions.h"
-#include "restorestate.h"
 #include "extracommands.h"
 #include "parseinput.h"
+#include "restorestate.h"
 
 char **InputWordStrings = NULL;
 int WordsInInput = 0;
@@ -30,7 +30,8 @@ DictWord *Prepositions;
 
 int LastVerb = 0, LastNoun = 0, LastPrep = 0, LastPartp = 0, LastNoun2 = 0, LastAdverb = 0;
 
-void FreeInputWords(void) {
+void FreeInputWords(void)
+{
     WordIndex = 0;
     if (InputWordStrings != NULL) {
         for (int i = 0; i < WordsInInput && InputWordStrings[i] != NULL; i++) {
@@ -43,7 +44,8 @@ void FreeInputWords(void) {
     WordsInInput = 0;
 }
 
-int CompareUpToHashSign(char *word1, char *word2) {
+int CompareUpToHashSign(char *word1, char *word2)
+{
     size_t len1 = strlen(word1);
     size_t len2 = strlen(word2);
     size_t longest = MAX(len1, len2);
@@ -58,7 +60,8 @@ int CompareUpToHashSign(char *word1, char *word2) {
     return 1;
 }
 
-int YesOrNo(void) {
+int YesOrNo(void)
+{
     glk_request_char_event(Bottom);
 
     event_t ev;
@@ -136,10 +139,11 @@ static int MatchingChars(const char *synonym, const char *original)
             return 0;
     }
 
-    return (i == strlen(synonym) && (original[i] == 0 || original[i] == ' ' || (i > 0 && original[i-1] == 0)));
+    return (i == strlen(synonym) && (original[i] == 0 || original[i] == ' ' || (i > 0 && original[i - 1] == 0)));
 }
 
-static int IsSynonymMatch(const char *synonym, const char *original) {
+static int IsSynonymMatch(const char *synonym, const char *original)
+{
     char c = synonym[0];
     if (c == 0)
         return -1;
@@ -154,13 +158,13 @@ static int IsSynonymMatch(const char *synonym, const char *original) {
     return -1;
 }
 
-static char *StripDoubleSpaces(char *result, int *len) {
+static char *StripDoubleSpaces(char *result, int *len)
+{
     int found = 0;
     do {
         found = 0;
         for (int i = 0; i < *len - 1; i++) {
-            if (isspace(result[i]) && isspace(result[i + 1]))
-            {
+            if (isspace(result[i]) && isspace(result[i + 1])) {
                 found = 1;
                 char new[512];
                 if (i > 0)
@@ -182,11 +186,11 @@ static char *StripDoubleSpaces(char *result, int *len) {
     return result;
 }
 
-static char *StripPunctuation(char *buf, int *len) {
+static char *StripPunctuation(char *buf, int *len)
+{
     for (int i = 0; i < *len; i++) {
         char c = buf[i];
-        if (c == '.' || c == ',' || c == ':' || c == ';' || c == '\'' || c == '\"' || c == '-' || c == '!')
-        {
+        if (c == '.' || c == ',' || c == ':' || c == ';' || c == '\'' || c == '\"' || c == '-' || c == '!') {
             buf[i] = ' ';
         }
     }
@@ -195,7 +199,6 @@ static char *StripPunctuation(char *buf, int *len) {
     memcpy(final, buf, *len + 1);
     return final;
 }
-
 
 static char *ConcatStrings(const char *head, int headlen, const char *mid, int midlen, const char *tail, int taillen)
 {
@@ -209,7 +212,6 @@ static char *ConcatStrings(const char *head, int headlen, const char *mid, int m
         result = StripDoubleSpaces(result, &totallen);
     return result;
 }
-
 
 static char *ReplaceString(char *source, const char *pattern, const char *replacement, int *startpos)
 {
@@ -241,7 +243,7 @@ static char *ReplaceString(char *source, const char *pattern, const char *replac
 static char *ReplaceSynonyms(char *buf, int *len)
 {
     char *result = MemAlloc(*len + 1);
-    for(int i = 0; i < *len; i++)
+    for (int i = 0; i < *len; i++)
         result[i] = toupper(buf[i]);
     result = StripDoubleSpaces(result, len);
     int finallen = (int)strlen(result);
@@ -314,7 +316,8 @@ static char **SplitIntoWords(const char *string, int length)
 
 WordToken *TokenWords = NULL;
 
-static int IntendedAsVerb(int i) {
+static int IntendedAsVerb(int i)
+{
     if (i == InitialIndex || i == 0)
         return 1;
     /* if the word before was an adverb and the one before that was not a verb */
@@ -323,7 +326,8 @@ static int IntendedAsVerb(int i) {
     return 0;
 }
 
-static void WordNotFoundError(int i) {
+static void WordNotFoundError(int i)
+{
     if (TokenWords[i].Type == ADVERB_TYPE)
         Display(Bottom, "%s do what?\n", InputWordStrings[i]);
     else if (IntendedAsVerb(i))
@@ -332,7 +336,8 @@ static void WordNotFoundError(int i) {
         Display(Bottom, "I don't know what %s means.\n", InputWordStrings[i]);
 }
 
-static int TokenizeInputWords(void) {
+static int TokenizeInputWords(void)
+{
     if (TokenWords != NULL)
         free(TokenWords);
     int word_not_found = -1;
@@ -445,20 +450,19 @@ static int TokenizeInputWords(void) {
     return 1;
 }
 
-int IsNextParticiple(int partp, int noun2) {
+int IsNextParticiple(int partp, int noun2)
+{
     if (WordIndex >= WordsInInput) {
         return 0;
     }
     if (partp == 1) { // None
         return 0;
     }
-    if (TokenWords[WordIndex].Type == NOUN_TYPE && partp == 2 &&
-        (noun2 == 0 || TokenWords[WordIndex].Index == noun2)) {
+    if (TokenWords[WordIndex].Type == NOUN_TYPE && partp == 2 && (noun2 == 0 || TokenWords[WordIndex].Index == noun2)) {
         CurPartp = 2;
         CurNoun2 = TokenWords[WordIndex++].Index;
         return 1;
-    } else if (TokenWords[WordIndex].Type == PREPOSITION_TYPE && WordIndex < WordsInInput - 1 &&
-        (partp == 0 || TokenWords[WordIndex].Index == partp)) {
+    } else if (TokenWords[WordIndex].Type == PREPOSITION_TYPE && WordIndex < WordsInInput - 1 && (partp == 0 || TokenWords[WordIndex].Index == partp)) {
         if (TokenWords[WordIndex + 1].Type == NOUN_TYPE && (noun2 == 0 || TokenWords[WordIndex + 1].Index == noun2)) {
             CurPartp = TokenWords[WordIndex++].Index;
             CurNoun2 = TokenWords[WordIndex++].Index;
@@ -684,7 +688,8 @@ static void LineInput(void)
     } while (WordsInInput == 0 || InputWordStrings == NULL);
 }
 
-static int RemainderContainsVerb(void) {
+static int RemainderContainsVerb(void)
+{
     debug_print("RemainderContainsVerb: WordIndex: %d WordsInInput: %d\n", WordIndex, WordsInInput);
     if (WordIndex < WordsInInput - 1) {
         for (int i = WordIndex; i < WordsInInput; i++)
@@ -694,7 +699,8 @@ static int RemainderContainsVerb(void) {
     return 0;
 }
 
-void StopProcessingCommand(void) {
+void StopProcessingCommand(void)
+{
     if (RemainderContainsVerb()) {
         Output("\nThe rest of your input was ignored. ");
     }

--- a/terps/plus/pcdraw.c
+++ b/terps/plus/pcdraw.c
@@ -11,47 +11,53 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "common.h"
 #include "glk.h"
 #include "graphics.h"
-#include "common.h"
 
 extern int at_last_line;
 
-int ycount=0;
-int skipy=1;
+int ycount = 0;
+int skipy = 1;
 
 /* palette handler stuff starts here */
 
 static void DrawDOSPixels(int pattern)
 {
-    int pix1,pix2,pix3,pix4;
+    int pix1, pix2, pix3, pix4;
     // Now get colors
-    pix1=(pattern & 0xc0)>>6;
-    pix2=(pattern & 0x30)>>4;
-    pix3=(pattern & 0x0c)>>2;
-    pix4=(pattern & 0x03);
+    pix1 = (pattern & 0xc0) >> 6;
+    pix2 = (pattern & 0x30) >> 4;
+    pix3 = (pattern & 0x0c) >> 2;
+    pix4 = (pattern & 0x03);
 
     if (!skipy) {
-        PutDoublePixel(x,y, pix1); x += 2;
-        PutDoublePixel(x,y, pix2); x += 2;
-        PutDoublePixel(x,y, pix3); x += 2;
-        PutDoublePixel(x,y, pix4); x += 2;
+        PutDoublePixel(x, y, pix1);
+        x += 2;
+        PutDoublePixel(x, y, pix2);
+        x += 2;
+        PutDoublePixel(x, y, pix3);
+        x += 2;
+        PutDoublePixel(x, y, pix4);
+        x += 2;
     } else {
-        PutPixel(x,y, pix1); x++;
-        PutPixel(x,y, pix2); x++;
-        PutPixel(x,y, pix3); x++;
-        PutPixel(x,y, pix4); x++;
+        PutPixel(x, y, pix1);
+        x++;
+        PutPixel(x, y, pix2);
+        x++;
+        PutPixel(x, y, pix3);
+        x++;
+        PutPixel(x, y, pix4);
+        x++;
     }
 
-    if (x >= xlen + xoff)
-    {
+    if (x >= xlen + xoff) {
         y += 2;
         x = xoff;
         ycount++;
     }
 
-    if (ycount > ylen)
-    {
+    if (ycount > ylen) {
         y = yoff + 1;
         at_last_line++;
         ycount = 0;
@@ -66,7 +72,8 @@ int DrawDOSImageFromData(uint8_t *ptr, size_t datasize)
 
     xlen = 0;
     ylen = 0;
-    xoff = 0; yoff = 0;
+    xoff = 0;
+    yoff = 0;
     ycount = 0;
     skipy = 1;
 
@@ -74,16 +81,18 @@ int DrawDOSImageFromData(uint8_t *ptr, size_t datasize)
     int c;
     int i;
     int rawoffset;
+    // clang-format off
     RGB black =   { 0,0,0 };
     RGB magenta = { 255,0,255 };
     RGB cyan =    { 0,255,255 };
     RGB white =   { 255,255,255 };
+    // clang-format on
 
     /* set up the palette */
-    SetColor(0,&black);
-    SetColor(1,&cyan);
-    SetColor(2,&magenta);
-    SetColor(3,&white);
+    SetColor(0, &black);
+    SetColor(1, &cyan);
+    SetColor(2, &magenta);
+    SetColor(3, &white);
 
     if (ptr == NULL) {
         fprintf(stderr, "DrawMSDOSImageFromData: ptr == NULL\n");
@@ -100,7 +109,8 @@ int DrawDOSImageFromData(uint8_t *ptr, size_t datasize)
     // Get whether it is lined
     ptr = origptr + 0x0d;
     work = *ptr++;
-    if (work == 0xff) skipy=0;
+    if (work == 0xff)
+        skipy = 0;
 
     // Get the offset
     ptr = origptr + 0x0f;
@@ -124,30 +134,25 @@ int DrawDOSImageFromData(uint8_t *ptr, size_t datasize)
     xlen = *ptr * 4;
 
     ptr = origptr + 0x17;
-    while (ptr - origptr < imagesize)
-    {
+    while (ptr - origptr < imagesize) {
         // First get count
         c = *ptr++;
 
-        if ((c & 0x80) == 0x80)
-        { // is a counter
+        if ((c & 0x80) == 0x80) { // is a counter
             work = *ptr++;
             c &= 0x7f;
-            for (i = 0; i <= c; i++)
-            {
+            for (i = 0; i <= c; i++) {
                 DrawDOSPixels(work);
             }
-        }
-        else
-        {
+        } else {
             // Don't count on the next j characters
-            for (i = 0; i <= c; i++)
-            {
+            for (i = 0; i <= c; i++) {
                 work = *ptr++;
                 DrawDOSPixels(work);
             }
         }
-        if (at_last_line > 1) break;
+        if (at_last_line > 1)
+            break;
     }
     return 1;
 }

--- a/terps/plus/plusmain.c
+++ b/terps/plus/plusmain.c
@@ -5,12 +5,12 @@
 //  Created by Petter Sjölund on 2022-05-06.
 //
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #include "glk.h"
@@ -19,6 +19,10 @@
 #endif
 #include "glkstart.h"
 
+#include "animations.h"
+#include "apple2detect.h"
+#include "atari8detect.h"
+#include "c64detect.h"
 #include "common.h"
 #include "definitions.h"
 #include "gameinfo.h"
@@ -26,13 +30,8 @@
 #include "layouttext.h"
 #include "loaddatabase.h"
 #include "parseinput.h"
-#include "animations.h"
 #include "restorestate.h"
-#include "apple2detect.h"
-#include "atari8detect.h"
-#include "c64detect.h"
 #include "stdetect.h"
-
 
 const char *game_file = NULL;
 char *DirPath = ".";
@@ -110,7 +109,6 @@ GLK_ATTRIBUTE_NORETURN void Fatal(const char *x)
     CleanupAndExit();
 }
 
-
 void *MemAlloc(size_t size)
 {
     void *t = (void *)malloc(size);
@@ -119,15 +117,18 @@ void *MemAlloc(size_t size)
     return (t);
 }
 
-void SetBit(int bit) {
+void SetBit(int bit)
+{
     BitFlags |= (uint64_t)1 << bit;
 }
 
-void ResetBit(int bit) {
+void ResetBit(int bit)
+{
     BitFlags &= ~((uint64_t)1 << bit);
 }
 
-int IsSet(int bit) {
+int IsSet(int bit)
+{
     return ((BitFlags & ((uint64_t)1 << bit)) != 0);
 }
 
@@ -137,13 +138,13 @@ void Display(winid_t w, const char *fmt, ...)
 {
     va_list ap;
     char msg[2048];
-    
+
     int size = sizeof msg;
-    
+
     va_start(ap, fmt);
     vsnprintf(msg, size, fmt, ap);
     va_end(ap);
-    
+
     glk_put_string_stream(glk_window_get_stream(w), msg);
     if (Transcript && w == Bottom)
         glk_put_string_stream(Transcript, msg);
@@ -162,13 +163,13 @@ static const glui32 OptimalPictureSize(glui32 *width, glui32 *height)
     multiplier = graphheight / h;
     if (w * multiplier > graphwidth)
         multiplier = graphwidth / w;
-    
+
     if (multiplier == 0)
         multiplier = 1;
-    
+
     *width = w * multiplier;
     *height = h * multiplier;
-    
+
     return multiplier;
 }
 
@@ -180,7 +181,7 @@ void OpenGraphicsWindow(void)
         return;
     glui32 graphwidth, graphheight, optimal_width, optimal_height;
     y_offset = 0;
-    
+
     if (Top == NULL)
         Top = FindGlkWindowWithRock(GLK_STATUS_ROCK);
     if (Graphics == NULL)
@@ -189,42 +190,42 @@ void OpenGraphicsWindow(void)
         glk_window_get_size(Top, &TopWidth, &TopHeight);
         glk_window_close(Top, NULL);
         Graphics = glk_window_open(Bottom, winmethod_Above | winmethod_Proportional,
-                                   60, wintype_Graphics, GLK_GRAPHICS_ROCK);
+            60, wintype_Graphics, GLK_GRAPHICS_ROCK);
         glk_window_get_size(Graphics, &graphwidth, &graphheight);
         pixel_size = OptimalPictureSize(&optimal_width, &optimal_height);
         x_offset = ((int)graphwidth - (int)optimal_width) / 2;
-        
+
         if (graphheight > optimal_height) {
             winid_t parent = glk_window_get_parent(Graphics);
             glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                       optimal_height, NULL);
+                optimal_height, NULL);
         }
-        
+
         /* Set the graphics window background to match
          * the main window background, best as we can,
          * and clear the window.
          */
         glui32 background_color;
         if (glk_style_measure(Bottom, style_Normal, stylehint_BackColor,
-                              &background_color)) {
+                &background_color)) {
             glk_window_set_background_color(Graphics, background_color);
             glk_window_clear(Graphics);
         }
-        
+
         Top = glk_window_open(Bottom, winmethod_Above | winmethod_Fixed, TopHeight,
-                              wintype_TextGrid, GLK_STATUS_ROCK);
+            wintype_TextGrid, GLK_STATUS_ROCK);
         glk_window_get_size(Top, &TopWidth, &TopHeight);
     } else {
         if (!Graphics)
             Graphics = glk_window_open(Bottom, winmethod_Above | winmethod_Proportional, 60,
-                                       wintype_Graphics, GLK_GRAPHICS_ROCK);
+                wintype_Graphics, GLK_GRAPHICS_ROCK);
         glk_window_get_size(Graphics, &graphwidth, &graphheight);
         pixel_size = OptimalPictureSize(&optimal_width, &optimal_height);
         x_offset = (graphwidth - optimal_width) / 2;
         winid_t parent = glk_window_get_parent(Graphics);
         if (parent)
             glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                   optimal_height, NULL);
+                optimal_height, NULL);
     }
 
     right_margin = optimal_width + x_offset;
@@ -241,28 +242,30 @@ void CloseGraphicsWindow(void)
     }
 }
 
-void SetTimer(glui32 milliseconds) {
+void SetTimer(glui32 milliseconds)
+{
     TimerRate = milliseconds;
     glk_request_timer_events(milliseconds);
 }
 
-void UpdateSettings(void) {
+void UpdateSettings(void)
+{
 #ifdef SPATTERLIGHT
     if (gli_sa_delays)
         Options &= ~NO_DELAYS;
     else
         Options |= NO_DELAYS;
 
-    switch(gli_sa_inventory) {
-        case 0:
-            Options &= ~(FORCE_INVENTORY | FORCE_INVENTORY_OFF);
-            break;
-        case 1:
-            Options = (Options | FORCE_INVENTORY) & ~FORCE_INVENTORY_OFF;
-            break;
-        case 2:
-            Options = (Options | FORCE_INVENTORY_OFF) & ~FORCE_INVENTORY;
-            break;
+    switch (gli_sa_inventory) {
+    case 0:
+        Options &= ~(FORCE_INVENTORY | FORCE_INVENTORY_OFF);
+        break;
+    case 1:
+        Options = (Options | FORCE_INVENTORY) & ~FORCE_INVENTORY_OFF;
+        break;
+    case 2:
+        Options = (Options | FORCE_INVENTORY_OFF) & ~FORCE_INVENTORY;
+        break;
     }
 
     if (gli_enable_graphics) {
@@ -273,10 +276,11 @@ void UpdateSettings(void) {
 #endif
 }
 
-static void FlushRoomDescription(char *buf,  int transcript);
+static void FlushRoomDescription(char *buf, int transcript);
 static void ListInventory(int upper);
 
-static void UpdateClaymorgueInventory(void) {
+static void UpdateClaymorgueInventory(void)
+{
     char *buf = MemAlloc(1000);
     buf = memset(buf, 0, 1000);
     room_description_stream = glk_stream_open_memory(buf, 1000, filemode_Write, 0);
@@ -342,7 +346,7 @@ void AnyKey(int timeout, int message)
     }
 
     glk_request_char_event(Bottom);
-    
+
     event_t ev;
     int result = 0;
 
@@ -397,7 +401,7 @@ static void PrintWindowDelimiter(void)
         glk_put_char(DelimiterChar);
 }
 
-static void FlushRoomDescription(char *buf,  int transcript)
+static void FlushRoomDescription(char *buf, int transcript)
 {
     glk_stream_close(room_description_stream, 0);
 
@@ -414,26 +418,26 @@ static void FlushRoomDescription(char *buf,  int transcript)
         free(roomtranscript);
         glk_put_string_stream(Transcript, " ");
     }
-    
+
     int print_delimiter = 1;
-    
+
     if (split_screen) {
         glk_window_clear(Top);
         glk_window_get_size(Top, &TopWidth, &TopHeight);
         int rows, length;
         char *text_with_breaks = LineBreakText(buf, TopWidth, &rows, &length);
-        
+
         glui32 bottomheight;
         glk_window_get_size(Bottom, NULL, &bottomheight);
         winid_t o2 = glk_window_get_parent(Top);
         if (!(bottomheight < 3 && TopHeight < rows)) {
             glk_window_get_size(Top, &TopWidth, &TopHeight);
             glk_window_set_arrangement(o2, winmethod_Above | winmethod_Fixed, rows,
-                                       Top);
+                Top);
         } else {
             print_delimiter = 0;
         }
-        
+
         int line = 0;
         int index = 0;
         int i;
@@ -455,34 +459,33 @@ static void FlushRoomDescription(char *buf,  int transcript)
             glk_window_move_cursor(Top, 0, line);
             Display(Top, "%s", string);
         }
-        
+
         if (line < rows - 1) {
             glk_window_get_size(Top, &TopWidth, &TopHeight);
             glk_window_set_arrangement(o2, winmethod_Above | winmethod_Fixed,
-                                       MIN(rows - 1, TopHeight - 1), Top);
+                MIN(rows - 1, TopHeight - 1), Top);
         }
-        
+
         free(text_with_breaks);
     } else {
         Display(Bottom, "%s", buf);
     }
-    
+
     if (print_delimiter) {
         PrintWindowDelimiter();
     }
-    
+
     if (buf != NULL) {
         free(buf);
         buf = NULL;
     }
 }
 
-
 static void WriteToRoomDescriptionStream(const char *fmt, ...)
 #ifdef __GNUC__
-__attribute__((__format__(__printf__, 1, 2)))
+    __attribute__((__format__(__printf__, 1, 2)))
 #endif
-;
+    ;
 
 static void WriteToRoomDescriptionStream(const char *fmt, ...)
 {
@@ -490,11 +493,11 @@ static void WriteToRoomDescriptionStream(const char *fmt, ...)
         return;
     va_list ap;
     char msg[2048];
-    
+
     va_start(ap, fmt);
     vsnprintf(msg, sizeof msg, fmt, ap);
     va_end(ap);
-    
+
     glk_put_string_stream(room_description_stream, msg);
 }
 
@@ -502,11 +505,11 @@ static void ListExits(void)
 {
     int ct = 0;
     int numexits = 0;
-    
+
     for (int i = 0; i < 6; i++)
         if (Rooms[MyLoc].Exits[i] != 0)
             numexits++;
-    
+
     if (numexits == 0) {
         WriteToRoomDescriptionStream("\n");
         return;
@@ -515,7 +518,7 @@ static void ListExits(void)
         WriteToRoomDescriptionStream(" I see exits ");
     else
         WriteToRoomDescriptionStream(" %s", sys[EXITS]);
-    
+
     for (int i = 0; i < 6; i++)
         if (Rooms[MyLoc].Exits[i] != 0) {
             if (ct) {
@@ -531,7 +534,8 @@ static void ListExits(void)
     WriteToRoomDescriptionStream(".\n");
 }
 
-static const char *IndefiniteArticle(const char *word) {
+static const char *IndefiniteArticle(const char *word)
+{
     char c = word[0];
     char vowels[6] = "aiouey";
     if (c == ' ')
@@ -542,18 +546,19 @@ static const char *IndefiniteArticle(const char *word) {
     return " a ";
 }
 
-void Look(int transcript) {
+void Look(int transcript)
+{
     showing_inventory = 0;
     found_match = 1;
     if (IsSet(DRAWBIT)) {
         ResetBit(DRAWBIT);
         DrawCurrentRoom();
     }
-    
+
     char *buf = MemAlloc(1000);
     buf = memset(buf, 0, 1000);
     room_description_stream = glk_stream_open_memory(buf, 1000, filemode_Write, 0);
-    
+
     Room *r;
     int ct;
 
@@ -570,9 +575,9 @@ void Look(int transcript) {
         FlushRoomDescription(buf, transcript);
         return;
     }
-    
+
     r = &Rooms[MyLoc];
-    
+
     if (!r->Text)
         return;
     /* An initial asterisk means the room description should not */
@@ -582,7 +587,7 @@ void Look(int transcript) {
     } else {
         WriteToRoomDescriptionStream("%s%s", sys[YOU_ARE], r->Text);
     }
-    
+
     ct = 0;
     int numobj = 0;
     for (int i = 0; i <= GameHeader.NumItems; i++)
@@ -601,9 +606,9 @@ void Look(int transcript) {
             ct++;
         }
     }
-    
+
     WriteToRoomDescriptionStream(".");
-    
+
     ListExits();
 
     if ((Options & FORCE_INVENTORY) && !(Options & FORCE_INVENTORY_OFF)) {
@@ -614,7 +619,6 @@ void Look(int transcript) {
     WriteToRoomDescriptionStream(" ");
     FlushRoomDescription(buf, transcript);
 }
-
 
 void Output(const char *string)
 {
@@ -647,7 +651,7 @@ void OpenTopWindow(void)
     if (Top == NULL) {
         if (split_screen) {
             Top = glk_window_open(Bottom, winmethod_Above | winmethod_Fixed,
-                                  TopHeight, wintype_TextGrid, GLK_STATUS_ROCK);
+                TopHeight, wintype_TextGrid, GLK_STATUS_ROCK);
             if (Top == NULL) {
                 split_screen = 0;
                 Top = Bottom;
@@ -667,7 +671,6 @@ static void DisplayInit(void)
     OpenGraphicsWindow();
 }
 
-
 static void OutputNumber(int a)
 {
     if (lastwasnewline) {
@@ -684,15 +687,15 @@ static void Delay(float seconds)
         return;
 
     event_t ev;
-    
+
     if (!glk_gestalt(gestalt_Timer, 0))
         return;
-    
+
     glk_request_char_event(Bottom);
     glk_cancel_char_event(Bottom);
-    
+
     SetTimer(1000 * seconds);
-    
+
     do {
         glk_select(&ev);
         Updates(ev);
@@ -731,9 +734,7 @@ static int CountItemsInRoom(int room)
 static int MatchUpItem(int noun, int loc)
 {
     for (int i = 0; i <= GameHeader.NumItems; i++)
-        if (Items[i].Dictword == noun &&
-            (Items[i].Location == loc || loc == -1) &&
-            (Items[i].Flag & 1))
+        if (Items[i].Dictword == noun && (Items[i].Location == loc || loc == -1) && (Items[i].Flag & 1))
             return i;
     return (0);
 }
@@ -776,7 +777,7 @@ static void PrintNoun(void)
     DictWord *dict = Nouns;
     for (int i = 0; dict->Word != NULL; i++) {
         if (dict->Group == CurNoun) {
-            Display(Bottom, "%s%s", lastwasnewline ? "": " ", dict->Word);
+            Display(Bottom, "%s%s", lastwasnewline ? "" : " ", dict->Word);
             lastwasnewline = 0;
             return;
         }
@@ -818,7 +819,8 @@ static void PlayerIsDead(void)
     Look(0);
 }
 
-void CheckForObjectImage(int obj) {
+void CheckForObjectImage(int obj)
+{
     for (int i = 0; i <= GameHeader.NumObjImg; i++)
         if (ObjectImages[i].Object == obj) {
             SetBit(DRAWBIT);
@@ -842,7 +844,7 @@ static void SwapCounters(int index)
         index = 63;
     }
     int temp = CurrentCounter;
-    
+
     CurrentCounter = Counters[index];
     Counters[index] = temp;
     debug_print("Value of new selected counter is %d\n", CurrentCounter);
@@ -873,7 +875,8 @@ static void DoneIt(void)
     }
 }
 
-static void WriteToLowerWindow(const char *fmt, ...) {
+static void WriteToLowerWindow(const char *fmt, ...)
+{
     va_list ap;
     char msg[2048];
 
@@ -892,7 +895,7 @@ static void ListInventory(int upper)
 {
     int i, ct = 0;
     int numcarried = 0;
-    
+
     for (i = 0; i <= GameHeader.NumItems; i++) {
         if (Items[i].Location == CARRIED && Items[i].Text[0] != 0)
             numcarried++;
@@ -909,7 +912,7 @@ static void ListInventory(int upper)
         print_function("%s", sys[INVENTORY]);
     else
         SystemMessage(INVENTORY);
-    
+
     for (i = 0; i <= GameHeader.NumItems; i++) {
         if (Items[i].Location == CARRIED) {
             if (Items[i].Text[0] == 0) {
@@ -917,14 +920,14 @@ static void ListInventory(int upper)
                 i++;
                 continue;
             }
-            
+
             if (ct) {
                 if (ct == numcarried - 1)
                     print_function(", and");
                 else
                     print_function("%s", sys[ITEM_DELIMITER]);
             }
-            
+
             print_function("%s%s", IndefiniteArticle(Items[i].Text), Items[i].Text);
             ct++;
         }
@@ -945,61 +948,62 @@ static void ClearScreen(void)
 
 void DrawApple2ImageFromVideoMem(void);
 
-static void SysCommand(int arg1, int arg2) {
+static void SysCommand(int arg1, int arg2)
+{
     switch (arg1) {
-        case 1:
-            SystemMessage(RESUME_A_SAVED_GAME);
-            if (YesOrNo())
-                LoadGame();
-            break;
-        case 2:
-            debug_print("Add special picture %d to animate buffer\n", Counters[arg2]);
-            AddSpecialImage(Counters[arg2]);
-            break;
-        case 3:
-            debug_print("Clear animate buffer\n");
-            ClearAnimationBuffer();
-            break;
-        case 4:
-            debug_print("Animate counter %d (%d)\n", arg2, Counters[arg2]);
-            Animate(Counters[arg2]);
-            break;
-        case 5:
-            debug_print("Unpack special picture %d (Set animation background)\n",arg2);
-            AnimationBackground = arg2;
-            break;
-        case 6:
-            debug_print("Beep and wait for key\n");
-            AnyKey(1, 1);
-            break;
-        case 7:
-            debug_print("DrawItemImage %d\n", Counters[arg2]);
-            DrawItemImage(Counters[arg2]);
-            if (CurrentSys == SYS_APPLE2)
-                DrawApple2ImageFromVideoMem();
-            break;
-        case 8:
-            debug_print("DrawRoomImage %d\n", Counters[arg2]);
-            DrawRoomImage(Counters[arg2]);
-            break;
-        case 9: {
-            debug_print("Swap item %d flags with counter 63\n", arg2);
-            int temp = Counters[63];
-            Counters[63] = Items[arg2].Flag;
-            Items[arg2].Flag = temp;
-            break;
-        }
-        case 10:
-            debug_print("Add item image %d to animate buffer\n", Counters[arg2]);
-            AddItemImage(Counters[arg2]);
-            break;
-        case 11:
-            debug_print("Add room image %d to animate buffer\n", Counters[arg2]);
-            AddRoomImage(Counters[arg2]);
-            break;
-        default:
-            debug_print("Unknown system command %d\n", arg1);
-            break;
+    case 1:
+        SystemMessage(RESUME_A_SAVED_GAME);
+        if (YesOrNo())
+            LoadGame();
+        break;
+    case 2:
+        debug_print("Add special picture %d to animate buffer\n", Counters[arg2]);
+        AddSpecialImage(Counters[arg2]);
+        break;
+    case 3:
+        debug_print("Clear animate buffer\n");
+        ClearAnimationBuffer();
+        break;
+    case 4:
+        debug_print("Animate counter %d (%d)\n", arg2, Counters[arg2]);
+        Animate(Counters[arg2]);
+        break;
+    case 5:
+        debug_print("Unpack special picture %d (Set animation background)\n", arg2);
+        AnimationBackground = arg2;
+        break;
+    case 6:
+        debug_print("Beep and wait for key\n");
+        AnyKey(1, 1);
+        break;
+    case 7:
+        debug_print("DrawItemImage %d\n", Counters[arg2]);
+        DrawItemImage(Counters[arg2]);
+        if (CurrentSys == SYS_APPLE2)
+            DrawApple2ImageFromVideoMem();
+        break;
+    case 8:
+        debug_print("DrawRoomImage %d\n", Counters[arg2]);
+        DrawRoomImage(Counters[arg2]);
+        break;
+    case 9: {
+        debug_print("Swap item %d flags with counter 63\n", arg2);
+        int temp = Counters[63];
+        Counters[63] = Items[arg2].Flag;
+        Items[arg2].Flag = temp;
+        break;
+    }
+    case 10:
+        debug_print("Add item image %d to animate buffer\n", Counters[arg2]);
+        AddItemImage(Counters[arg2]);
+        break;
+    case 11:
+        debug_print("Add room image %d to animate buffer\n", Counters[arg2]);
+        AddRoomImage(Counters[arg2]);
+        break;
+    default:
+        debug_print("Unknown system command %d\n", arg1);
+        break;
     }
 }
 
@@ -1009,59 +1013,61 @@ typedef enum {
     RIGHT_PAREN
 } ParenType;
 
-static ParenType SetLogicControlFlags(int mode, int *not_mode, int *not_continuous, int *or_mode, int *fuzzy_match) {
+static ParenType SetLogicControlFlags(int mode, int *not_mode, int *not_continuous, int *or_mode, int *fuzzy_match)
+{
     ParenType paren = NO_PAREN;
-debug_print("Mode %d, ", mode);
-    switch(mode) {
-        case 0:
-            *or_mode = 0;
-            break;
-        case 1:
-            debug_print("OR mode!\n");
-            *or_mode = 1;
-            break;
-        case 2:
-            Fatal("Unimplemented XOR mode");
-        case 3:
-            debug_print("Negate single!\n");
-            *not_mode = 1;
-            break;
-        case 4:
-            debug_print("Negate multiple!\n");
-            *not_continuous = 1;
-            *not_mode = 1;
-            break;
-        case 5:
-            debug_print("Cancel negate!\n");
-            *not_continuous = 0;
-            *not_mode = 0;
-            break;
-        case 6:
-            debug_print("Left paren!\n");
-            paren = LEFT_PAREN;
-            break;
-        case 7:
-            debug_print("Right paren!\n");
-            paren = RIGHT_PAREN;
-            break;
-        case 8:
-            debug_print("Keep going (Always true)!\n");
-            break;
-        case 9:
-            debug_print("Fuzzy match!\n");
-            *fuzzy_match = 1;
-            break;
-        case 10:
-            debug_print("Strict match!\n");
-            *fuzzy_match = 0;
-            break;
-        default:
-            debug_print("Unhandled logic control flag %d\n", mode);
+    debug_print("Mode %d, ", mode);
+    switch (mode) {
+    case 0:
+        *or_mode = 0;
+        break;
+    case 1:
+        debug_print("OR mode!\n");
+        *or_mode = 1;
+        break;
+    case 2:
+        Fatal("Unimplemented XOR mode");
+    case 3:
+        debug_print("Negate single!\n");
+        *not_mode = 1;
+        break;
+    case 4:
+        debug_print("Negate multiple!\n");
+        *not_continuous = 1;
+        *not_mode = 1;
+        break;
+    case 5:
+        debug_print("Cancel negate!\n");
+        *not_continuous = 0;
+        *not_mode = 0;
+        break;
+    case 6:
+        debug_print("Left paren!\n");
+        paren = LEFT_PAREN;
+        break;
+    case 7:
+        debug_print("Right paren!\n");
+        paren = RIGHT_PAREN;
+        break;
+    case 8:
+        debug_print("Keep going (Always true)!\n");
+        break;
+    case 9:
+        debug_print("Fuzzy match!\n");
+        *fuzzy_match = 1;
+        break;
+    case 10:
+        debug_print("Strict match!\n");
+        *fuzzy_match = 0;
+        break;
+    default:
+        debug_print("Unhandled logic control flag %d\n", mode);
     }
     return paren;
 }
 
-int CalculateConditionResult(int x, int y, int or_condition) {
+int CalculateConditionResult(int x, int y, int or_condition)
+{
     if (or_condition == 0) {
         return (x && y);
     }
@@ -1072,7 +1078,8 @@ int CalculateConditionResult(int x, int y, int or_condition) {
 int parens_depth = 0;
 int parens_stack[5];
 
-static ActionResultType TestConditions(uint16_t *ptr) {
+static ActionResultType TestConditions(uint16_t *ptr)
+{
     int negate_condition = 0;
     int negate_multiple = 0;
     int or_condition = 0;
@@ -1105,234 +1112,234 @@ static ActionResultType TestConditions(uint16_t *ptr) {
         current_result = 1;
 
         switch (cv) {
-            case 0:
-                break;
-            case 1:
-                debug_print("Does the player carry %s?\n", Items[dv].Text);
-                if (Items[dv].Location != CARRIED) {
-                    current_result = 0;
-                }
-                break;
-            case 2:
-                if (dv < 0 || dv > GameHeader.NumItems) {
-                    debug_print("Parameter out of range! (%d)\n", dv);
-                    current_result = 0;
-                    break;
-                }
-
-                debug_print("Is %s in location?\n", Items[dv].Text);
-                if (Items[dv].Location != MyLoc) {
-                    current_result = 0;
-                }
-                break;
-            case 3:
-                debug_print("Is %s held or in location?\n", Items[dv].Text);
-                if (Items[dv].Location != CARRIED && Items[dv].Location != MyLoc) {
-                    current_result = 0;
-                }
-                break;
-            case 4:
-                debug_print("Is location room %d, %s?\n", dv, Rooms[dv].Text);
-                if (MyLoc != dv)
-                    current_result = 0;
-                break;
-            case 5:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is description of room %d (counter %d) (%d) == Message %d?\n", Counters[dv], dv, Rooms[Counters[dv]].Exits[6], dv2);
-                if (Rooms[Counters[dv]].Exits[6] != dv2)
-                    return ACT_FAILURE;
-                break;
-            case 8:
-                debug_print("Is bitflag %d set?\n", dv);
-                if (!IsSet(dv)) {
-                    current_result = 0;
-                }
-                break;
-            case 9:
-                debug_print("Is bitflag %d NOT set?\n", dv);
-                if (IsSet(dv)) {
-                    current_result = 0;
-                }
-                break;
-            case 10:
-                debug_print("Does the player carry anything?\n");
-                if (CountItemsInRoom(dv) == 0) {
-                    current_result = 0;
-                }
-                break;
-            case 13:
-                debug_print("Is %s (%d) in play?\n", Items[dv].Text, dv);
-                if (Items[dv].Location == 0) {
-                    current_result = 0;
-                }
-                break;
-            case 14:
-                debug_print("Is %s NOT in play?\n", Items[dv].Text);
-                if (Items[dv].Location) {
-                    current_result = 0;
-                }
-                break;
-            case 15:
-                debug_print("Is CurrentCounter <= %d?\n", dv);
-                if (CurrentCounter > dv) {
-                    current_result = 0;
-                }
-                break;
-            case 16:
-                debug_print("Is CurrentCounter > %d?\n", dv);
-                if (CurrentCounter <= dv) {
-                    current_result = 0;
-                }
-                break;
-            case 17:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is Counter %d == Counter %d?\n", dv, dv2);
-
-                if (Counters[dv] != Counters[dv2]) {
-                    current_result = 0;
-                }
-                break;
-            case 18:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is counter %d (%d) greater than counter %d (%d)?\n", dv, Counters[dv], dv2,  Counters[dv2]);
-                if (Counters[dv] <= Counters[dv2]) {
-                    current_result = 0;
-                }
-                break;
-            case 19:
-                debug_print("Is current counter == %d?\n", dv);
-                if (CurrentCounter != dv) {
-                    current_result = 0;
-                }
-                break;
-            case 20:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is counter %d (%d) == %d?\n", dv, Counters[dv], dv2);
-                if (Counters[dv] != dv2)
-                    current_result = 0;
-                break;
-
-            case 21:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is counter %d (%d) >= %d?\n", dv, Counters[dv], dv2);
-                if (Counters[dv] < dv2)
-                    current_result = 0;
-                break;
-            case 22:
-                debug_print("Is counter %d (%d) == 0?\n", dv, Counters[dv]);
-                if (Counters[dv] != 0)
-                    current_result = 0;
-                break;
-            case 23:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is item %d (%s) in room (counter %d) %d?\n", dv, Items[dv].Text, dv2, Counters[dv2]);
-                if (Items[dv].Location != Counters[dv2])
-                    current_result = 0;
-                break;
-            case 26:
-                cc++;
-                dv2 = ptr[cc++];
-                debug_print("Is object %d in room %d?\n", dv, dv2);
-                if (Items[dv].Location != dv2)
-                    current_result = 0;
-
-                break;
-            case 28:
-                cc++;
-                dv2 = ptr[cc++];
-                if (dv < 1 || dv2 < 1 || dv > GameHeader.NumItems + 1 || dv2 > GameHeader.NumItems + 1)
-                    debug_print("Is dictword of item (dv) %d == dictword group (dv2) %d?\n", dv, dv2);
-                else
-                    debug_print("Is dictword (%d) of item %d (%s) == dictword (%d) of item %d (%s)?\n", Items[dv].Dictword, dv, Items[dv].Text, Items[dv2].Dictword, dv2, Items[dv2].Text);
-                if (originaldv == 999) {
-                    if (CurNoun2 == dv2)
-                        break;
-                    current_result = 0;
-                } else if (originaldv == 998) {
-                    if (CurNoun == dv2)
-                        break;
-                    current_result = 0;
-                } else if (originaldv == 997) {
-                    Fatal("With list unimplemented");
-                } else {
-                    if (Items[dv].Dictword == 0)
-                        break;
-                    if (dv > GameHeader.NumItems + 1 || dv2 > GameHeader.NumItems + 1 || Items[dv].Dictword != Items[dv2].Dictword) {
-                        current_result = 0;
-                        if (dv > GameHeader.NumItems + 1 || dv2 > GameHeader.NumItems + 1)
-                            debug_print("Error: Argument out of bounds\n!");
-                    }
-                }
-                break;
-            case 29:
-                cc++;
-                dv2 = ptr[cc++];
-                if (dv2 == 998)
-                    dv2 = CurNoun;
-                else if (dv2 == 999)
-                    dv2 = CurNoun2;
-                else if (dv2 == 997)
-                    Fatal("With list unimplemented");
-                debug_print("Is dictword of object %d (%s) %d? (%s)\n", dv, Nouns[GetDictWord(Items[NounObject].Dictword)].Word, dv2, Nouns[GetDictWord(dv2)].Word);
-                if (fuzzy_match) {
-                    debug_print("(Fuzzy match)\n");
-                    char *dictword1 = Nouns[GetDictWord(Items[NounObject].Dictword)].Word;
-                    char *dictword2 = Nouns[GetDictWord(dv2)].Word;
-                    if (!CompareUpToHashSign(dictword1, dictword2))
-                        current_result = 0;
-                } else {
-                    debug_print("(Exact match)\n");
-                    if (Items[NounObject].Dictword != dv2) {
-                        current_result = 0;
-                    }
-                }
-                break;
-            case 30:
-                cc++;
-                dv2 = ptr[cc++];
-                if (dv > GameHeader.NumItems)
-                    debug_print("Bug! dv Out of bounds! dv:%d GameHeader.NumItems:%d\n", dv, GameHeader.NumItems);
-                debug_print("Is Object flag %d & %d != 0\n", dv, dv2);
-                if ((Items[dv].Flag & dv2) == 0)
-                    current_result = 0;
-                break;
-            case 31: /* logics control flags */
-            {
-
-                if (dv == 1 && one_success == 0) {
-                    last_result = 0;
-                }
-
-                ParenType paren = SetLogicControlFlags(dv, &negate_condition, &negate_multiple, &or_condition, &fuzzy_match);
-
-                if (paren == LEFT_PAREN) {
-                    if (parens_depth >= 4)
-                        Fatal("Too many nested parentheses in conditions");
-                    parens_stack[parens_depth] = last_result;
-                    debug_print("left parent.n\nSet parens_stack[%d] to last result %d\n", parens_depth, last_result);
-                    last_result = (or_condition == 0);
-                    parens_depth++;
-                } else if (paren == RIGHT_PAREN) {
-                    if (parens_depth <= 0)
-                        Fatal("Mismatched parentheses");
-                    parens_depth--;
-                    debug_print("right parens.\n\nGetting pushed result %d from parens_stack[%d]\n", parens_stack[parens_depth], parens_depth);
-                    current_result = last_result;
-                    last_result = parens_stack[parens_depth];
-                    last_result = CalculateConditionResult(last_result, current_result, or_condition);
-                }
-                break;
+        case 0:
+            break;
+        case 1:
+            debug_print("Does the player carry %s?\n", Items[dv].Text);
+            if (Items[dv].Location != CARRIED) {
+                current_result = 0;
             }
-            default:
-                debug_print("Unknown condition %d, arg == %d\n", cv, dv);
+            break;
+        case 2:
+            if (dv < 0 || dv > GameHeader.NumItems) {
+                debug_print("Parameter out of range! (%d)\n", dv);
                 current_result = 0;
                 break;
+            }
+
+            debug_print("Is %s in location?\n", Items[dv].Text);
+            if (Items[dv].Location != MyLoc) {
+                current_result = 0;
+            }
+            break;
+        case 3:
+            debug_print("Is %s held or in location?\n", Items[dv].Text);
+            if (Items[dv].Location != CARRIED && Items[dv].Location != MyLoc) {
+                current_result = 0;
+            }
+            break;
+        case 4:
+            debug_print("Is location room %d, %s?\n", dv, Rooms[dv].Text);
+            if (MyLoc != dv)
+                current_result = 0;
+            break;
+        case 5:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is description of room %d (counter %d) (%d) == Message %d?\n", Counters[dv], dv, Rooms[Counters[dv]].Exits[6], dv2);
+            if (Rooms[Counters[dv]].Exits[6] != dv2)
+                return ACT_FAILURE;
+            break;
+        case 8:
+            debug_print("Is bitflag %d set?\n", dv);
+            if (!IsSet(dv)) {
+                current_result = 0;
+            }
+            break;
+        case 9:
+            debug_print("Is bitflag %d NOT set?\n", dv);
+            if (IsSet(dv)) {
+                current_result = 0;
+            }
+            break;
+        case 10:
+            debug_print("Does the player carry anything?\n");
+            if (CountItemsInRoom(dv) == 0) {
+                current_result = 0;
+            }
+            break;
+        case 13:
+            debug_print("Is %s (%d) in play?\n", Items[dv].Text, dv);
+            if (Items[dv].Location == 0) {
+                current_result = 0;
+            }
+            break;
+        case 14:
+            debug_print("Is %s NOT in play?\n", Items[dv].Text);
+            if (Items[dv].Location) {
+                current_result = 0;
+            }
+            break;
+        case 15:
+            debug_print("Is CurrentCounter <= %d?\n", dv);
+            if (CurrentCounter > dv) {
+                current_result = 0;
+            }
+            break;
+        case 16:
+            debug_print("Is CurrentCounter > %d?\n", dv);
+            if (CurrentCounter <= dv) {
+                current_result = 0;
+            }
+            break;
+        case 17:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is Counter %d == Counter %d?\n", dv, dv2);
+
+            if (Counters[dv] != Counters[dv2]) {
+                current_result = 0;
+            }
+            break;
+        case 18:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is counter %d (%d) greater than counter %d (%d)?\n", dv, Counters[dv], dv2, Counters[dv2]);
+            if (Counters[dv] <= Counters[dv2]) {
+                current_result = 0;
+            }
+            break;
+        case 19:
+            debug_print("Is current counter == %d?\n", dv);
+            if (CurrentCounter != dv) {
+                current_result = 0;
+            }
+            break;
+        case 20:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is counter %d (%d) == %d?\n", dv, Counters[dv], dv2);
+            if (Counters[dv] != dv2)
+                current_result = 0;
+            break;
+
+        case 21:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is counter %d (%d) >= %d?\n", dv, Counters[dv], dv2);
+            if (Counters[dv] < dv2)
+                current_result = 0;
+            break;
+        case 22:
+            debug_print("Is counter %d (%d) == 0?\n", dv, Counters[dv]);
+            if (Counters[dv] != 0)
+                current_result = 0;
+            break;
+        case 23:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is item %d (%s) in room (counter %d) %d?\n", dv, Items[dv].Text, dv2, Counters[dv2]);
+            if (Items[dv].Location != Counters[dv2])
+                current_result = 0;
+            break;
+        case 26:
+            cc++;
+            dv2 = ptr[cc++];
+            debug_print("Is object %d in room %d?\n", dv, dv2);
+            if (Items[dv].Location != dv2)
+                current_result = 0;
+
+            break;
+        case 28:
+            cc++;
+            dv2 = ptr[cc++];
+            if (dv < 1 || dv2 < 1 || dv > GameHeader.NumItems + 1 || dv2 > GameHeader.NumItems + 1)
+                debug_print("Is dictword of item (dv) %d == dictword group (dv2) %d?\n", dv, dv2);
+            else
+                debug_print("Is dictword (%d) of item %d (%s) == dictword (%d) of item %d (%s)?\n", Items[dv].Dictword, dv, Items[dv].Text, Items[dv2].Dictword, dv2, Items[dv2].Text);
+            if (originaldv == 999) {
+                if (CurNoun2 == dv2)
+                    break;
+                current_result = 0;
+            } else if (originaldv == 998) {
+                if (CurNoun == dv2)
+                    break;
+                current_result = 0;
+            } else if (originaldv == 997) {
+                Fatal("With list unimplemented");
+            } else {
+                if (Items[dv].Dictword == 0)
+                    break;
+                if (dv > GameHeader.NumItems + 1 || dv2 > GameHeader.NumItems + 1 || Items[dv].Dictword != Items[dv2].Dictword) {
+                    current_result = 0;
+                    if (dv > GameHeader.NumItems + 1 || dv2 > GameHeader.NumItems + 1)
+                        debug_print("Error: Argument out of bounds\n!");
+                }
+            }
+            break;
+        case 29:
+            cc++;
+            dv2 = ptr[cc++];
+            if (dv2 == 998)
+                dv2 = CurNoun;
+            else if (dv2 == 999)
+                dv2 = CurNoun2;
+            else if (dv2 == 997)
+                Fatal("With list unimplemented");
+            debug_print("Is dictword of object %d (%s) %d? (%s)\n", dv, Nouns[GetDictWord(Items[NounObject].Dictword)].Word, dv2, Nouns[GetDictWord(dv2)].Word);
+            if (fuzzy_match) {
+                debug_print("(Fuzzy match)\n");
+                char *dictword1 = Nouns[GetDictWord(Items[NounObject].Dictword)].Word;
+                char *dictword2 = Nouns[GetDictWord(dv2)].Word;
+                if (!CompareUpToHashSign(dictword1, dictword2))
+                    current_result = 0;
+            } else {
+                debug_print("(Exact match)\n");
+                if (Items[NounObject].Dictword != dv2) {
+                    current_result = 0;
+                }
+            }
+            break;
+        case 30:
+            cc++;
+            dv2 = ptr[cc++];
+            if (dv > GameHeader.NumItems)
+                debug_print("Bug! dv Out of bounds! dv:%d GameHeader.NumItems:%d\n", dv, GameHeader.NumItems);
+            debug_print("Is Object flag %d & %d != 0\n", dv, dv2);
+            if ((Items[dv].Flag & dv2) == 0)
+                current_result = 0;
+            break;
+        case 31: /* logics control flags */
+        {
+
+            if (dv == 1 && one_success == 0) {
+                last_result = 0;
+            }
+
+            ParenType paren = SetLogicControlFlags(dv, &negate_condition, &negate_multiple, &or_condition, &fuzzy_match);
+
+            if (paren == LEFT_PAREN) {
+                if (parens_depth >= 4)
+                    Fatal("Too many nested parentheses in conditions");
+                parens_stack[parens_depth] = last_result;
+                debug_print("left parent.n\nSet parens_stack[%d] to last result %d\n", parens_depth, last_result);
+                last_result = (or_condition == 0);
+                parens_depth++;
+            } else if (paren == RIGHT_PAREN) {
+                if (parens_depth <= 0)
+                    Fatal("Mismatched parentheses");
+                parens_depth--;
+                debug_print("right parens.\n\nGetting pushed result %d from parens_stack[%d]\n", parens_stack[parens_depth], parens_depth);
+                current_result = last_result;
+                last_result = parens_stack[parens_depth];
+                last_result = CalculateConditionResult(last_result, current_result, or_condition);
+            }
+            break;
+        }
+        default:
+            debug_print("Unknown condition %d, arg == %d\n", cv, dv);
+            current_result = 0;
+            break;
         }
 
         if (cv != 31) {
@@ -1363,31 +1370,38 @@ static ActionResultType TestConditions(uint16_t *ptr) {
         return ACT_FAILURE;
 }
 
-static void PrintFlagInfo(int arg) {
+static void PrintFlagInfo(int arg)
+{
     switch (arg) {
-        case 15: debug_print("15, darkbit\n");
-            break;
-        case 33: debug_print("33, a command matched on vocabulary, but its conditions failed\n");
-            break;
-        case 34: debug_print("34, room picture changed\n");
-            break;
-        case 35: debug_print("35, graphics on/off\n");
-            break;
-        case 60: debug_print("60, first action matches regardless of input\n");
-            break;
-        case 63: debug_print("63, skip automatics (stop time)\n");
-            break;
-        default:
-            break;
+    case 15:
+        debug_print("15, darkbit\n");
+        break;
+    case 33:
+        debug_print("33, a command matched on vocabulary, but its conditions failed\n");
+        break;
+    case 34:
+        debug_print("34, room picture changed\n");
+        break;
+    case 35:
+        debug_print("35, graphics on/off\n");
+        break;
+    case 60:
+        debug_print("60, first action matches regardless of input\n");
+        break;
+    case 63:
+        debug_print("63, skip automatics (stop time)\n");
+        break;
+    default:
+        break;
     }
 }
 
 static ActionResultType PerformLine(int ct)
 {
-debug_print("\nPerforming line %d: ", ct);
+    debug_print("\nPerforming line %d: ", ct);
     int continuation = 0, dead = 0, done = 0;
     int loop = 0;
-    
+
     int cc = 0;
 
     if (TestConditions(Actions[ct].Conditions) == ACT_FAILURE) {
@@ -1397,7 +1411,7 @@ debug_print("\nPerforming line %d: ", ct);
 #if defined(__clang__)
 #pragma mark Commands
 #endif
-    
+
     /* Commands */
     cc = 0;
     uint8_t *commands = Actions[ct].Commands;
@@ -1405,7 +1419,7 @@ debug_print("\nPerforming line %d: ", ct);
     while (cc <= length) {
         int cmd = commands[cc++];
         int16_t arg1 = 0, arg2 = 0, arg3 = 0,
-        ca1 = 0, ca2 = 0, ca3 = 0;
+                ca1 = 0, ca2 = 0, ca3 = 0;
 
         int object = 0;
         int plus_one_arg = 0;
@@ -1442,420 +1456,420 @@ debug_print("\nPerforming line %d: ", ct);
                 Fatal("With list unimplemented");
             }
         }
-        
+
         debug_print("\nPerforming command %d: ", cmd);
         if (cmd >= 1 && cmd < 52) {
             PrintMessage(cmd);
         } else
             switch (cmd) {
-                case 0: /* NOP */
-                    break;
-                case 52:
-                    if (CountItemsInRoom(0) >= GameHeader.MaxCarry) {
-                        SystemMessage(YOURE_CARRYING_TOO_MUCH);
-                        lastwasnewline = 1;
-                        return ACT_SUCCESS;
-                    }
-                    Items[object].Location = CARRIED;
-                    CheckForObjectImage(object);
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 53:
-                    debug_print("Item %d (\"%s\") is now in location.\n", object,
-                            Items[object].Text);
-                    Items[object].Location = MyLoc;
-                    CheckForObjectImage(object);
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 54:
-                    debug_print("Player location is now room %d (%s).\n", arg1,
-                            Rooms[arg1].Text);
-                    MyLoc = commands[cc++];
-                    SetBit(DRAWBIT);
-                    break;
-                case 55:
-                    debug_print("The command is changed to ");
-                    PrintDictWord(arg1, Verbs);
-                    debug_print(" ");
-                    PrintDictWord(arg2, Nouns);
-                    debug_print(".\n");
-                    CurVerb = arg1;
-                    CurNoun = arg2;
-                    CurPartp = 0;
-                    CurPrep = 0;
-                    CurNoun2 = 0;
-                    keep_going = 1;
-                    done = 1;
-                    found_match = 0;
-                    cc += 2;
-                    break;
-                case 56:
-                    SetBit(DARKBIT);
-                    break;
-                case 57:
-                    ResetBit(DARKBIT);
-                    break;
-                case 58:
-                    debug_print("Bitflag %d is set\n", arg1);
+            case 0: /* NOP */
+                break;
+            case 52:
+                if (CountItemsInRoom(0) >= GameHeader.MaxCarry) {
+                    SystemMessage(YOURE_CARRYING_TOO_MUCH);
+                    lastwasnewline = 1;
+                    return ACT_SUCCESS;
+                }
+                Items[object].Location = CARRIED;
+                CheckForObjectImage(object);
+                cc += 1 + plus_one_arg;
+                break;
+            case 53:
+                debug_print("Item %d (\"%s\") is now in location.\n", object,
+                    Items[object].Text);
+                Items[object].Location = MyLoc;
+                CheckForObjectImage(object);
+                cc += 1 + plus_one_arg;
+                break;
+            case 54:
+                debug_print("Player location is now room %d (%s).\n", arg1,
+                    Rooms[arg1].Text);
+                MyLoc = commands[cc++];
+                SetBit(DRAWBIT);
+                break;
+            case 55:
+                debug_print("The command is changed to ");
+                PrintDictWord(arg1, Verbs);
+                debug_print(" ");
+                PrintDictWord(arg2, Nouns);
+                debug_print(".\n");
+                CurVerb = arg1;
+                CurNoun = arg2;
+                CurPartp = 0;
+                CurPrep = 0;
+                CurNoun2 = 0;
+                keep_going = 1;
+                done = 1;
+                found_match = 0;
+                cc += 2;
+                break;
+            case 56:
+                SetBit(DARKBIT);
+                break;
+            case 57:
+                ResetBit(DARKBIT);
+                break;
+            case 58:
+                debug_print("Bitflag %d is set\n", arg1);
 #ifdef DEBUG_ACTIONS
-                    PrintFlagInfo(arg1);
+                PrintFlagInfo(arg1);
 #endif
-                    SetBit(commands[cc++]);
-                    break;
-                case 59:
-                    debug_print("Item %d (%s) is removed from play.\n", object,
-                            Items[object].Text);
-                    Items[object].Location = 0;
-                    CheckForObjectImage(object);
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 60:
-                    debug_print("BitFlag %d is cleared\n", arg1);
-                    PrintFlagInfo(arg1);
-                    ResetBit(commands[cc++]);
-                    break;
-                case 61:
-                    PlayerIsDead();
-                    break;
-                case 62:
-                    cc += 1 + plus_one_arg;
-                    PutItemAInRoomB(object, commands[cc++]);
-                    break;
-                case 63:
-                    debug_print("Dead\n");
-                    DoneIt();
-                    dead = 1;
-                    break;
-                case 64:
-                    debug_print("Counter %d == %d\n", arg2, arg1);
-                    Counters[arg2] = arg1;
-                    cc += 2 + plus_one_arg;
-                    break;
-                case 65:
-                    debug_print("Multiply: Counter %d = Counter %d (%d) * Counter %d (%d) == %d\n", arg2, arg1, ca1, arg2, ca2, ca1 * ca2);
-                    Counters[arg2] = ca1 * ca2;
-                    cc += 2;
-                    break;
-                case 66:
-                    ListInventory(0);
-                    if (CurrentGame == CLAYMORGUE)
-                        UpdateClaymorgueInventory();
-                    break;
-                case 67:
-                    debug_print("Set bitflag 0\n");
-                    SetBit(0);
-                    break;
-                case 68:
-                    debug_print("Clear bitflag 0\n");
-                    ResetBit(0);
-                    break;
-                case 69:
-                    debug_print("Done (stop reading lines)\n");
-                    done = 1;
-                    break;
-                case 70:
-                    ClearScreen();
-                    break;
-                case 71:
-                    SaveGame();
-                    break;
-                case 72:
-                    cc += 1 + plus_one_arg;
-                    CheckForObjectImage(object);
-                    CheckForObjectImage(commands[cc]);
-                    SwapItemLocations(object, commands[cc++]);
-                    break;
-                case 73:
-                    debug_print("Continue with next line\n");
-                    continuation = 1;
-                    break;
-                case 74:
-                    Items[object].Location = CARRIED;
-                    CheckForObjectImage(object);
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 75:
-                    cc += 1 + plus_one_arg;
-                    CheckForObjectImage(object);
-                    MoveItemAToLocOfItemB(object, commands[cc++]);
-                    break;
-                case 76:
-                    debug_print("LOOK\n");
-                    Look(1);
-                    break;
-                case 77:
-                    if (CurrentCounter >= 1)
-                        CurrentCounter--;
-                    debug_print("decrementing current counter. Current counter is now %d.\n",
-                            CurrentCounter);
-                    break;
-                case 78:
-                    OutputNumber(CurrentCounter);
-                    break;
-                case 79:
-                    debug_print("CurrentCounter is set to %d.\n", arg1);
-                    CurrentCounter = arg1;
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 80:
-                    debug_print("Counter %d is set to location of object %d.\n", arg2, object);
-                    Counters[arg2] = Items[object].Location;
-                    cc += 2 + plus_one_arg;
-                    break;
-                case 81:
-                    SwapCounters(commands[cc++]);
-                    break;
-                case 82:
-                    debug_print("Add %d to current counter(%d)\n", arg1, CurrentCounter);
-                    CurrentCounter += arg1;
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 83:
-                    CurrentCounter -= arg1;
-                    if (CurrentCounter < -1)
-                        CurrentCounter = -1;
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 84:
-                    PrintNoun();
-                    break;
-                case 85:
-                    debug_print("Print name of item %d (%s)\n", object, Items[object].Text);
-                    Display(Bottom, " %s",  Items[object].Text);
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 86:
-                    debug_print("Output dictword of item (%d) + space.\n", arg1);
-                    Display(Bottom, "%s ", Nouns[GetDictWord(Items[arg1].Dictword)].Word);
-                    cc++;
-                    break;
-                case 88:
-                    debug_print("Delay\n");
-                    Delay(1);
-                    break;
-                case 89:
-                    debug_print("Draw current room image\n");
-                    DrawCurrentRoom();
-                    ResetBit(DRAWBIT);
-                    break;
-                case 90:
-                    debug_print("Draw closeup image %d\n", arg1);
-                    DrawCloseup(commands[cc++]);
+                SetBit(commands[cc++]);
+                break;
+            case 59:
+                debug_print("Item %d (%s) is removed from play.\n", object,
+                    Items[object].Text);
+                Items[object].Location = 0;
+                CheckForObjectImage(object);
+                cc += 1 + plus_one_arg;
+                break;
+            case 60:
+                debug_print("BitFlag %d is cleared\n", arg1);
+                PrintFlagInfo(arg1);
+                ResetBit(commands[cc++]);
+                break;
+            case 61:
+                PlayerIsDead();
+                break;
+            case 62:
+                cc += 1 + plus_one_arg;
+                PutItemAInRoomB(object, commands[cc++]);
+                break;
+            case 63:
+                debug_print("Dead\n");
+                DoneIt();
+                dead = 1;
+                break;
+            case 64:
+                debug_print("Counter %d == %d\n", arg2, arg1);
+                Counters[arg2] = arg1;
+                cc += 2 + plus_one_arg;
+                break;
+            case 65:
+                debug_print("Multiply: Counter %d = Counter %d (%d) * Counter %d (%d) == %d\n", arg2, arg1, ca1, arg2, ca2, ca1 * ca2);
+                Counters[arg2] = ca1 * ca2;
+                cc += 2;
+                break;
+            case 66:
+                ListInventory(0);
+                if (CurrentGame == CLAYMORGUE)
+                    UpdateClaymorgueInventory();
+                break;
+            case 67:
+                debug_print("Set bitflag 0\n");
+                SetBit(0);
+                break;
+            case 68:
+                debug_print("Clear bitflag 0\n");
+                ResetBit(0);
+                break;
+            case 69:
+                debug_print("Done (stop reading lines)\n");
+                done = 1;
+                break;
+            case 70:
+                ClearScreen();
+                break;
+            case 71:
+                SaveGame();
+                break;
+            case 72:
+                cc += 1 + plus_one_arg;
+                CheckForObjectImage(object);
+                CheckForObjectImage(commands[cc]);
+                SwapItemLocations(object, commands[cc++]);
+                break;
+            case 73:
+                debug_print("Continue with next line\n");
+                continuation = 1;
+                break;
+            case 74:
+                Items[object].Location = CARRIED;
+                CheckForObjectImage(object);
+                cc += 1 + plus_one_arg;
+                break;
+            case 75:
+                cc += 1 + plus_one_arg;
+                CheckForObjectImage(object);
+                MoveItemAToLocOfItemB(object, commands[cc++]);
+                break;
+            case 76:
+                debug_print("LOOK\n");
+                Look(1);
+                break;
+            case 77:
+                if (CurrentCounter >= 1)
+                    CurrentCounter--;
+                debug_print("decrementing current counter. Current counter is now %d.\n",
+                    CurrentCounter);
+                break;
+            case 78:
+                OutputNumber(CurrentCounter);
+                break;
+            case 79:
+                debug_print("CurrentCounter is set to %d.\n", arg1);
+                CurrentCounter = arg1;
+                cc += 1 + plus_one_arg;
+                break;
+            case 80:
+                debug_print("Counter %d is set to location of object %d.\n", arg2, object);
+                Counters[arg2] = Items[object].Location;
+                cc += 2 + plus_one_arg;
+                break;
+            case 81:
+                SwapCounters(commands[cc++]);
+                break;
+            case 82:
+                debug_print("Add %d to current counter(%d)\n", arg1, CurrentCounter);
+                CurrentCounter += arg1;
+                cc += 1 + plus_one_arg;
+                break;
+            case 83:
+                CurrentCounter -= arg1;
+                if (CurrentCounter < -1)
+                    CurrentCounter = -1;
+                cc += 1 + plus_one_arg;
+                break;
+            case 84:
+                PrintNoun();
+                break;
+            case 85:
+                debug_print("Print name of item %d (%s)\n", object, Items[object].Text);
+                Display(Bottom, " %s", Items[object].Text);
+                cc += 1 + plus_one_arg;
+                break;
+            case 86:
+                debug_print("Output dictword of item (%d) + space.\n", arg1);
+                Display(Bottom, "%s ", Nouns[GetDictWord(Items[arg1].Dictword)].Word);
+                cc++;
+                break;
+            case 88:
+                debug_print("Delay\n");
+                Delay(1);
+                break;
+            case 89:
+                debug_print("Draw current room image\n");
+                DrawCurrentRoom();
+                ResetBit(DRAWBIT);
+                break;
+            case 90:
+                debug_print("Draw closeup image %d\n", arg1);
+                DrawCloseup(commands[cc++]);
+                SetBit(DRAWBIT);
+                AnyKey(0, 1);
+                break;
+            case 91:
+                debug_print("Divide: Counter %d = Counter %d (%d) / counter %d (%d), Counter %d = Counter %d (%d) / counter %d (%d)\n", arg2, arg2, ca2, arg1, ca1, arg3, arg2, ca2, arg1, ca1);
+                if (ca1) {
+                    Counters[arg3] = ca2 % ca1;
+                    Counters[arg2] = ca2 / ca1;
+                }
+                cc += 3;
+                break;
+            case 92:
+                debug_print("Domore reset\n");
+                keep_going = 0;
+                break;
+            case 93:
+                debug_print("Delay Counter %d (%d) * .25 seconds (%f)\n", arg1, Counters[arg1], Counters[arg1] * 0.25);
+                if (CurrentGame == CLAYMORGUE)
+                    Delay(Counters[arg1] * 0.125);
+                else
+                    Delay(Counters[arg1] * 0.25);
+                cc++;
+                break;
+            case 94:
+                debug_print("Counter %d = exit %d from room %d\n", arg1, ca3, ca2);
+                Counters[arg1] = Rooms[ca2].Exits[ca3];
+                cc += 3;
+                break;
+            case 95:
+                debug_print("Exit %d of room %d is set to %d\n", ca2, ca1, ca3);
+                Rooms[ca1].Exits[ca2] = ca3;
+                cc += 3;
+                break;
+            case 97:
+                debug_print("Swap counters %d %d \n", arg1, arg2);
+                /* Draw room image after jumping off Claymorgue crate */
+                if (arg1 == 32 && ca2 != MyLoc)
                     SetBit(DRAWBIT);
-                    AnyKey(0, 1);
-                    break;
-                case 91:
-                    debug_print("Divide: Counter %d = Counter %d (%d) / counter %d (%d), Counter %d = Counter %d (%d) / counter %d (%d)\n", arg2, arg2, ca2, arg1, ca1, arg3, arg2, ca2, arg1, ca1);
-                    if (ca1) {
-                        Counters[arg3] = ca2 % ca1;
-                        Counters[arg2] = ca2 / ca1;
-                    }
-                    cc += 3;
-                    break;
-                case 92:
-                    debug_print("Domore reset\n");
-                    keep_going = 0;
-                    break;
-                case 93:
-                    debug_print("Delay Counter %d (%d) * .25 seconds (%f)\n", arg1, Counters[arg1], Counters[arg1] * 0.25);
-                    if (CurrentGame == CLAYMORGUE)
-                        Delay(Counters[arg1] * 0.125);
-                    else
-                        Delay(Counters[arg1] * 0.25);
-                    cc++;
-                    break;
-                case 94:
-                    debug_print("Counter %d = exit %d from room %d\n", arg1, ca3, ca2);
-                    Counters[arg1] = Rooms[ca2].Exits[ca3];
-                    cc += 3;
-                    break;
-                case 95:
-                    debug_print("Exit %d of room %d is set to %d\n",  ca2, ca1, ca3);
-                    Rooms[ca1].Exits[ca2] = ca3;
-                    cc += 3;
-                    break;
-                case 97:
-                    debug_print("Swap counters %d %d \n", arg1, arg2);
-                    /* Draw room image after jumping off Claymorgue crate */
-                    if (arg1 == 32 && ca2 != MyLoc)
-                        SetBit(DRAWBIT);
-                    Counters[arg1] = ca2;
-                    Counters[arg2] = ca1;
-                    cc += 2;
-                    break;
-                case 98:
-                    debug_print("Counter %d = counter %d\n", arg2, arg1);
-                    Counters[arg2] = ca1;
-                    cc += 2;
-                    break;
-                case 99:
-                    debug_print("Counter %d is set to %d \n", arg2, arg1);
-                    Counters[arg2] = arg1;
-                    cc += 2 + plus_one_arg;
-                    break;
-                case 100:
-                    debug_print("Add %d to counter %d\n", arg1, arg2);
-                    Counters[arg2] += arg1;
-                    cc += 2 + plus_one_arg;
-                    break;
-                case 101:
-                    debug_print("Decrease counter %d by %d\n", arg2, arg1);
-                    Counters[arg2] -= arg1;
-                    cc += 2 + plus_one_arg;
-                    break;
-                case 102:
-                    debug_print("Print counter %d\n", arg1);
-                    OutputNumber(Counters[arg1]);
-                    cc++;
-                    break;
-                case 103:
-                    debug_print("ABS counter %d\n", arg1);
-                    if (ca1 < 0)
-                        Counters[arg1] = -ca1;
-                    cc++;
-                    break;
-                case 104:
-                    debug_print("NEG counter %d\n", arg1);
-                    Counters[arg1] = -Counters[arg1];
-                    cc++;
-                    break;
-                case 105:
-                    debug_print("AND counter %d with counter %d\n", arg2, arg1);
-                    Counters[arg2] = ca1 & ca2;
-                    cc += 2;
-                    break;
-                case 106:
-                    debug_print("OR counter %d with counter %d\n", arg2, arg1);
-                    Counters[arg2] = ca1 | ca2;
-                    cc += 2;
-                    break;
-                case 107:
-                    debug_print("XOR counter %d with counter %d\n", arg2, arg1);
-                    Counters[arg2] = ca1 ^ ca2;
-                    cc += 2;
-                    break;
-                case 108:
-                    debug_print("Put random number (1 to 100) in counter %d\n", arg1);
-                    uint64_t rv = (uint64_t)rand() << 6;
-                    rv &= 0xffffffff;
-                    rv %= 100 + 1;
-                    Counters[arg1] = rv;
-                    cc++;
-                    break;
-                case 109:
-                    debug_print("Clear counter %d\n", arg1);
-                    Counters[arg1] = 0;
-                    cc++;
-                    break;
-                case 110:
-                    debug_print("System command %d %d\n", arg1, arg2);
-                    SysCommand(arg1, arg2);
-                    cc += 2;
-                    break;
-                case 111:
-                    debug_print("Start over\n");
-                    keep_going = 1;
-                    done = 1;
-                    startover = 1;
-                    break;
-                case 112:
-                    debug_print("Start loop\n");
-                    loop = 1;
-                    break;
-                case 113:
-                    debug_print("Loop back\n");
-                    return ACT_LOOP;
-                case 114:
+                Counters[arg1] = ca2;
+                Counters[arg2] = ca1;
+                cc += 2;
+                break;
+            case 98:
+                debug_print("Counter %d = counter %d\n", arg2, arg1);
+                Counters[arg2] = ca1;
+                cc += 2;
+                break;
+            case 99:
+                debug_print("Counter %d is set to %d \n", arg2, arg1);
+                Counters[arg2] = arg1;
+                cc += 2 + plus_one_arg;
+                break;
+            case 100:
+                debug_print("Add %d to counter %d\n", arg1, arg2);
+                Counters[arg2] += arg1;
+                cc += 2 + plus_one_arg;
+                break;
+            case 101:
+                debug_print("Decrease counter %d by %d\n", arg2, arg1);
+                Counters[arg2] -= arg1;
+                cc += 2 + plus_one_arg;
+                break;
+            case 102:
+                debug_print("Print counter %d\n", arg1);
+                OutputNumber(Counters[arg1]);
+                cc++;
+                break;
+            case 103:
+                debug_print("ABS counter %d\n", arg1);
+                if (ca1 < 0)
+                    Counters[arg1] = -ca1;
+                cc++;
+                break;
+            case 104:
+                debug_print("NEG counter %d\n", arg1);
+                Counters[arg1] = -Counters[arg1];
+                cc++;
+                break;
+            case 105:
+                debug_print("AND counter %d with counter %d\n", arg2, arg1);
+                Counters[arg2] = ca1 & ca2;
+                cc += 2;
+                break;
+            case 106:
+                debug_print("OR counter %d with counter %d\n", arg2, arg1);
+                Counters[arg2] = ca1 | ca2;
+                cc += 2;
+                break;
+            case 107:
+                debug_print("XOR counter %d with counter %d\n", arg2, arg1);
+                Counters[arg2] = ca1 ^ ca2;
+                cc += 2;
+                break;
+            case 108:
+                debug_print("Put random number (1 to 100) in counter %d\n", arg1);
+                uint64_t rv = (uint64_t)rand() << 6;
+                rv &= 0xffffffff;
+                rv %= 100 + 1;
+                Counters[arg1] = rv;
+                cc++;
+                break;
+            case 109:
+                debug_print("Clear counter %d\n", arg1);
+                Counters[arg1] = 0;
+                cc++;
+                break;
+            case 110:
+                debug_print("System command %d %d\n", arg1, arg2);
+                SysCommand(arg1, arg2);
+                cc += 2;
+                break;
+            case 111:
+                debug_print("Start over\n");
+                keep_going = 1;
+                done = 1;
+                startover = 1;
+                break;
+            case 112:
+                debug_print("Start loop\n");
+                loop = 1;
+                break;
+            case 113:
+                debug_print("Loop back\n");
+                return ACT_LOOP;
+            case 114:
                 // 114 and 115 are now functionally the same, so at least one of them is wrong.
                 // 114 is supposed to be instant while 115 is supposed to
                 // do a 114 at the next loopback (113).
                 // Things seems to work fine this way, however, and I'm not even sure what
                 // the difference would be in practice.
-                    debug_print("Remove a loop from stack\n");
-                    loops[loop_index] = 0;
-                    if (loop_index > 0)
-                        loop_index--;
-                    break;
-                case 115:
-                    debug_print("Remove a loop from stack at next loopback\n");
-                    if (loop_index > 0)
-                        loop_index--;
-                    break;
-                case 116:
-                    debug_print("Continue looking for commands\n");
-                    debug_print("found_match = 0, domore = 1, done = 1\n");
-                    found_match = 0;
-                    keep_going = 1;
-                    done = 1;
-                    break;
-                case 117:
-                    debug_print("Set found_match to 1\n");
-                    found_match = 1;
-                    SetBit(MATCHBIT);
-                    break;
-                case 118:
-                    debug_print("Set done to 1\n");
-                    done = 1;
-                    break;
-                case 119:
-                    cc++;
-                    if (arg1 >= 128) {
-                        arg1 = commands[cc++] - 76;
-                    }
-                    debug_print("Set command prompt to string arg %d (%s)\n", arg1, Messages[arg1]);
-                    ProtagonistString = arg1;
-                    break;
-                case 120:
-                    debug_print("counter 48: verb, counter 49: noun, counter 50: preposition, counter 51: adverb, counter 52: participle, counter 53: noun 2\n");
-                case 121:
-                    debug_print("Set input words to counters 48 to 53\n");
-                    keep_going = 1;
-                    done = 1;
-                    found_match = 0;
-                    break;
-                case 122:
-                    debug_print("Print object %d with article\n", object);
-                    Display(Bottom, "%s%s", IndefiniteArticle(Items[object].Text),  Items[object].Text);
-                    cc += 1 + plus_one_arg;
-                    break;
-                case 123:
-                    debug_print("Add counter %d to counter %d.\n", arg1, arg2);
-                    Counters[arg2] += ca1;
-                    cc += 2;
-                    break;
-                case 124:
-                    debug_print("Reset all loops.\n");
-                    loop_index = 0;
-                    break;
-                case 125:
-                    debug_print("Flag %d = Flag %d.\n", arg2, arg1);
-                    if (IsSet(arg1))
-                        SetBit(arg2);
-                    else
-                        ResetBit(arg2);
-                    cc += 2;
-                    break;
-                case 126:
-                    debug_print("Counter (Counter %d) = Counter %d\n", arg2, arg1);
-                    Counters[ca2] = ca1;
-                    cc += 2;
-                    break;
-                case 127:
-                    debug_print("Counter %d = Counter (Counter %d)\n", arg2, arg1);
-                    Counters[arg2]  = Counters[ca1];
-                    cc += 2;
-                    break;
-                case 128:
-                    PrintMessage(commands[cc++] - 76);
-                    break;
-                default:
-                    if (cc < length - 1)
+                debug_print("Remove a loop from stack\n");
+                loops[loop_index] = 0;
+                if (loop_index > 0)
+                    loop_index--;
+                break;
+            case 115:
+                debug_print("Remove a loop from stack at next loopback\n");
+                if (loop_index > 0)
+                    loop_index--;
+                break;
+            case 116:
+                debug_print("Continue looking for commands\n");
+                debug_print("found_match = 0, domore = 1, done = 1\n");
+                found_match = 0;
+                keep_going = 1;
+                done = 1;
+                break;
+            case 117:
+                debug_print("Set found_match to 1\n");
+                found_match = 1;
+                SetBit(MATCHBIT);
+                break;
+            case 118:
+                debug_print("Set done to 1\n");
+                done = 1;
+                break;
+            case 119:
+                cc++;
+                if (arg1 >= 128) {
+                    arg1 = commands[cc++] - 76;
+                }
+                debug_print("Set command prompt to string arg %d (%s)\n", arg1, Messages[arg1]);
+                ProtagonistString = arg1;
+                break;
+            case 120:
+                debug_print("counter 48: verb, counter 49: noun, counter 50: preposition, counter 51: adverb, counter 52: participle, counter 53: noun 2\n");
+            case 121:
+                debug_print("Set input words to counters 48 to 53\n");
+                keep_going = 1;
+                done = 1;
+                found_match = 0;
+                break;
+            case 122:
+                debug_print("Print object %d with article\n", object);
+                Display(Bottom, "%s%s", IndefiniteArticle(Items[object].Text), Items[object].Text);
+                cc += 1 + plus_one_arg;
+                break;
+            case 123:
+                debug_print("Add counter %d to counter %d.\n", arg1, arg2);
+                Counters[arg2] += ca1;
+                cc += 2;
+                break;
+            case 124:
+                debug_print("Reset all loops.\n");
+                loop_index = 0;
+                break;
+            case 125:
+                debug_print("Flag %d = Flag %d.\n", arg2, arg1);
+                if (IsSet(arg1))
+                    SetBit(arg2);
+                else
+                    ResetBit(arg2);
+                cc += 2;
+                break;
+            case 126:
+                debug_print("Counter (Counter %d) = Counter %d\n", arg2, arg1);
+                Counters[ca2] = ca1;
+                cc += 2;
+                break;
+            case 127:
+                debug_print("Counter %d = Counter (Counter %d)\n", arg2, arg1);
+                Counters[arg2] = Counters[ca1];
+                cc += 2;
+                break;
+            case 128:
+                PrintMessage(commands[cc++] - 76);
+                break;
+            default:
+                if (cc < length - 1)
                     debug_print("Unknown action %d [Param begins %d %d]\n", cmd,
-                            commands[cc], commands[cc + 1]);
-                    break;
+                        commands[cc], commands[cc + 1]);
+                break;
             }
     }
-    
+
     if (dead) {
         debug_print("PerformLine: Returning ACT_GAMEOVER\n");
         return ACT_GAMEOVER;
@@ -1874,7 +1888,8 @@ debug_print("\nPerforming line %d: ", ct);
     }
 }
 
-static int IsExtraWordMatch(int ct) {
+static int IsExtraWordMatch(int ct)
+{
     /* If the action has no "extra words" the command must contain no participle */
     if (Actions[ct].NumWords == 0) {
         return (CurPartp == 0);
@@ -1891,51 +1906,49 @@ static int IsExtraWordMatch(int ct) {
     debug_print("Action %d has %d extra words\n", ct, Actions[ct].NumWords);
 
     for (int i = 0; i < Actions[ct].NumWords; i++) {
-        uint8_t word =  Actions[ct].Words[i];
+        uint8_t word = Actions[ct].Words[i];
         debug_print("Extra word %d: %d ", i, word);
         uint8_t wordval = word & 63;
         switch (word >> 6) {
-            case 1: /* adverb */
-                debug_print("(adverb)\n");
-                foundadverb = 1;
-                if (wordval == CurAdverb || wordval == 0 || (wordval == 1 && CurAdverb == 0))
-                    matchedadverb = 1;
-                debug_print("Matched adverb %d (%s)\n", wordval, Prepositions[GetAnyDictWord(wordval, Adverbs)].Word);
+        case 1: /* adverb */
+            debug_print("(adverb)\n");
+            foundadverb = 1;
+            if (wordval == CurAdverb || wordval == 0 || (wordval == 1 && CurAdverb == 0))
+                matchedadverb = 1;
+            debug_print("Matched adverb %d (%s)\n", wordval, Prepositions[GetAnyDictWord(wordval, Adverbs)].Word);
+            break;
+        case 2: /* participle */
+            debug_print("(participle)\n");
+            i++;
+            foundpartp = 1;
+            uint8_t n2 = Actions[ct].Words[i];
+            if (CurPartp == 0 && wordval > 1 && !IsNextParticiple(wordval, n2)) {
                 break;
-            case 2: /* participle */
-                debug_print("(participle)\n");
-                i++;
-                foundpartp = 1;
-                uint8_t n2 = Actions[ct].Words[i];
-                if (CurPartp == 0 && wordval > 1 && !IsNextParticiple(wordval, n2)) {
-                    break;
+            }
+            if (wordval == CurPartp || wordval == 0 || (wordval == 1 && CurPartp == 0)) { /* 1 means NONE */
+                debug_print("Matched participle %d (%s)\n", wordval, Prepositions[GetAnyDictWord(wordval, Prepositions)].Word);
+                if (n2 == CurNoun2 || n2 == 0) {
+                    debug_print("Matched object %d (%s)\n", n2, Nouns[GetDictWord(n2)].Word);
+                    matchedpartp = 1;
                 }
-                if (wordval == CurPartp || wordval == 0 || (wordval == 1 && CurPartp == 0)) { /* 1 means NONE */
-                    debug_print("Matched participle %d (%s)\n", wordval, Prepositions[GetAnyDictWord(wordval, Prepositions)].Word);
-                    if (n2 == CurNoun2 || n2 == 0) {
-                        debug_print("Matched object %d (%s)\n", n2, Nouns[GetDictWord(n2)].Word);
-                        matchedpartp = 1;
-                    }
-                }
-                break;
-            case 3: /* preposition */
-                debug_print("(preposition)\n");
-                foundprep = 1;
-                if (CurPrep == wordval || wordval == 0 || (wordval == 1 && CurPrep == 0)) {
-                    debug_print("Matched preposition %d (%s)\n", wordval, Prepositions[GetAnyDictWord(wordval, Prepositions)].Word);
-                    matchedprep = 1;
-                }
-                break;
-            default:
-                debug_print("(unknown type)\n");
-                debug_print("word >> 6: %d\n", word >> 6);
-                break;
+            }
+            break;
+        case 3: /* preposition */
+            debug_print("(preposition)\n");
+            foundprep = 1;
+            if (CurPrep == wordval || wordval == 0 || (wordval == 1 && CurPrep == 0)) {
+                debug_print("Matched preposition %d (%s)\n", wordval, Prepositions[GetAnyDictWord(wordval, Prepositions)].Word);
+                matchedprep = 1;
+            }
+            break;
+        default:
+            debug_print("(unknown type)\n");
+            debug_print("word >> 6: %d\n", word >> 6);
+            break;
         }
     }
 
-    if ((foundprep && !matchedprep) ||
-        (foundpartp && !matchedpartp) ||
-        (foundadverb && !matchedadverb)) {
+    if ((foundprep && !matchedprep) || (foundpartp && !matchedpartp) || (foundadverb && !matchedadverb)) {
         debug_print("IsExtraWordMatch failed\n");
         return 0;
     }
@@ -1943,26 +1956,28 @@ static int IsExtraWordMatch(int ct) {
     return 1;
 }
 
-static int IsImplicitMatch(int ct, int doagain) {
+static int IsImplicitMatch(int ct, int doagain)
+{
 
     if (RandomPercent(Actions[ct].NounOrChance)) {
         return 1;
     }
-    
+
     if (doagain)
         return 1;
-    
+
     return 0;
 }
 
-static int IsMatch(int ct, int doagain) {
+static int IsMatch(int ct, int doagain)
+{
 
     int verbvalue = Actions[ct].Verb;
     int nounvalue = Actions[ct].NounOrChance;
-    
+
     if (verbvalue != CurVerb && !(doagain && verbvalue == 0))
         return 0;
-    
+
     if (verbvalue == 0) {
         if (RandomPercent(nounvalue)) {
             return 1;
@@ -1970,7 +1985,7 @@ static int IsMatch(int ct, int doagain) {
             return 0;
         }
     }
-    
+
     if (!(doagain && verbvalue == 0) && !IsExtraWordMatch(ct)) {
         return 0;
     }
@@ -1996,52 +2011,52 @@ static CommandResultType PerformImplicit(void)
 
     while (ct <= GameHeader.NumActions) {
         int verbvalue = Actions[ct].Verb;
-        
+
         if (verbvalue != 0)
             break;
-        
+
         if (IsImplicitMatch(ct, chain_on)) {
             ActionResultType actresult = PerformLine(ct);
-            
+
             if (actresult != ACT_FAILURE) {
                 result = ER_SUCCESS;
                 switch (actresult) {
-                    case ACT_CONTINUE:
-                        chain_on = 1;
-                        break;
-                    case ACT_DONE:
-                        chain_on = 0;
-                        loops[loop_index] = 0;
-                        if (loop_index)
-                            loop_index--;
-                        break;
-                    case ACT_LOOP_BEGIN:
-                        loop_index++;
-                        if (loop_index >= MAX_LOOPS)
-                            Fatal("Loop stack overflow");
-                        loops[loop_index] = ct;
-                        chain_on = 1;
-                        break;
-                    case ACT_LOOP:
-                        if (loop_index) {
-                            ct = loops[loop_index];
-                        }
-                        break;
-                    case ACT_GAMEOVER:
-                        return ER_SUCCESS;
-                    default:
-                        break;
+                case ACT_CONTINUE:
+                    chain_on = 1;
+                    break;
+                case ACT_DONE:
+                    chain_on = 0;
+                    loops[loop_index] = 0;
+                    if (loop_index)
+                        loop_index--;
+                    break;
+                case ACT_LOOP_BEGIN:
+                    loop_index++;
+                    if (loop_index >= MAX_LOOPS)
+                        Fatal("Loop stack overflow");
+                    loops[loop_index] = ct;
+                    chain_on = 1;
+                    break;
+                case ACT_LOOP:
+                    if (loop_index) {
+                        ct = loops[loop_index];
+                    }
+                    break;
+                case ACT_GAMEOVER:
+                    return ER_SUCCESS;
+                default:
+                    break;
                 }
             }
         }
-        
+
         ct++;
 
         if (startover) {
             ct = 0;
             startover = 0;
         }
-        
+
         if (ct <= GameHeader.NumActions && (Actions[ct].Verb + Actions[ct].NounOrChance != 0))
             chain_on = 0;
 
@@ -2050,7 +2065,7 @@ static CommandResultType PerformImplicit(void)
             return result;
         }
     }
-    
+
     return result;
 }
 
@@ -2078,7 +2093,7 @@ static CommandResultType PerformExplicit(void)
 
         if (IsMatch(ct, chain_on)) {
             ActionResultType actresult = PerformLine(ct);
-            
+
             if (actresult != ACT_FAILURE) {
                 if (actresult != ACT_DONE)
                     ResetBit(MATCHBIT);
@@ -2088,33 +2103,33 @@ static CommandResultType PerformExplicit(void)
                 } else {
                     result = ER_RAN_ALL_LINES;
                 }
-                
+
                 switch (actresult) {
-                    case ACT_CONTINUE:
-                        chain_on = 1;
-                        break;
-                    case ACT_DONE:
-                        chain_on = 0;
-                        loops[loop_index] = 0;
-                        if (loop_index)
-                            loop_index--;
-                        break;
-                    case ACT_LOOP_BEGIN:
-                        loop_index++;
-                        if (loop_index >= MAX_LOOPS)
-                            Fatal("Loop stack overflow");
-                        loops[loop_index] = ct;
-                        chain_on = 1;
-                        break;
-                    case ACT_LOOP:
-                        if (loop_index) {
-                            ct = loops[loop_index];
-                        }
-                        break;
-                    case ACT_GAMEOVER:
-                        return ER_SUCCESS;
-                    default:
-                        break;
+                case ACT_CONTINUE:
+                    chain_on = 1;
+                    break;
+                case ACT_DONE:
+                    chain_on = 0;
+                    loops[loop_index] = 0;
+                    if (loop_index)
+                        loop_index--;
+                    break;
+                case ACT_LOOP_BEGIN:
+                    loop_index++;
+                    if (loop_index >= MAX_LOOPS)
+                        Fatal("Loop stack overflow");
+                    loops[loop_index] = ct;
+                    chain_on = 1;
+                    break;
+                case ACT_LOOP:
+                    if (loop_index) {
+                        ct = loops[loop_index];
+                    }
+                    break;
+                case ACT_GAMEOVER:
+                    return ER_SUCCESS;
+                default:
+                    break;
                 }
             } else {
                 if (verbvalue == CurVerb && (nounvalue == CurNoun || nounvalue == 0))
@@ -2128,7 +2143,7 @@ static CommandResultType PerformExplicit(void)
             ct = 0;
             startover = 0;
         }
-        
+
         if (ct <= GameHeader.NumActions && (Actions[ct].Verb != 0)) {
             chain_on = 0;
         }
@@ -2149,15 +2164,15 @@ int glkunix_startup_code(glkunix_startup_t *data)
 {
     int argc = data->argc;
     char **argv = data->argv;
-    
+
     if (argc < 1)
         return 0;
-    
+
 #ifdef GARGLK
     garglk_set_program_name("Plus 1.0");
     garglk_set_program_info("Plus 1.0 by Petter Sjölund");
 #endif
-    
+
     if (argc == 2) {
         game_file = argv[1];
 
@@ -2178,11 +2193,12 @@ int glkunix_startup_code(glkunix_startup_t *data)
             debug_print("Directory path: \"%s\"\n", DirPath);
         }
     }
-    
+
     return 1;
 }
 
-void ResizeTitleImage(void) {
+void ResizeTitleImage(void)
+{
     glui32 graphwidth, graphheight, optimal_width, optimal_height;
 #ifdef SPATTERLIGHT
     glk_window_set_background_color(Graphics, gbgcol);
@@ -2195,8 +2211,8 @@ void ResizeTitleImage(void) {
     y_offset = ((int)graphheight - (int)optimal_height) / 3;
 }
 
-
-void DrawTitleImage(void) {
+void DrawTitleImage(void)
+{
     DisplayInit();
 #ifdef SPATTERLIGHT
     if (!gli_enable_graphics)
@@ -2213,7 +2229,7 @@ void DrawTitleImage(void) {
         glk_request_char_event(Graphics);
     } else {
         Bottom = glk_window_open(Graphics, winmethod_Below | winmethod_Fixed,
-                                 2, wintype_TextBuffer, GLK_BUFFER_ROCK);
+            2, wintype_TextBuffer, GLK_BUFFER_ROCK);
         glk_request_char_event(Bottom);
     }
 
@@ -2249,7 +2265,8 @@ void DrawTitleImage(void) {
     DisplayInit();
 }
 
-void glk_main(void) {
+void glk_main(void)
+{
     if (game_file == NULL)
         Fatal("No game file");
 
@@ -2258,11 +2275,10 @@ void glk_main(void) {
         if (sysdict_i_am[i])
             sys[i] = sysdict_i_am[i];
     }
-    
+
     FILE *f = fopen(game_file, "r");
     if (f == NULL)
         Fatal("Cannot open game");
-
 
     if (LoadDatabasePlaintext(f, DEBUG_ACTIONS) == UNKNOWN_GAME) {
         fseek(f, 0, SEEK_END);
@@ -2357,7 +2373,7 @@ void glk_main(void) {
                 SystemMessage(YOU_CANT_DO_THAT_YET);
             StopProcessingCommand();
         }
-        
+
         JustStarted = 0;
     }
 }

--- a/terps/plus/restorestate.c
+++ b/terps/plus/restorestate.c
@@ -6,17 +6,16 @@
 //
 
 #include <inttypes.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-#include "glk.h"
-#include "common.h"
 #include "animations.h"
+#include "common.h"
+#include "glk.h"
 #include "graphics.h"
 #include "parseinput.h"
 #include "restorestate.h"
-
 
 #define MAX_UNDOS 100
 
@@ -184,7 +183,7 @@ void SaveGame(void)
     char buf[128];
 
     ref = glk_fileref_create_by_prompt(fileusage_TextMode | fileusage_SavedGame,
-                                       filemode_Write, 0);
+        filemode_Write, 0);
     if (ref == NULL)
         return;
 
@@ -218,7 +217,7 @@ int LoadGame(void)
     short lo;
 
     ref = glk_fileref_create_by_prompt(fileusage_TextMode | fileusage_SavedGame,
-                                       filemode_Read, 0);
+        filemode_Read, 0);
     if (ref == NULL)
         return 0;
 
@@ -241,8 +240,8 @@ int LoadGame(void)
     }
     glk_get_line_stream(file, buf, sizeof buf);
     int SavedImgTypeInt;
-    result = sscanf(buf, "%" SCNu64 " %d %d %d %d\n", &BitFlags,  &ProtagonistString,
-                    &dummy, &SavedImgTypeInt, &SavedImgIndex);
+    result = sscanf(buf, "%" SCNu64 " %d %d %d %d\n", &BitFlags, &ProtagonistString,
+        &dummy, &SavedImgTypeInt, &SavedImgIndex);
     SavedImgType = SavedImgTypeInt;
     debug_print("LoadGame: Result of sscanf: %d\n", result);
     if ((result < 3) || MyLoc > GameHeader.NumRooms || MyLoc < 1) {
@@ -254,10 +253,7 @@ int LoadGame(void)
         glk_get_line_stream(file, buf, sizeof buf);
         result = sscanf(buf, "%hd\n", &lo);
         Items[ct].Location = (unsigned char)lo;
-        if (result != 1 || (Items[ct].Location > GameHeader.NumRooms &&
-                            Items[ct].Location != CARRIED &&
-                            Items[ct].Location != HIDDEN &&
-                            Items[ct].Location != HELD_BY_OTHER_GUY)) {
+        if (result != 1 || (Items[ct].Location > GameHeader.NumRooms && Items[ct].Location != CARRIED && Items[ct].Location != HIDDEN && Items[ct].Location != HELD_BY_OTHER_GUY)) {
             fprintf(stderr, "LoadGame: Unexpected item location in save game file (Item %d, %s, is in room %d)\n", ct, Items[ct].Text, Items[ct].Location);
             RecoverFromBadRestore(state);
             return 0;

--- a/terps/plus/stdraw.c
+++ b/terps/plus/stdraw.c
@@ -33,7 +33,8 @@ typedef struct {
     Pixel *Pixels;
 } AnimationColor;
 
-static int IsSTBitSet(int bit, uint8_t byte) {
+static int IsSTBitSet(int bit, uint8_t byte)
+{
     return ((byte & (1 << bit)) != 0);
 }
 
@@ -41,7 +42,8 @@ static uint32_t NumAnimCols, NumOldAnimCols = 0, ImgAddrOffs, NibblesWide, NxtLi
 
 static uint32_t ColorCycle = 0;
 
-static glui32 StColToGlk(uint8_t hi, uint8_t lo) {
+static glui32 StColToGlk(uint8_t hi, uint8_t lo)
+{
     int blue = lo & 0xf;
     int green = (lo >> 4) & 0xf;
     int red = hi & 0xf;
@@ -55,7 +57,8 @@ static glui32 StColToGlk(uint8_t hi, uint8_t lo) {
 
 AnimationColor *AnimColors = NULL;
 
-static void FreeAnimCols(void) {
+static void FreeAnimCols(void)
+{
     if (AnimColors == NULL)
         return;
     for (int i = 0; i < NumOldAnimCols; i++) {
@@ -73,7 +76,8 @@ static void FreeAnimCols(void) {
     NumAnimCols = 0;
 }
 
-static uint8_t *SetPaletteAnimation(uint8_t *ptr) {
+static uint8_t *SetPaletteAnimation(uint8_t *ptr)
+{
     if (NumAnimCols != 0) {
         if (AnimColors != NULL) {
             FreeAnimCols();
@@ -135,8 +139,8 @@ static void GeneratePatternLookup(void)
     } while (previous != 256);
 }
 
-
-static void DrawSTNibble(uint8_t byte, uint8_t mask, int xpos, int ypos, Pixel **pixels) {
+static void DrawSTNibble(uint8_t byte, uint8_t mask, int xpos, int ypos, Pixel **pixels)
+{
     uint16_t offs = byte << 2;
     int startbit = 7;
     int endbit = 4;
@@ -174,8 +178,8 @@ static void DrawSTNibble(uint8_t byte, uint8_t mask, int xpos, int ypos, Pixel *
     }
 }
 
-
-static void DrawPattern(uint8_t pattern, Pixel **pixels) {
+static void DrawPattern(uint8_t pattern, Pixel **pixels)
+{
     // mask and LastMask alternate between 0x0f and 0xf0
     uint8_t mask = LastMask ^ 0xff;
 
@@ -211,18 +215,21 @@ void SetRGB(int32_t index, int red, int green, int blue);
 
 int ColorCyclingRunning = 0;
 
-int Intersects(Pixel pix, int xpos, int ypos, int width, int height) {
+int Intersects(Pixel pix, int xpos, int ypos, int width, int height)
+{
     return MAX(pix.x, xpos) <= MIN(pix.x + pix.width, xpos + width)
-    && MAX(pix.y, ypos) <= MIN(pix.y, ypos + height);
+        && MAX(pix.y, ypos) <= MIN(pix.y, ypos + height);
 }
 
-void CopyPixel(Pixel *a, Pixel *b) {
+void CopyPixel(Pixel *a, Pixel *b)
+{
     a->width = b->width;
     a->x = b->x;
     a->y = b->y;
 }
 
-void CopyAnimCol(AnimationColor *a, AnimationColor *b) {
+void CopyAnimCol(AnimationColor *a, AnimationColor *b)
+{
     a->ColIdx = b->ColIdx;
     a->CurCol = b->CurCol;
     a->NumCol = b->NumCol;
@@ -236,7 +243,8 @@ void CopyAnimCol(AnimationColor *a, AnimationColor *b) {
     memcpy(a->Pixels, b->Pixels, datasize);
 }
 
-void AddPixels(AnimationColor *animcol, Pixel *pixels, int numpixels) {
+void AddPixels(AnimationColor *animcol, Pixel *pixels, int numpixels)
+{
     int pixidx = 0;
     Pixel newpix[4000];
     for (int i = 0; i < animcol->NumPix; i++) {
@@ -253,8 +261,8 @@ void AddPixels(AnimationColor *animcol, Pixel *pixels, int numpixels) {
     animcol->NumPix = pixidx;
 }
 
-
-int AddNonHiddenColAnim(AnimationColor *old, AnimationColor *new, int numnew, int xpos, int ypos, int width, int height) {
+int AddNonHiddenColAnim(AnimationColor *old, AnimationColor *new, int numnew, int xpos, int ypos, int width, int height)
+{
     int goodpixels = 0;
     Pixel pixels[3000];
 
@@ -269,7 +277,7 @@ int AddNonHiddenColAnim(AnimationColor *old, AnimationColor *new, int numnew, in
     }
 
     for (int i = 0; i < numnew; i++) {
-        if (new[i].ColIdx == old->ColIdx && new[i].NumPix) {
+        if (new[i].ColIdx == old->ColIdx &&new[i].NumPix) {
             AddPixels(&new[i], pixels, goodpixels);
             return 0;
         }
@@ -279,7 +287,8 @@ int AddNonHiddenColAnim(AnimationColor *old, AnimationColor *new, int numnew, in
     return 1;
 }
 
-int DrawSTImageFromData(uint8_t *imgdata, size_t total_size) {
+int DrawSTImageFromData(uint8_t *imgdata, size_t total_size)
+{
 
     uint8_t *ptr = &imgdata[4];
 
@@ -338,7 +347,7 @@ int DrawSTImageFromData(uint8_t *imgdata, size_t total_size) {
         FreeAnimCols();
     }
 
-    Pixel **Pixels = MemAlloc(sizeof(Pixel*) * NumAnimCols);
+    Pixel **Pixels = MemAlloc(sizeof(Pixel *) * NumAnimCols);
     for (int i = 0; i < NumAnimCols; i++)
         Pixels[i] = MemAlloc(sizeof(Pixel) * 3000);
 
@@ -395,7 +404,6 @@ int DrawSTImageFromData(uint8_t *imgdata, size_t total_size) {
             AnimColors[i].Colors = NULL;
             AnimColors[i].Pixels = NULL;
         }
-
     }
 
     for (int i = 0; i < NumOldAnimCols; i++) {
@@ -433,13 +441,14 @@ void ColorCyclingPixel(Pixel p, glui32 glk_color)
     ypos += y_offset;
 
     glk_window_fill_rect(Graphics, glk_color, xpos,
-                         ypos, pixel_size * p.width, pixel_size);
+        ypos, pixel_size * p.width, pixel_size);
 }
 
 extern int STWebAnimation;
 extern int STWebAnimationFinished;
 
-void UpdateColorCycling(void) {
+void UpdateColorCycling(void)
+{
     for (int i = 0; i < NumAnimCols; i++) {
         if ((ColorCycle + AnimColors[i].StartOffset) % AnimColors[i].Rate == 0) {
             glui32 color = AnimColors[i].Colors[AnimColors[i].CurCol];

--- a/terps/scott/ai_uk/c64decrunch.c
+++ b/terps/scott/ai_uk/c64decrunch.c
@@ -15,8 +15,8 @@
 #include "scottgameinfo.h"
 
 #include "c64decrunch.h"
-#include "detectgame.h"
 #include "c64diskimage.h"
+#include "detectgame.h"
 #include "sagadraw.h"
 #include "sagagraphics.h"
 
@@ -46,6 +46,7 @@ struct c64rec {
     size_t imgoffset;
 };
 
+// clang-format off
 static const struct c64rec c64_registry[] = {
     { BATON_C64,        0x2ab00, 0xc3fc, TYPE_D64, 0, NULL, NULL, 0, 0, 0, 0, 0 }, // Mysterious Adventures C64 dsk 1
     { TIME_MACHINE_C64, 0x2ab00, 0xc3fc, TYPE_D64, 0, NULL, NULL, 0, 0, 0, 0, 0 },
@@ -161,6 +162,7 @@ static const struct c64rec c64_registry[] = {
 
     { UNKNOWN_GAME, 0, 0, UNKNOWN_FILE_TYPE, 0, NULL, NULL, 0, 0, 0, 0, 0 }
 };
+// clang-format off
 
 uint16_t checksum(uint8_t *sf, uint32_t extent)
 {

--- a/terps/scott/ai_uk/decompresstext.c
+++ b/terps/scott/ai_uk/decompresstext.c
@@ -33,7 +33,7 @@ char *DecompressText(uint8_t *source, int stringindex)
         // Get eight characters squeezed into five bytes
         uint64_t fortybits = ((uint64_t)source[0] << 32) | ((uint64_t)source[1] << 24) | ((uint64_t)source[2] << 16) | ((uint64_t)source[3] << 8) | source[4];
         source += 5;
-        for (j = 35; j >= 0; j -=5) {
+        for (j = 35; j >= 0; j -= 5) {
             // Decompress one character:
             int next = (fortybits >> j) & 0x1f;
             c = alphabet[next];

--- a/terps/scott/ai_uk/decompresstext.h
+++ b/terps/scott/ai_uk/decompresstext.h
@@ -8,8 +8,8 @@
 #ifndef decompresstext_h
 #define decompresstext_h
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 char *DecompressText(uint8_t *source, int stringindex);
 

--- a/terps/scott/ai_uk/decompressz80.c
+++ b/terps/scott/ai_uk/decompressz80.c
@@ -36,9 +36,9 @@
 */
 
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 
 /* Sizes of some of the arrays in the snap structure */
@@ -492,10 +492,8 @@ uint8_t *DecompressZ80(uint8_t *raw_data, size_t length)
     for (int i = 0; i < SNAPSHOT_RAM_PAGES; i++)
         if (snap->pages[i] != NULL)
             free(snap->pages[i]);
+
     free(snap);
-
-//    writeToFile("/Users/administrator/Desktop/Z80Decompressed", uncompressed, 0xC000);
-
     return uncompressed;
 }
 

--- a/terps/scott/ai_uk/decompressz80.h
+++ b/terps/scott/ai_uk/decompressz80.h
@@ -8,8 +8,8 @@
 #ifndef decompressz80_h
 #define decompressz80_h
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 /* Will return NULL on error or 0xc000 (49152) bytes of uncompressed raw data on
  * success */

--- a/terps/scott/ai_uk/game_specific.c
+++ b/terps/scott/ai_uk/game_specific.c
@@ -7,11 +7,11 @@
 
 #include <string.h>
 
-#include "game_specific.h"
-#include "sagadraw.h"
 #include "apple2draw.h"
-#include "scott.h"
+#include "game_specific.h"
 #include "saga.h"
+#include "sagadraw.h"
+#include "scott.h"
 
 void UpdateSecretAnimations(void)
 {
@@ -356,56 +356,55 @@ void Mysterious64Sysmess(void)
     sys[I_DONT_KNOW_HOW_TO] = "\"";
     sys[PLAY_AGAIN] = "The game is over, thanks for playing\nWant to play again ? ";
 
-
     char *dictword = NULL;
     size_t len = GameHeader.WordLength;
-    for (int i = 1 ; i <= 6; i++) {
+    for (int i = 1; i <= 6; i++) {
         dictword = MemAlloc(len + 1);
-        strncpy(dictword, sys[i-1], GameHeader.WordLength);
+        strncpy(dictword, sys[i - 1], GameHeader.WordLength);
         dictword[len] = '\0';
         Nouns[i] = dictword;
     }
 
     Nouns[0] = "ANY\0";
 
-    switch(CurrentGame) {
-        case BATON_C64:
-            Nouns[79] = "CAST\0";
-            Verbs[79] = ".\0";
-            GameHeader.NumWords = 79;
-            break;
-        case TIME_MACHINE_C64:
-            Verbs[86] = ".\0";
-            break;
-        case ARROW1_C64:
-            Nouns[82] = ".\0";
-            break;
-        case ARROW2_C64:
-            Verbs[80] = ".\0";
-            break;
-        case PULSAR7_C64:
-            Nouns[102] = ".\0";
-            break;
-        case CIRCUS_C64:
-            Nouns[96] = ".\0";
-            break;
-        case FEASIBILITY_C64:
-            Nouns[80] = ".\0";
-            break;
-        case PERSEUS_C64:
-            Nouns[82] = ".\0";
-            break;
-        default:
-            break;
+    switch (CurrentGame) {
+    case BATON_C64:
+        Nouns[79] = "CAST\0";
+        Verbs[79] = ".\0";
+        GameHeader.NumWords = 79;
+        break;
+    case TIME_MACHINE_C64:
+        Verbs[86] = ".\0";
+        break;
+    case ARROW1_C64:
+        Nouns[82] = ".\0";
+        break;
+    case ARROW2_C64:
+        Verbs[80] = ".\0";
+        break;
+    case PULSAR7_C64:
+        Nouns[102] = ".\0";
+        break;
+    case CIRCUS_C64:
+        Nouns[96] = ".\0";
+        break;
+    case FEASIBILITY_C64:
+        Nouns[80] = ".\0";
+        break;
+    case PERSEUS_C64:
+        Nouns[82] = ".\0";
+        break;
+    default:
+        break;
     }
 }
 
-void PerseusItalianSysmess(void) {
+void PerseusItalianSysmess(void)
+{
     sys[YOU_ARE] = "Sono in ";
     sys[YOU_SEE] = "\nQui posso vedere:\n";
     sys[INVENTORY] = "Ho raccolto: ";
 }
-
 
 void Supergran64Sysmess(void)
 {
@@ -501,50 +500,50 @@ void SecretMission64Sysmess(void)
     sys[I_DONT_KNOW_HOW_TO] = "I don't know how to \"";
 }
 
-
-void VoodooShowImageOnExamineUS(int noun) {
+void VoodooShowImageOnExamineUS(int noun)
+{
     int image = -1;
     switch (noun) {
-        case 8: // Count Cristo
-            if (Items[27].Location == MyLoc)
-                image = 11;
-            break;
-        case 13: // Broken sword
-            if (Items[33].Location == MyLoc || Items[33].Location == CARRIED)
-                image = 0;
-            break;
-        case 55: // Voodoo doll
-            if (Items[44].Location == MyLoc || Items[44].Location == CARRIED)
-                image = 1;
-            break;
-        case 63: // Voodoo book
-            if (Items[52].Location == MyLoc || Items[52].Location == CARRIED)
-                image = 2;
-            break;
-        case 32: // Ring
-            if (Items[25].Location == MyLoc || Items[25].Location == CARRIED)
-                image = 3;
-            break;
-        case 43: // Ju-ju man statue
-            if (Items[53].Location == MyLoc || Items[53].Location == CARRIED)
-                image = 4;
-            break;
-        case 9: // Glowing idol
-            if (Items[9].Location == MyLoc || Items[9].Location == CARRIED)
-                image = 5;
-            if (Items[43].Location == MyLoc || Items[43].Location == CARRIED)
-                image = 10;
-            break;
-        case 42: // Chemicals
-            if (Items[38].Location == MyLoc || Items[38].Location == CARRIED)
-                image = 6;
-            break;
-        case 7: // Bloody knife
-            if (Items[0].Location == MyLoc || Items[0].Location == CARRIED)
-                image = 7;
+    case 8: // Count Cristo
+        if (Items[27].Location == MyLoc)
+            image = 11;
+        break;
+    case 13: // Broken sword
+        if (Items[33].Location == MyLoc || Items[33].Location == CARRIED)
+            image = 0;
+        break;
+    case 55: // Voodoo doll
+        if (Items[44].Location == MyLoc || Items[44].Location == CARRIED)
+            image = 1;
+        break;
+    case 63: // Voodoo book
+        if (Items[52].Location == MyLoc || Items[52].Location == CARRIED)
+            image = 2;
+        break;
+    case 32: // Ring
+        if (Items[25].Location == MyLoc || Items[25].Location == CARRIED)
+            image = 3;
+        break;
+    case 43: // Ju-ju man statue
+        if (Items[53].Location == MyLoc || Items[53].Location == CARRIED)
+            image = 4;
+        break;
+    case 9: // Glowing idol
+        if (Items[9].Location == MyLoc || Items[9].Location == CARRIED)
+            image = 5;
+        if (Items[43].Location == MyLoc || Items[43].Location == CARRIED)
+            image = 10;
+        break;
+    case 42: // Chemicals
+        if (Items[38].Location == MyLoc || Items[38].Location == CARRIED)
+            image = 6;
+        break;
+    case 7: // Bloody knife
+        if (Items[0].Location == MyLoc || Items[0].Location == CARRIED)
+            image = 7;
 
-        default:
-            break;
+    default:
+        break;
     }
 
     if (image >= 0) {
@@ -560,19 +559,20 @@ void VoodooShowImageOnExamineUS(int noun) {
     }
 }
 
-void CountShowImageOnExamineUS(int noun) {
+void CountShowImageOnExamineUS(int noun)
+{
     int image = -1;
     switch (noun) {
-        case 21: // Package
-            if (Items[45].Location == MyLoc || Items[45].Location == CARRIED)
-                image = 0;
-            break;
-        case 50: // Crowd
-            if (Items[50].Location == MyLoc)
-                image = 1;
-            break;
-        default:
-            break;
+    case 21: // Package
+        if (Items[45].Location == MyLoc || Items[45].Location == CARRIED)
+            image = 0;
+        break;
+    case 50: // Crowd
+        if (Items[50].Location == MyLoc)
+            image = 1;
+        break;
+    default:
+        break;
     }
 
     if (image >= 0) {

--- a/terps/scott/ai_uk/gremlins.c
+++ b/terps/scott/ai_uk/gremlins.c
@@ -250,7 +250,8 @@ void LoadExtraGermanGremlinsData(void)
     FillInGermanSystemMessages();
 }
 
-void LoadCommonSpanishGremlinsData(void) {
+void LoadCommonSpanishGremlinsData(void)
+{
     sys[WHAT] = sys[HUH];
     sys[YES] = "s}";
     sys[NO] = "no";
@@ -287,7 +288,8 @@ void LoadCommonSpanishGremlinsData(void) {
         ExtraCommands[i] = SpanishExtraCommands[i];
 }
 
-void LoadExtraSpanishGremlinsData(void) {
+void LoadExtraSpanishGremlinsData(void)
+{
     for (int i = YOU_ARE; i <= HIT_ENTER; i++)
         sys[i] = system_messages[15 - YOU_ARE + i];
     for (int i = I_DONT_UNDERSTAND; i <= THATS_BEYOND_MY_POWER; i++)
@@ -302,7 +304,8 @@ void LoadExtraSpanishGremlinsData(void) {
     LoadCommonSpanishGremlinsData();
 }
 
-void LoadExtraSpanishGremlinsC64Data(void) {
+void LoadExtraSpanishGremlinsC64Data(void)
+{
     SysMessageType messagekey[] = {
         EXITS,
         YOU_SEE,

--- a/terps/scott/ai_uk/hulk.c
+++ b/terps/scott/ai_uk/hulk.c
@@ -5,56 +5,57 @@
 //  Created by Petter Sjölund on 2022-01-18.
 //
 
-#include "sagagraphics.h"
-#include "apple2draw.h"
-#include "scott.h"
 #include "hulk.h"
+#include "apple2draw.h"
 #include "saga.h"
+#include "sagagraphics.h"
+#include "scott.h"
 
-void HulkShowImageOnExamineUS(int noun) {
+void HulkShowImageOnExamineUS(int noun)
+{
     if (!Graphics)
         return;
     int image = -1;
     switch (noun) {
-        case 55:
-            if (Items[11].Location == MyLoc)
-                // Dome
-                image = 0;
-            break;
-        case 124: // Bio-Gem
-        case 41:
-            if (Items[18].Location == MyLoc || Items[18].Location == CARRIED)
-                image = 1;
-            break;
-        case 108:
-            if (Items[17].Location == MyLoc || Items[17].Location == CARRIED)
-                // Natter energy egg
-                image = 2;
-            break;
-        case 72:
-            if (Items[20].Location == MyLoc || Items[20].Location == CARRIED)
-                // Alien army ants
-                image = 3;
-            break;
-        case 21: // Killer Bees
-            if (Items[24].Location == MyLoc)
-                image = 4;
-            break;
-        case 83: // Iron ring
-            if (Items[33].Location == MyLoc)
-                image = 5;
-            break;
-        case 121: // Cage
-            if (Items[47].Location == MyLoc)
-                image = 6;
-            break;
-        case 26: // BASE
-        case 66: // HOLE
-            if (MyLoc == 14)
-                image = 7;
-            break;
-        default:
-            break;
+    case 55:
+        if (Items[11].Location == MyLoc)
+            // Dome
+            image = 0;
+        break;
+    case 124: // Bio-Gem
+    case 41:
+        if (Items[18].Location == MyLoc || Items[18].Location == CARRIED)
+            image = 1;
+        break;
+    case 108:
+        if (Items[17].Location == MyLoc || Items[17].Location == CARRIED)
+            // Natter energy egg
+            image = 2;
+        break;
+    case 72:
+        if (Items[20].Location == MyLoc || Items[20].Location == CARRIED)
+            // Alien army ants
+            image = 3;
+        break;
+    case 21: // Killer Bees
+        if (Items[24].Location == MyLoc)
+            image = 4;
+        break;
+    case 83: // Iron ring
+        if (Items[33].Location == MyLoc)
+            image = 5;
+        break;
+    case 121: // Cage
+        if (Items[47].Location == MyLoc)
+            image = 6;
+        break;
+    case 26: // BASE
+    case 66: // HOLE
+        if (MyLoc == 14)
+            image = 7;
+        break;
+    default:
+        break;
     }
 
     if (image >= 0) {
@@ -131,8 +132,6 @@ void HulkLook(void)
     }
 }
 
-
-
 void DrawHulkImage(int p)
 {
     if (CurrentGame == HULK_US) {
@@ -186,4 +185,3 @@ void DrawHulkImage(int p)
         HitEnter();
     }
 }
-

--- a/terps/scott/ai_uk/hulk.h
+++ b/terps/scott/ai_uk/hulk.h
@@ -8,6 +8,7 @@
 #ifndef hulk_h
 #define hulk_h
 
+#include "scottdefines.h"
 #include <stdio.h>
 
 void HulkShowImageOnExamine(int noun);

--- a/terps/scott/ai_uk/line_drawing.h
+++ b/terps/scott/ai_uk/line_drawing.h
@@ -8,6 +8,8 @@
 #ifndef line_drawing_h
 #define line_drawing_h
 
+#include <stdint.h>
+
 struct line_image {
     uint8_t *data;
     int bgcolour;

--- a/terps/scott/ai_uk/ringbuffer.c
+++ b/terps/scott/ai_uk/ringbuffer.c
@@ -5,12 +5,12 @@
 //  Created by Petter Sjölund on 2022-03-04.
 //
 
-#include <assert.h>
 #include "ringbuffer.h"
+#include <assert.h>
 
 // The hidden definition of our circular buffer structure
 struct circular_buf_t {
-    uint8_t * buffer;
+    uint8_t *buffer;
     size_t head;
     size_t tail;
     size_t max; //of the buffer
@@ -18,7 +18,7 @@ struct circular_buf_t {
 };
 
 // Return a pointer to a struct instance
-cbuf_handle_t circular_buf_init(uint8_t* buffer, size_t size)
+cbuf_handle_t circular_buf_init(uint8_t *buffer, size_t size)
 {
     assert(buffer && size);
 
@@ -63,12 +63,11 @@ bool circular_buf_empty(cbuf_handle_t me)
     return (!me->full && (me->head == me->tail));
 }
 
-
 static void advance_pointer(cbuf_handle_t me)
 {
     assert(me);
 
-    if(me->full) {
+    if (me->full) {
         if (++(me->tail) == me->max) {
             me->tail = 0;
         }
@@ -96,10 +95,10 @@ int circular_buf_putXY(cbuf_handle_t me, uint8_t x, uint8_t y)
 
     assert(me && me->buffer);
 
-    if(!circular_buf_full(me)) {
+    if (!circular_buf_full(me)) {
         me->buffer[me->head] = x;
         advance_pointer(me);
-        if(!circular_buf_full(me)) {
+        if (!circular_buf_full(me)) {
             me->buffer[me->head] = y;
             advance_pointer(me);
             r = 0;
@@ -108,16 +107,16 @@ int circular_buf_putXY(cbuf_handle_t me, uint8_t x, uint8_t y)
     return r;
 }
 
-int circular_buf_getXY(cbuf_handle_t me, uint8_t *x,  uint8_t *y)
+int circular_buf_getXY(cbuf_handle_t me, uint8_t *x, uint8_t *y)
 {
     assert(me && x && y && me->buffer);
 
     int r = -1;
 
-    if(!circular_buf_empty(me)) {
+    if (!circular_buf_empty(me)) {
         *x = me->buffer[me->tail];
         retreat_pointer(me);
-        if(!circular_buf_empty(me)) {
+        if (!circular_buf_empty(me)) {
             *y = me->buffer[me->tail];
             retreat_pointer(me);
             r = 0;

--- a/terps/scott/ai_uk/ringbuffer.h
+++ b/terps/scott/ai_uk/ringbuffer.h
@@ -15,11 +15,11 @@
 // Opaque circular buffer structure
 typedef struct circular_buf_t circular_buf_t;
 // Handle type, the way users interact with the API
-typedef circular_buf_t* cbuf_handle_t;
+typedef circular_buf_t *cbuf_handle_t;
 
 /// Pass in a storage buffer and size
 /// Returns a circular buffer handle
-cbuf_handle_t circular_buf_init(uint8_t* buffer, size_t size);
+cbuf_handle_t circular_buf_init(uint8_t *buffer, size_t size);
 
 /// Free a circular buffer structure.
 /// Does not free data buffer; owner is responsible for that
@@ -34,7 +34,7 @@ int circular_buf_putXY(cbuf_handle_t me, uint8_t x, uint8_t y);
 
 /// Retrieve a value from the buffer
 /// Returns 0 on success, -1 if the buffer is empty
-int circular_buf_getXY(cbuf_handle_t me, uint8_t *x,  uint8_t *y);
+int circular_buf_getXY(cbuf_handle_t me, uint8_t *x, uint8_t *y);
 
 /// Returns true if the buffer is empty
 bool circular_buf_empty(cbuf_handle_t me);

--- a/terps/scott/ai_uk/robinofsherwood.c
+++ b/terps/scott/ai_uk/robinofsherwood.c
@@ -249,7 +249,7 @@ void UpdateRobinOfSherwoodAnimations(void)
 GameIDType LoadExtraSherwoodData(void)
 {
 
-// room images
+    // room images
 
     int offset = 0x3d99 + file_baseline_offset;
     uint8_t *ptr;
@@ -273,7 +273,7 @@ GameIDType LoadExtraSherwoodData(void)
         }
     }
 
-// rooms
+    // rooms
 
     ct = 0;
     rp = Rooms;
@@ -331,7 +331,7 @@ GameIDType LoadExtraSherwoodData(void)
 GameIDType LoadExtraSherwoodData64(void)
 {
 
-// room images
+    // room images
 
     int offset = 0x1ffd + file_baseline_offset;
     uint8_t *ptr;
@@ -356,7 +356,7 @@ GameIDType LoadExtraSherwoodData64(void)
         }
     }
 
-// rooms
+    // rooms
 
     ct = 0;
     rp = Rooms;

--- a/terps/scott/ai_uk/sagadraw.c
+++ b/terps/scott/ai_uk/sagadraw.c
@@ -5,14 +5,14 @@
  */
 
 #include "glk.h"
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 
-#include "scottdefines.h"
-#include "scott.h"
 #include "sagagraphics.h"
+#include "scott.h"
+#include "scottdefines.h"
 #include "seasofblood.h"
 
 #include "sagadraw.h"
@@ -447,8 +447,6 @@ void transform(int32_t character, int32_t flip_mode, int32_t ptr)
     }
 }
 
-
-
 void RectFill(int32_t x, int32_t y, int32_t width, int32_t height,
     int32_t color)
 {
@@ -506,7 +504,7 @@ struct image_patch image_patches[] = {
     { CLAYMORGUE_C64, 16, 0, 12,
         "\x82\xfd\x00\x82\x81\x00\xff\x05\xff\x05\xff\x05" },
     { CLAYMORGUE, 14, 0, 12,
-      "\x82\xfd\x00\x82\x81\x00\xff\x05\xff\x05\xff\x05" },
+        "\x82\xfd\x00\x82\x81\x00\xff\x05\xff\x05\xff\x05" },
     { GREMLINS_C64, 21, 10, 5, "\x01\xa0\x03\x00\x01" },
     { GREMLINS_C64, 44, 304, 1, "\xb1" },
     { GREMLINS_C64, 81, 176, 1, "\xa0" },
@@ -538,7 +536,7 @@ void Patch(uint8_t *offset, int patch_number)
     struct image_patch *patch = &image_patches[patch_number];
     for (int i = 0; i < patch->number_of_bytes; i++) {
         uint8_t newval = patch->patch[i];
-//        debug_print("Patch: changing offset %d in image %d from %x to %x.\n", i + patch->offset, patch->picture_number, offset[i + patch->offset], newval);
+        //        debug_print("Patch: changing offset %d in image %d from %x to %x.\n", i + patch->offset, patch->picture_number, offset[i + patch->offset], newval);
         offset[i + patch->offset] = newval;
     }
 }
@@ -559,16 +557,16 @@ void PatchOutBrokenClaymorgueImagesC64(void)
 
 void PatchOutBrokenClaymorgueImagesZX(void)
 {
-   Output("[This copy of The Sorcerer of Claymorgue Castle has 26 broken or "
-          "missing pictures. These have been patched out.]\n\n");
-   for (int i = 9; i < 36; i++) {
-      if (i != 14)
-         for (int j = 0; j < GameHeader.NumRooms; j++) {
-            if (Rooms[j].Image == i) {
-               Rooms[j].Image = 255;
+    Output("[This copy of The Sorcerer of Claymorgue Castle has 26 broken or "
+           "missing pictures. These have been patched out.]\n\n");
+    for (int i = 9; i < 36; i++) {
+        if (i != 14)
+            for (int j = 0; j < GameHeader.NumRooms; j++) {
+                if (Rooms[j].Image == i) {
+                    Rooms[j].Image = 255;
+                }
             }
-         }
-   }
+    }
 }
 
 size_t hulk_coordinates = 0x26db;
@@ -576,7 +574,6 @@ size_t hulk_item_image_offsets = 0x2798;
 size_t hulk_look_image_offsets = 0x27bc;
 size_t hulk_special_image_offsets = 0x276e;
 size_t hulk_image_offset = 0x441b;
-
 
 void SagaSetup(size_t imgoffset)
 {

--- a/terps/scott/ai_uk/sagadraw.h
+++ b/terps/scott/ai_uk/sagadraw.h
@@ -12,15 +12,15 @@
 #include "scottdefines.h"
 
 typedef struct {
-  uint8_t *imagedata;
-  uint8_t xoff;
-  uint8_t yoff;
-  uint8_t width;
-  uint8_t height;
+    uint8_t *imagedata;
+    uint8_t xoff;
+    uint8_t yoff;
+    uint8_t width;
+    uint8_t height;
 } Image;
 
 uint8_t *DrawSagaPictureFromData(uint8_t *dataptr, int xsize, int ysize,
-                                     int xoff, int yoff);
+    int xoff, int yoff);
 
 void DrawSagaPictureNumber(int picture_number);
 void DrawSagaPictureAtPos(int picture_number, int x, int y);

--- a/terps/scott/debugprint.h
+++ b/terps/scott/debugprint.h
@@ -16,8 +16,11 @@
 
 #ifdef DEBUG
 
-#define debug_print(fmt, ...) \
-do { if (DEBUG_PRINT) fprintf(stderr, fmt, ##__VA_ARGS__); } while (0)
+#define debug_print(fmt, ...)                    \
+    do {                                         \
+        if (DEBUG_PRINT)                         \
+            fprintf(stderr, fmt, ##__VA_ARGS__); \
+    } while (0)
 
 #else
 

--- a/terps/scott/detectgame.c
+++ b/terps/scott/detectgame.c
@@ -13,9 +13,9 @@
 
 #include "decompresstext.h"
 #include "detectgame.h"
-#include "scottgameinfo.h"
-#include "sagadraw.h"
 #include "line_drawing.h"
+#include "sagadraw.h"
+#include "scottgameinfo.h"
 
 #include "game_specific.h"
 #include "gremlins.h"
@@ -23,11 +23,11 @@
 #include "robinofsherwood.h"
 #include "seasofblood.h"
 
+#include "apple2detect.h"
+#include "atari8detect.h"
 #include "c64decrunch.h"
 #include "decompressz80.h"
 #include "load_ti99_4a.h"
-#include "atari8detect.h"
-#include "apple2detect.h"
 
 #include "parser.h"
 
@@ -43,10 +43,12 @@ struct dictionaryKey {
 struct dictionaryKey dictKeys[] = {
     { FOUR_LETTER_UNCOMPRESSED, "AUTO\0GO\0", 8 },
     { THREE_LETTER_UNCOMPRESSED, "AUT\0GO\0", 7 },
-    { FIVE_LETTER_UNCOMPRESSED, "GO\0\0\0\0*CROSS*RUN\0", 17}, // Claymorgue
+    { FIVE_LETTER_UNCOMPRESSED, "GO\0\0\0\0*CROSS*RUN\0", 17 }, // Claymorgue
     { FOUR_LETTER_COMPRESSED, "aUTOgO\0", 7 },
     { GERMAN_C64, "gEHENSTEIGE", 11 }, // Gremlins German C64
-    { GERMAN, "\xc7" "EHENSTEIGE", 10 },
+    { GERMAN, "\xc7"
+              "EHENSTEIGE",
+        10 },
     { SPANISH, "\x81\0\0\0\xc9R\0\0ANDAENTR", 16 },
     { SPANISH_C64, "\x81\0\0\0iR\0\0ANDAENTR", 16 },
     { ITALIAN, "AUTO\0VAI\0\0*ENTR", 15 },
@@ -70,16 +72,16 @@ DictionaryType GetId(size_t *offset)
     for (int i = 0; dictKeys[i].dict != NOT_A_GAME; i++) {
         *offset = FindCode(dictKeys[i].signature, dictKeys[i].len);
         if (*offset != -1) {
-            switch(dictKeys[i].dict) {
-                case GERMAN_C64:
-                case GERMAN:
-                    *offset -= 5;
-                    break;
-                case FIVE_LETTER_UNCOMPRESSED:
-                    *offset -= 6;
-                    break;
-                default:
-                    break;
+            switch (dictKeys[i].dict) {
+            case GERMAN_C64:
+            case GERMAN:
+                *offset -= 5;
+                break;
+            case FIVE_LETTER_UNCOMPRESSED:
+                *offset -= 6;
+                break;
+            default:
+                break;
             }
             return dictKeys[i].dict;
         }
@@ -227,147 +229,147 @@ int ParseHeader(int *h, HeaderType type, int *ni, int *na, int *nw, int *nr,
     int *trm)
 {
     switch (type) {
-        case NO_HEADER:
-            return 0;
-        case EARLY:
-            *ni = h[1];
-            *na = h[2];
-            *nw = h[3];
-            *nr = h[4];
-            *mc = h[5];
-            *pr = h[6];
-            *tr = h[7];
-            *wl = h[8];
-            *lt = h[9];
-            *mn = h[10];
-            *trm = h[11];
-            break;
-        case LATE:
-            *ni = h[1];
-            *na = h[2];
-            *nw = h[3];
-            *nr = h[4];
-            *mc = h[5];
-            *wl = h[6];
-            *mn = h[7];
-            *pr = 1;
-            *tr = 0;
-            *lt = -1;
-            *trm = 0;
-            break;
-        case US_HEADER:
-            *ni = h[3];
-            *na = h[2];
-            *nw = h[1];
-            *nr = h[5];
-            *mc = h[6];
-            *pr = h[7];
-            *tr = h[8];
-            *wl = h[0];
-            *lt = h[9];
-            *mn = h[4];
-            *trm = h[10] >> 8;
-            break;
-        case ROBIN_C64_HEADER:
-            *ni = h[1];
-            *na = h[2];
-            *nw = h[6];
-            *nr = h[4];
-            *mc = h[5];
-            *pr = 1;
-            *tr = 0;
-            *wl = h[7];
-            *lt = -1;
-            *mn = h[3];
-            *trm = 0;
-            break;
-        case GREMLINS_C64_HEADER:
-            *ni = h[1];
-            *na = h[2];
-            *nw = h[5];
-            *nr = h[3];
-            *mc = h[6];
-            *pr = h[8];
-            *tr = 0;
-            *wl = h[7];
-            *lt = -1;
-            *mn = 98;
-            *trm = 0;
-            break;
-        case SUPERGRAN_C64_HEADER:
-            *ni = h[3];
-            *na = h[1];
-            *nw = h[2];
-            *nr = h[4];
-            *mc = h[8];
-            *pr = 1;
-            *tr = 0;
-            *wl = h[6];
-            *lt = -1;
-            *mn = h[5];
-            *trm = 0;
-            break;
-        case SEAS_OF_BLOOD_C64_HEADER:
-            *ni = h[0];
-            *na = h[1];
-            *nw = 134;
-            *nr = h[3];
-            *mc = h[4];
-            *pr = 1;
-            *tr = 0;
-            *wl = h[6];
-            *lt = -1;
-            *mn = h[2];
-            *trm = 0;
-            break;
-        case MYSTERIOUS_C64_HEADER:
-            *ni = h[1];
-            *na = h[2];
-            *nw = h[3];
-            *nr = h[4];
-            *mc = h[5] & 0xff;
-            *pr = h[5] >> 8;
-            *tr = h[6];
-            *wl = h[7];
-            *lt = h[8];
-            *mn = h[9];
-            *trm = 0;
-            break;
-        case ARROW_OF_DEATH_PT_2_C64_HEADER:
-            *ni = h[3];
-            *na = h[1];
-            *nw = h[2];
-            *nr = h[4];
-            *mc = h[5] & 0xff;
-            *pr = h[5] >> 8;
-            *tr = h[6];
-            *wl = h[7];
-            *lt = h[8];
-            *mn = h[9];
-            *trm = 0;
-            break;
-        case INDIANS_C64_HEADER:
-            *ni = h[1];
-            *na = h[2];
-            *nw = h[3];
-            *nr = h[4];
-            *mc = h[5] & 0xff;
-            *pr = h[5] >> 8;
-            *tr = h[6] & 0xff;
-            *wl = h[6] >> 8;
-            *lt = h[7] >> 8;
-            *mn = h[8] >> 8;
-            *trm = 0;
-            break;
-        default:
-            debug_print("Unhandled header type!\n");
-            return 0;
+    case NO_HEADER:
+        return 0;
+    case EARLY:
+        *ni = h[1];
+        *na = h[2];
+        *nw = h[3];
+        *nr = h[4];
+        *mc = h[5];
+        *pr = h[6];
+        *tr = h[7];
+        *wl = h[8];
+        *lt = h[9];
+        *mn = h[10];
+        *trm = h[11];
+        break;
+    case LATE:
+        *ni = h[1];
+        *na = h[2];
+        *nw = h[3];
+        *nr = h[4];
+        *mc = h[5];
+        *wl = h[6];
+        *mn = h[7];
+        *pr = 1;
+        *tr = 0;
+        *lt = -1;
+        *trm = 0;
+        break;
+    case US_HEADER:
+        *ni = h[3];
+        *na = h[2];
+        *nw = h[1];
+        *nr = h[5];
+        *mc = h[6];
+        *pr = h[7];
+        *tr = h[8];
+        *wl = h[0];
+        *lt = h[9];
+        *mn = h[4];
+        *trm = h[10] >> 8;
+        break;
+    case ROBIN_C64_HEADER:
+        *ni = h[1];
+        *na = h[2];
+        *nw = h[6];
+        *nr = h[4];
+        *mc = h[5];
+        *pr = 1;
+        *tr = 0;
+        *wl = h[7];
+        *lt = -1;
+        *mn = h[3];
+        *trm = 0;
+        break;
+    case GREMLINS_C64_HEADER:
+        *ni = h[1];
+        *na = h[2];
+        *nw = h[5];
+        *nr = h[3];
+        *mc = h[6];
+        *pr = h[8];
+        *tr = 0;
+        *wl = h[7];
+        *lt = -1;
+        *mn = 98;
+        *trm = 0;
+        break;
+    case SUPERGRAN_C64_HEADER:
+        *ni = h[3];
+        *na = h[1];
+        *nw = h[2];
+        *nr = h[4];
+        *mc = h[8];
+        *pr = 1;
+        *tr = 0;
+        *wl = h[6];
+        *lt = -1;
+        *mn = h[5];
+        *trm = 0;
+        break;
+    case SEAS_OF_BLOOD_C64_HEADER:
+        *ni = h[0];
+        *na = h[1];
+        *nw = 134;
+        *nr = h[3];
+        *mc = h[4];
+        *pr = 1;
+        *tr = 0;
+        *wl = h[6];
+        *lt = -1;
+        *mn = h[2];
+        *trm = 0;
+        break;
+    case MYSTERIOUS_C64_HEADER:
+        *ni = h[1];
+        *na = h[2];
+        *nw = h[3];
+        *nr = h[4];
+        *mc = h[5] & 0xff;
+        *pr = h[5] >> 8;
+        *tr = h[6];
+        *wl = h[7];
+        *lt = h[8];
+        *mn = h[9];
+        *trm = 0;
+        break;
+    case ARROW_OF_DEATH_PT_2_C64_HEADER:
+        *ni = h[3];
+        *na = h[1];
+        *nw = h[2];
+        *nr = h[4];
+        *mc = h[5] & 0xff;
+        *pr = h[5] >> 8;
+        *tr = h[6];
+        *wl = h[7];
+        *lt = h[8];
+        *mn = h[9];
+        *trm = 0;
+        break;
+    case INDIANS_C64_HEADER:
+        *ni = h[1];
+        *na = h[2];
+        *nw = h[3];
+        *nr = h[4];
+        *mc = h[5] & 0xff;
+        *pr = h[5] >> 8;
+        *tr = h[6] & 0xff;
+        *wl = h[6] >> 8;
+        *lt = h[7] >> 8;
+        *mn = h[8] >> 8;
+        *trm = 0;
+        break;
+    default:
+        debug_print("Unhandled header type!\n");
+        return 0;
     }
     return 1;
 }
 
 void PrintHeaderInfo(int *h, int ni, int na, int nw, int nr, int mc, int pr,
-                     int tr, int wl, int lt, int mn, int trm)
+    int tr, int wl, int lt, int mn, int trm)
 {
 #if (DEBUG_PRINT)
     uint16_t value;
@@ -397,7 +399,8 @@ typedef struct {
     size_t size;
 } LineImage;
 
-void LoadVectorData(struct GameInfo info, uint8_t *ptr) {
+void LoadVectorData(struct GameInfo info, uint8_t *ptr)
+{
     size_t offset;
 
     if (info.start_of_image_data == FOLLOWS)
@@ -666,7 +669,6 @@ GameIDType TryLoadingOld(struct GameInfo info, int dict_start)
         LoadVectorData(info, ptr);
     }
 
-
 #pragma mark System messages
 
     ct = 0;
@@ -853,8 +855,7 @@ GameIDType TryLoading(struct GameInfo info, int dict_start, int loud)
         }
         if (loud)
             debug_print("Offset after reading item images: %lx\n",
-                    ptr - entire_file - file_baseline_offset);
-
+                ptr - entire_file - file_baseline_offset);
     }
 
 #pragma mark actions
@@ -911,8 +912,7 @@ GameIDType TryLoading(struct GameInfo info, int dict_start, int loud)
     }
     if (loud)
         debug_print("Offset after reading actions: %lx\n",
-                ptr - entire_file - file_baseline_offset);
-
+            ptr - entire_file - file_baseline_offset);
 
 #pragma mark dictionary
 
@@ -1021,7 +1021,6 @@ GameIDType TryLoading(struct GameInfo info, int dict_start, int loud)
                 charindex++;
                 if (charindex > 255)
                     break;
-
             }
         }
     }
@@ -1190,13 +1189,7 @@ int IsMysterious(void)
 {
     for (int i = 0; games[i].Title != NULL; i++) {
         if (games[i].subtype & MYSTERIOUS) {
-            if (games[i].number_of_items == GameHeader.NumItems &&
-                games[i].number_of_actions == GameHeader.NumActions &&
-                games[i].number_of_words == GameHeader.NumWords &&
-                games[i].number_of_rooms == GameHeader.NumRooms &&
-                games[i].max_carried == GameHeader.MaxCarry &&
-                games[i].word_length == GameHeader.WordLength &&
-                games[i].number_of_messages == GameHeader.NumMessages)
+            if (games[i].number_of_items == GameHeader.NumItems && games[i].number_of_actions == GameHeader.NumActions && games[i].number_of_words == GameHeader.NumWords && games[i].number_of_rooms == GameHeader.NumRooms && games[i].max_carried == GameHeader.MaxCarry && games[i].word_length == GameHeader.WordLength && games[i].number_of_messages == GameHeader.NumMessages)
                 return 1;
         }
     }
@@ -1208,7 +1201,8 @@ int IsMysterious(void)
 // which use RLE compression: Pirate Adventure, Voodoo Castle, Strange Odyssey and Buckaroo Banzai.
 // This function decompresses them.
 
-uint8_t *DecompressParsec(uint8_t *start, uint8_t *end, uint8_t *dataptr) {
+uint8_t *DecompressParsec(uint8_t *start, uint8_t *end, uint8_t *dataptr)
+{
     if (dataptr - 3 < entire_file) {
         return NULL;
     }
@@ -1243,7 +1237,8 @@ uint8_t *DecompressParsec(uint8_t *start, uint8_t *end, uint8_t *dataptr) {
     return dataptr;
 }
 
-GameIDType DetectZXSpectrum(void) {
+GameIDType DetectZXSpectrum(void)
+{
     GameIDType detectedGame = UNKNOWN_GAME;
     int wasz80 = 0;
     uint8_t *uncompressed = DecompressZ80(entire_file, file_length);
@@ -1279,8 +1274,8 @@ GameIDType DetectZXSpectrum(void) {
         if (HL < file_length)
             result = DecompressParsec(&mem[0x0fff], &mem[0x07ff], &mem[HL]);
         if (result) {
-            uint16_t BC = mem[0x1b48] +  mem[0x1b49] * 0x100 - 0x4000;
-            uint16_t DE = mem[0x1b4b] +  mem[0x1b4c] * 0x100 - 0x4000;
+            uint16_t BC = mem[0x1b48] + mem[0x1b49] * 0x100 - 0x4000;
+            uint16_t DE = mem[0x1b4b] + mem[0x1b4c] * 0x100 - 0x4000;
             DecompressParsec(&mem[BC], &mem[DE], result);
             dict_type = GetId(&offset);
             if (dict_type == NOT_A_GAME)
@@ -1383,130 +1378,130 @@ GameIDType DetectGame(const char *file_name)
     }
 
     switch (detectedGame) {
-        case ROBIN_OF_SHERWOOD:
-            LoadExtraSherwoodData();
+    case ROBIN_OF_SHERWOOD:
+        LoadExtraSherwoodData();
+        break;
+    case ROBIN_OF_SHERWOOD_C64:
+        LoadExtraSherwoodData64();
+        break;
+    case SEAS_OF_BLOOD:
+        LoadExtraSeasOfBloodData();
+        break;
+    case SEAS_OF_BLOOD_C64:
+        LoadExtraSeasOfBlood64Data();
+        break;
+    case CLAYMORGUE:
+        for (int i = OK; i <= RESUME_A_SAVED_GAME; i++)
+            sys[i] = system_messages[6 - OK + i];
+        for (int i = PLAY_AGAIN; i <= ON_A_SCALE_THAT_RATES; i++)
+            sys[i] = system_messages[2 - PLAY_AGAIN + i];
+        break;
+    case SECRET_MISSION:
+    case SECRET_MISSION_C64:
+        Items[3].Image = 23;
+        Items[3].Flag = 128 | 2;
+        Rooms[2].Image = 0;
+        if (detectedGame == SECRET_MISSION_C64) {
+            SecretMission64Sysmess();
             break;
-        case ROBIN_OF_SHERWOOD_C64:
-            LoadExtraSherwoodData64();
-            break;
-        case SEAS_OF_BLOOD:
-            LoadExtraSeasOfBloodData();
-            break;
-        case SEAS_OF_BLOOD_C64:
-            LoadExtraSeasOfBlood64Data();
-            break;
-        case CLAYMORGUE:
-            for (int i = OK; i <= RESUME_A_SAVED_GAME; i++)
-                sys[i] = system_messages[6 - OK + i];
-            for (int i = PLAY_AGAIN; i <= ON_A_SCALE_THAT_RATES; i++)
-                sys[i] = system_messages[2 - PLAY_AGAIN + i];
-            break;
-        case SECRET_MISSION:
-        case SECRET_MISSION_C64:
-            Items[3].Image = 23;
-            Items[3].Flag = 128 | 2;
-            Rooms[2].Image = 0;
-            if (detectedGame == SECRET_MISSION_C64) {
-                SecretMission64Sysmess();
+        }
+    case ADVENTURELAND:
+        for (int i = PLAY_AGAIN; i <= ON_A_SCALE_THAT_RATES; i++)
+            sys[i] = system_messages[2 - PLAY_AGAIN + i];
+        for (int i = OK; i <= YOU_HAVENT_GOT_IT; i++)
+            sys[i] = system_messages[6 - OK + i];
+        for (int i = YOU_DONT_SEE_IT; i <= RESUME_A_SAVED_GAME; i++)
+            sys[i] = system_messages[13 - YOU_DONT_SEE_IT + i];
+        break;
+    case ADVENTURELAND_C64:
+        Adventureland64Sysmess();
+        break;
+    case CLAYMORGUE_C64:
+        Claymorgue64Sysmess();
+        break;
+    case GREMLINS_GERMAN_C64:
+        LoadExtraGermanGremlinsc64Data();
+        break;
+    case SPIDERMAN_C64:
+        Spiderman64Sysmess();
+        break;
+    case SUPERGRAN_C64:
+        Supergran64Sysmess();
+        break;
+    case SAVAGE_ISLAND_C64:
+        Items[20].Image = 13;
+        // fallthrough
+    case SAVAGE_ISLAND2_C64:
+        Supergran64Sysmess();
+        sys[IM_DEAD] = "I'm DEAD!! ";
+        if (detectedGame == SAVAGE_ISLAND2_C64)
+            Rooms[30].Image = 20;
+        break;
+    case SAVAGE_ISLAND:
+        Items[20].Image = 13;
+        // fallthrough
+    case SAVAGE_ISLAND2:
+        MyLoc = 30; /* Both parts of Savage Island begin in room 30 */
+        // fallthrough
+    case GREMLINS_GERMAN:
+    case GREMLINS:
+    case SUPERGRAN:
+        for (int i = DROPPED; i <= OK; i++)
+            sys[i] = system_messages[2 - DROPPED + i];
+        for (int i = I_DONT_UNDERSTAND; i <= THATS_BEYOND_MY_POWER; i++)
+            sys[i] = system_messages[6 - I_DONT_UNDERSTAND + i];
+        for (int i = YOU_ARE; i <= HIT_ENTER; i++)
+            sys[i] = system_messages[17 - YOU_ARE + i];
+        sys[PLAY_AGAIN] = system_messages[5];
+        sys[YOURE_CARRYING_TOO_MUCH] = system_messages[24];
+        sys[IM_DEAD] = system_messages[25];
+        sys[YOU_CANT_GO_THAT_WAY] = system_messages[14];
+        break;
+    case GREMLINS_SPANISH:
+        LoadExtraSpanishGremlinsData();
+        break;
+    case GREMLINS_SPANISH_C64:
+        LoadExtraSpanishGremlinsC64Data();
+        break;
+    case HULK_C64:
+    case HULK:
+        for (int i = 0; i < 6; i++) {
+            sys[i] = (char *)sysdict_zx[i];
+        }
+        break;
+    default:
+        if (!(Game->subtype & C64)) {
+            if (Game->subtype & MYSTERIOUS) {
+                for (int i = PLAY_AGAIN; i <= YOU_HAVENT_GOT_IT; i++)
+                    sys[i] = system_messages[2 - PLAY_AGAIN + i];
+                for (int i = YOU_DONT_SEE_IT; i <= WHAT_NOW; i++)
+                    sys[i] = system_messages[15 - YOU_DONT_SEE_IT + i];
+                for (int i = LIGHT_HAS_RUN_OUT; i <= RESUME_A_SAVED_GAME; i++)
+                    sys[i] = system_messages[31 - LIGHT_HAS_RUN_OUT + i];
+                sys[ITEM_DELIMITER] = " - ";
+                sys[MESSAGE_DELIMITER] = "\n";
+                sys[YOU_SEE] = "\nThings I can see:\n";
                 break;
+            } else {
+                for (int i = PLAY_AGAIN; i <= RESUME_A_SAVED_GAME; i++)
+                    sys[i] = system_messages[2 - PLAY_AGAIN + i];
             }
-        case ADVENTURELAND:
-            for (int i = PLAY_AGAIN; i <= ON_A_SCALE_THAT_RATES; i++)
-                sys[i] = system_messages[2 - PLAY_AGAIN + i];
-            for (int i = OK; i <= YOU_HAVENT_GOT_IT; i++)
-                sys[i] = system_messages[6 - OK + i];
-            for (int i = YOU_DONT_SEE_IT; i <= RESUME_A_SAVED_GAME; i++)
-                sys[i] = system_messages[13 - YOU_DONT_SEE_IT + i];
-            break;
-        case ADVENTURELAND_C64:
-            Adventureland64Sysmess();
-            break;
-        case CLAYMORGUE_C64:
-            Claymorgue64Sysmess();
-            break;
-        case GREMLINS_GERMAN_C64:
-            LoadExtraGermanGremlinsc64Data();
-            break;
-        case SPIDERMAN_C64:
-            Spiderman64Sysmess();
-            break;
-        case SUPERGRAN_C64:
-            Supergran64Sysmess();
-            break;
-        case SAVAGE_ISLAND_C64:
-            Items[20].Image = 13;
-            // fallthrough
-        case SAVAGE_ISLAND2_C64:
-            Supergran64Sysmess();
-            sys[IM_DEAD] = "I'm DEAD!! ";
-            if (detectedGame == SAVAGE_ISLAND2_C64)
-                Rooms[30].Image = 20;
-            break;
-        case SAVAGE_ISLAND:
-            Items[20].Image = 13;
-            // fallthrough
-        case SAVAGE_ISLAND2:
-            MyLoc = 30; /* Both parts of Savage Island begin in room 30 */
-            // fallthrough
-        case GREMLINS_GERMAN:
-        case GREMLINS:
-        case SUPERGRAN:
-            for (int i = DROPPED; i <= OK; i++)
-                sys[i] = system_messages[2 - DROPPED + i];
-            for (int i = I_DONT_UNDERSTAND; i <= THATS_BEYOND_MY_POWER; i++)
-                sys[i] = system_messages[6 - I_DONT_UNDERSTAND + i];
-            for (int i = YOU_ARE; i <= HIT_ENTER; i++)
-                sys[i] = system_messages[17 - YOU_ARE + i];
-            sys[PLAY_AGAIN] = system_messages[5];
-            sys[YOURE_CARRYING_TOO_MUCH] = system_messages[24];
-            sys[IM_DEAD] = system_messages[25];
-            sys[YOU_CANT_GO_THAT_WAY] = system_messages[14];
-            break;
-        case GREMLINS_SPANISH:
-            LoadExtraSpanishGremlinsData();
-            break;
-        case GREMLINS_SPANISH_C64:
-            LoadExtraSpanishGremlinsC64Data();
-            break;
-        case HULK_C64:
-        case HULK:
-            for (int i = 0; i < 6; i++) {
-                sys[i] = (char *)sysdict_zx[i];
-            }
-            break;
-        default:
-            if (!(Game->subtype & C64)) {
-                if (Game->subtype & MYSTERIOUS) {
-                    for (int i = PLAY_AGAIN; i <= YOU_HAVENT_GOT_IT; i++)
-                        sys[i] = system_messages[2 - PLAY_AGAIN + i];
-                    for (int i = YOU_DONT_SEE_IT; i <= WHAT_NOW; i++)
-                        sys[i] = system_messages[15 - YOU_DONT_SEE_IT + i];
-                    for (int i = LIGHT_HAS_RUN_OUT; i <= RESUME_A_SAVED_GAME; i++)
-                        sys[i] = system_messages[31 - LIGHT_HAS_RUN_OUT + i];
-                    sys[ITEM_DELIMITER] = " - ";
-                    sys[MESSAGE_DELIMITER] = "\n";
-                    sys[YOU_SEE] = "\nThings I can see:\n";
-                    break;
-                } else {
-                    for (int i = PLAY_AGAIN; i <= RESUME_A_SAVED_GAME; i++)
-                        sys[i] = system_messages[2 - PLAY_AGAIN + i];
-                }
-            }
-            break;
+        }
+        break;
     }
 
     switch (detectedGame) {
-        case GREMLINS_GERMAN:
-            LoadExtraGermanGremlinsData();
-            break;
-        case GREMLINS_GERMAN_C64:
-            LoadExtraGermanGremlinsc64Data();
-            break;
-        case PERSEUS_ITALIAN:
-            PerseusItalianSysmess();
-            break;
-        default:
-            break;
+    case GREMLINS_GERMAN:
+        LoadExtraGermanGremlinsData();
+        break;
+    case GREMLINS_GERMAN_C64:
+        LoadExtraGermanGremlinsc64Data();
+        break;
+    case PERSEUS_ITALIAN:
+        PerseusItalianSysmess();
+        break;
+    default:
+        break;
     }
 
     if ((Game->subtype & (MYSTERIOUS | C64)) == (MYSTERIOUS | C64))

--- a/terps/scott/detectgame.h
+++ b/terps/scott/detectgame.h
@@ -19,11 +19,11 @@ DictionaryType GetId(size_t *offset);
 int FindCode(const char *x, int base);
 uint8_t *ReadHeader(uint8_t *ptr);
 int ParseHeader(int *h, HeaderType type, int *ni, int *na, int *nw, int *nr,
-                int *mc, int *pr, int *tr, int *wl, int *lt, int *mn,
-                int *trm);
+    int *mc, int *pr, int *tr, int *wl, int *lt, int *mn,
+    int *trm);
 
 void PrintHeaderInfo(int *h, int ni, int na, int nw, int nr, int mc, int pr,
-                     int tr, int wl, int lt, int mn, int trm);
+    int tr, int wl, int lt, int mn, int trm);
 
 extern int header[];
 

--- a/terps/scott/layouttext.c
+++ b/terps/scott/layouttext.c
@@ -15,7 +15,7 @@ static int FindBreak(const char *buf, int pos, int columns)
 {
     if (isspace((unsigned char)buf[pos]))
         return 0;
-    
+
     int diff = 0;
 
     while (diff < columns && !isspace((unsigned char)buf[pos])) {

--- a/terps/scott/parser.c
+++ b/terps/scott/parser.c
@@ -9,9 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "scottdefines.h"
 #include "parser.h"
 #include "scott.h"
+#include "scottdefines.h"
 
 #include "bsd.h"
 
@@ -29,7 +29,6 @@ static int WordsInInput = 0;
 static int lastnoun = 0;
 
 static glui32 *FirstErrorMessage = NULL;
-
 
 const char *EnglishDirections[NUMBER_OF_DIRECTIONS] = {
     NULL, "north", "south", "east", "west", "up", "down",
@@ -156,9 +155,22 @@ extra_command ExtraCommandsKey[NUMBER_OF_EXTRA_COMMANDS] = {
 };
 
 const char *EnglishExtraNouns[NUMBER_OF_EXTRA_NOUNS] = {
-    NULL, "game", "story", "on", "off", "load",
-    "restore", "save", "move", "command", "turn",
-    "all", "everything", "it", " ", " ",
+    NULL,
+    "game",
+    "story",
+    "on",
+    "off",
+    "load",
+    "restore",
+    "save",
+    "move",
+    "command",
+    "turn",
+    "all",
+    "everything",
+    "it",
+    " ",
+    " ",
 };
 
 const char *GermanExtraNouns[NUMBER_OF_EXTRA_NOUNS] = {
@@ -341,8 +353,8 @@ glui32 *ToUnicode(const char *string)
             case '}':
                 unichar = 0xfc;
                 break;
-                case 12:
-                    unichar = 0xf6;
+            case 12:
+                unichar = 0xf6;
                 break;
             case '{':
                 unichar = 0xe4;
@@ -428,7 +440,8 @@ static char *FromUnicode(glui32 *unicode_string, int origlength)
     return result;
 }
 
-static int MatchYMCA(glui32 *string, int length, int index) {
+static int MatchYMCA(glui32 *string, int length, int index)
+{
     const char *ymca = "y.m.c.a.";
     int i;
     for (i = 0; i < 8; i++) {
@@ -466,53 +479,50 @@ void SplitIntoWords(glui32 *string, int length)
     for (int i = 0; string[i] != 0 && i < length && word_index < MAX_WORDS; i++) {
         foundspace = 0;
         switch (string[i]) {
-            case 'y':
-            {
-                int ymca = MatchYMCA(string, length, i);
-                if (ymca > 3)
-                {
-                    /* Start a new word */
-                    startpos[words_found] = i;
-                    wordlength[words_found] = ymca;
-                    words_found++;
-                    wordlength[words_found] = 0;
-                    i += ymca;
-                    if (i < length)
-                        foundspace = 1;
-                    lastwasspace = 0;
-                }
+        case 'y': {
+            int ymca = MatchYMCA(string, length, i);
+            if (ymca > 3) {
+                /* Start a new word */
+                startpos[words_found] = i;
+                wordlength[words_found] = ymca;
+                words_found++;
+                wordlength[words_found] = 0;
+                i += ymca;
+                if (i < length)
+                    foundspace = 1;
+                lastwasspace = 0;
             }
+        } break;
+            /* Unicode space and tab variants */
+        case ' ':
+        case '\t':
+        case '!':
+        case '?':
+        case '\"':
+        case 0x83: // ¿
+        case 0x80: // ¡
+        case 0xa0: // non-breaking space
+        case 0x2000: // en quad
+        case 0x2001: // em quad
+        case 0x2003: // em
+        case 0x2004: // three-per-em
+        case 0x2005: // four-per-em
+        case 0x2006: // six-per-em
+        case 0x2007: // figure space
+        case 0x2009: // thin space
+        case 0x200A: // hair space
+        case 0x202f: // narrow no-break space
+        case 0x205f: // medium mathematical space
+        case 0x3000: // ideographic space
+            foundspace = 1;
             break;
-                /* Unicode space and tab variants */
-            case ' ':
-            case '\t':
-            case '!':
-            case '?':
-            case '\"':
-            case 0x83: // ¿
-            case 0x80: // ¡
-            case 0xa0: // non-breaking space
-            case 0x2000: // en quad
-            case 0x2001: // em quad
-            case 0x2003: // em
-            case 0x2004: // three-per-em
-            case 0x2005: // four-per-em
-            case 0x2006: // six-per-em
-            case 0x2007: // figure space
-            case 0x2009: // thin space
-            case 0x200A: // hair space
-            case 0x202f: // narrow no-break space
-            case 0x205f: // medium mathematical space
-            case 0x3000: // ideographic space
-                foundspace = 1;
-                break;
-            case '.':
-            case ',':
-            case ';':
-                foundcomma = 1;
-                break;
-            default:
-                break;
+        case '.':
+        case ',':
+        case ';':
+            foundcomma = 1;
+            break;
+        default:
+            break;
         }
         if (!foundspace) {
             if (lastwasspace || foundcomma) {
@@ -591,7 +601,7 @@ void LineInput(void)
     return;
 }
 
- int WhichWord(const char *word, const char **list, int word_length,
+int WhichWord(const char *word, const char **list, int word_length,
     int list_length)
 {
     int n = 1;
@@ -768,10 +778,10 @@ static int FindExtaneousWords(int *index, int noun)
     if (list == NULL) {
         if (*index >= WordsInInput)
             *index = WordsInInput - 1;
-//        debug_print("FindExtaneousWords Error: I don't know what a \"%s\" is\n", CharWords[*index]);
+        //        debug_print("FindExtaneousWords Error: I don't know what a \"%s\" is\n", CharWords[*index]);
         CreateErrorMessage(sys[I_DONT_KNOW_WHAT_A], UnicodeWords[*index], sys[IS]);
     } else {
-//        debug_print("FindExtaneousWords Error: I don't understand\n");
+        //        debug_print("FindExtaneousWords Error: I don't understand\n");
         CreateErrorMessage(sys[I_DONT_UNDERSTAND], NULL, NULL);
     }
 
@@ -833,7 +843,7 @@ static struct Command *CommandFromStrings(int index, struct Command *previous)
         if (CurrentGame != GREMLINS_GERMAN && CurrentGame != GREMLINS_GERMAN_C64) {
             if (!previous) {
                 CreateErrorMessage(sys[I_DONT_KNOW_HOW_TO], UnicodeWords[i - 1],
-                                   sys[SOMETHING]);
+                    sys[SOMETHING]);
                 return NULL;
             } else {
                 verbindex = previous->verbwordindex;
@@ -856,10 +866,10 @@ static struct Command *CommandFromStrings(int index, struct Command *previous)
     if (i == WordsInInput) {
         if (lastverb) {
             return CreateCommandStruct(lastverb, verb, previous->verbwordindex, i,
-                                       previous);
+                previous);
         } else if (found_noun_at_verb_position) {
             CreateErrorMessage(sys[I_DONT_KNOW_HOW_TO], UnicodeWords[i - 1],
-                               sys[SOMETHING]);
+                sys[SOMETHING]);
             return NULL;
         } else {
             return CreateCommandStruct(verb, 0, i - 1, i, previous);
@@ -881,7 +891,7 @@ static struct Command *CommandFromStrings(int index, struct Command *previous)
         if (list == ExtraNouns && i < WordsInInput && noun - GameHeader.NumWords == ALL) {
             int stringlength = strlen(CharWords[i]);
             except = WhichWord(CharWords[i], ExtraCommands, stringlength,
-                                   NUMBER_OF_EXTRA_COMMANDS);
+                NUMBER_OF_EXTRA_COMMANDS);
         }
         if (ExtraCommandsKey[except] != EXCEPT && FindExtaneousWords(&i, noun) != 0)
             return NULL;
@@ -911,7 +921,7 @@ static struct Command *CommandFromStrings(int index, struct Command *previous)
         if (i < WordsInInput && verb - GameHeader.NumWords == ALL) {
             int stringlength = strlen(CharWords[i]);
             except = WhichWord(CharWords[i], ExtraCommands, stringlength,
-                               NUMBER_OF_EXTRA_COMMANDS);
+                NUMBER_OF_EXTRA_COMMANDS);
         }
         if (ExtraCommandsKey[except] != EXCEPT && FindExtaneousWords(&i, 0) != 0)
             return NULL;
@@ -969,7 +979,7 @@ static int CreateAllCommands(struct Command *command)
                 found = 1;
                 c->verb = command->verb;
                 c->noun = WhichWord(Items[i].AutoGet, Nouns, GameHeader.WordLength,
-                                    GameHeader.NumWords);
+                    GameHeader.NumWords);
                 c->item = i;
                 c->next = NULL;
                 c->nounwordindex = 0;

--- a/terps/scott/restorestate.h
+++ b/terps/scott/restorestate.h
@@ -10,7 +10,6 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <stdint.h>
 
 struct SavedState {
     int Counters[16];

--- a/terps/scott/saga/apple2detect.c
+++ b/terps/scott/saga/apple2detect.c
@@ -5,41 +5,41 @@
 //  Created by Petter Sjölund on 2022-08-03.
 //
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
-#include "scott.h"
-#include "scottdefines.h"
-#include "saga.h"
-#include "sagagraphics.h"
-#include "woz2nib.h"
+#include "apple2draw.h"
 #include "ciderpress.h"
 #include "hulk.h"
-#include "apple2draw.h"
+#include "saga.h"
+#include "sagagraphics.h"
+#include "scott.h"
+#include "scottdefines.h"
+#include "woz2nib.h"
 
 #include "apple2detect.h"
 
 static const pairrec a2companionlist[][2] = {
-    {{ 0x23000, 0xa989, "Scott Adams Graphic Adventure 1 - Adventureland v2.0-416 (4am crack) side A.dsk", 79}, { 0x23000, 0x5750, "Scott Adams Graphic Adventure 1 - Adventureland v2.0-416 (4am crack) side B - boot.dsk", 86 }},
+    { { 0x23000, 0xa989, "Scott Adams Graphic Adventure 1 - Adventureland v2.0-416 (4am crack) side A.dsk", 79 }, { 0x23000, 0x5750, "Scott Adams Graphic Adventure 1 - Adventureland v2.0-416 (4am crack) side B - boot.dsk", 86 } },
 
-    {{ 0x39557, 0x3ff3, "SAGA #1 - Adventureland v2.0-416 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 90 },{ 0x39557, 0x374e, "SAGA #1 - Adventureland v2.0-416 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 96 }},
+    { { 0x39557, 0x3ff3, "SAGA #1 - Adventureland v2.0-416 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 90 }, { 0x39557, 0x374e, "SAGA #1 - Adventureland v2.0-416 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 96 } },
 
-    {{ 0x39567, 0x8aa4, "SAGA #2 - Pirate Adventure v2.1-408 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 93 },{ 0x39567, 0xcf60, "SAGA #2 - Pirate Adventure v2.1-408 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 99 }},
+    { { 0x39567, 0x8aa4, "SAGA #2 - Pirate Adventure v2.1-408 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 93 }, { 0x39567, 0xcf60, "SAGA #2 - Pirate Adventure v2.1-408 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 99 } },
 
-    {{ 0x39554, 0xbbd3, "SAGA #3 - Mission Impossible v2.1-306 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 95 }, { 0x39554, 0x361a, "SAGA #3 - Mission Impossible v2.1-306 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 101 }},
+    { { 0x39554, 0xbbd3, "SAGA #3 - Mission Impossible v2.1-306 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 95 }, { 0x39554, 0x361a, "SAGA #3 - Mission Impossible v2.1-306 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 101 } },
 
-    {{ 0x39558, 0x958f, "SAGA #4 - Voodoo Castle v2.1-119 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 90 }, { 0x39558, 0xff6a, "SAGA #4 - Voodoo Castle v2.1-119 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 96 }},
+    { { 0x39558, 0x958f, "SAGA #4 - Voodoo Castle v2.1-119 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 90 }, { 0x39558, 0xff6a, "SAGA #4 - Voodoo Castle v2.1-119 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 96 } },
 
-    {{ 0x23000, 0xedf, "Scott Adams Graphic Adventure 5 - The Count v2.1-115 (4am crack) side A.dsk", 75}, { 0x23000, 0x09f4, "Scott Adams Graphic Adventure 5 - The Count v2.1-115 (4am crack) side B - boot.dsk", 82 }},
+    { { 0x23000, 0xedf, "Scott Adams Graphic Adventure 5 - The Count v2.1-115 (4am crack) side A.dsk", 75 }, { 0x23000, 0x09f4, "Scott Adams Graphic Adventure 5 - The Count v2.1-115 (4am crack) side B - boot.dsk", 82 } },
 
-    {{ 0x39589, 0x7010, "SAGA #5 - The Count v2.1-115 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 86 }, { 0x39589, 0xbf0e, "SAGA #5 - The Count v2.1-115 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 92 }},
+    { { 0x39589, 0x7010, "SAGA #5 - The Count v2.1-115 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 86 }, { 0x39589, 0xbf0e, "SAGA #5 - The Count v2.1-115 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 92 } },
 
-    {{ 0x39589, 0xee5d, "SAGA #6 - Strange Odyssey v2.1-119 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 92 }, { 0x39589, 0x4c17, "SAGA #6 - Strange Odyssey v2.1-119 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 98 }},
+    { { 0x39589, 0xee5d, "SAGA #6 - Strange Odyssey v2.1-119 (1982)(Adventure International)(II+)(US)(Side A)[48K].woz", 92 }, { 0x39589, 0x4c17, "SAGA #6 - Strange Odyssey v2.1-119 (1982)(Adventure International)(II+)(US)(Side B)(Boot)[48K].woz", 98 } },
 
-    {{ 0x23000, 0xd8ca, "Scott Adams Graphic Adventure 6 - Strange Odyssey v2.1-119 (4am crack) side A.dsk", 81 }, { 0x23000, 0xd700, "Scott Adams Graphic Adventure 6 - Strange Odyssey v2.1-119 (4am crack) side B - boot.dsk", 88 }},
+    { { 0x23000, 0xd8ca, "Scott Adams Graphic Adventure 6 - Strange Odyssey v2.1-119 (4am crack) side A.dsk", 81 }, { 0x23000, 0xd700, "Scott Adams Graphic Adventure 6 - Strange Odyssey v2.1-119 (4am crack) side B - boot.dsk", 88 } },
 
-    {{ 0,0, NULL }, { 0,0, NULL }}
+    { { 0, 0, NULL }, { 0, 0, NULL } }
 };
 
 typedef struct imglist {
@@ -91,10 +91,10 @@ static const imglist a2listHulk[] = {
     { IMG_ROOM, 97, 0x19400, 0x63c }, // outlet
     { IMG_ROOM, 99, 0x19b00, 0xe1b }, // title
 
-    { IMG_INV_OBJ, 1, 0x1aa00, 0x523 }, // rage (Hulk with bag)
-    { IMG_INV_OBJ, 2, 0x1b000, 0x83 }, // mirror
-    { IMG_INV_OBJ, 3, 0x1b100, 0x102 }, // broken chair
-    { IMG_INV_OBJ, 4, 0x1b300, 0x3e }, // gem 1
+    { IMG_INV_OBJ, 01, 0x1aa00, 0x523 }, // rage (Hulk with bag)
+    { IMG_INV_OBJ, 02, 0x1b000, 0x83 }, // mirror
+    { IMG_INV_OBJ, 03, 0x1b100, 0x102 }, // broken chair
+    { IMG_INV_OBJ, 04, 0x1b300, 0x3e }, // gem 1
     { IMG_INV_OBJ, 12, 0x1b400, 0x3e }, // gem 2
 
     { IMG_ROOM_OBJ, 13, 0x1b500, 0xc2 }, // pit
@@ -150,7 +150,6 @@ static const imglist a2listHulk[] = {
     { IMG_ROOM_OBJ, 72, 0x20700, 0x3f }, // Wax in room
 
     { IMG_INV_OBJ, 51, 0x21200, 0x3c }, // gem 16
-
 
     { 0, 0, 0, 0 }
 };
@@ -266,7 +265,6 @@ static const imglist a2listHulk126[] = {
 
     { 0, 0, 0, 0 }
 };
-
 
 static const imglist a2listClaymorgue[] = {
     { IMG_ROOM, 0, 0x1000, 0x01ac }, // Too dark
@@ -386,7 +384,7 @@ static const imglist a2listClaymorgue126[] = {
     { IMG_ROOM, 2, 0x1f00, 0x67a }, // *I'm on a Drawbridge
     { IMG_ROOM, 3, 0x2600, 0x116a }, // courtyard
     { IMG_ROOM, 4, 0x3800, 0xb41 }, // magic fountain
-//    { IMG_ROOM, 5, 0x4400, 0xdbc }, // stream of lava
+    //    { IMG_ROOM, 5, 0x4400, 0xdbc }, // stream of lava
     { IMG_ROOM, 6, 0x5000, 0xdbc }, // on top of the fountain
     { IMG_ROOM, 7, 0x5e00, 0x78b }, // ball room
     { IMG_ROOM, 8, 0x6600, 0xa75 }, // on a large chandelier
@@ -400,7 +398,7 @@ static const imglist a2listClaymorgue126[] = {
     { IMG_ROOM, 16, 0xb200, 0x1100 }, // I'm in the water of a moat
     { IMG_ROOM, 17, 0xc400, 0x7d }, // I'm underwater in thick murky fluid
     { IMG_ROOM, 18, 0xc500, 0x4b7 }, // I'm under the stairs
-//    { IMG_ROOM, 19, 0xd200, 0x1131 }, // hollow tree sign says drop stars here
+    //    { IMG_ROOM, 19, 0xd200, 0x1131 }, // hollow tree sign says drop stars here
     { IMG_ROOM, 20, 0xee00, 0x8fb }, // pool of dirty water
     { IMG_ROOM, 21, 0xf800, 0x8e1 }, // kitchen
     { IMG_ROOM, 22, 0x10200, 0x1130 }, // I'm on a box
@@ -436,12 +434,12 @@ static const imglist a2listClaymorgue126[] = {
     { IMG_INV_OBJ, 20, 0x1b400, 0x41 }, // Magic mirror
     { IMG_INV_OBJ, 24, 0x1b500, 0x4e }, // Fire spell
 
-    { IMG_ROOM_OBJ, 26, 0x1b600, 0x11f9}, // Fallen Chandelier
+    { IMG_ROOM_OBJ, 26, 0x1b600, 0x11f9 }, // Fallen Chandelier
 
     { IMG_INV_OBJ, 28, 0x1ba00, 0x45 }, // Broken glass
 
-    { IMG_ROOM_OBJ, 30, 0x1bb00, 0x196}, // Open door
-    { IMG_ROOM_OBJ, 32, 0x1bd00, 0x14d}, // Open door 2
+    { IMG_ROOM_OBJ, 30, 0x1bb00, 0x196 }, // Open door
+    { IMG_ROOM_OBJ, 32, 0x1bd00, 0x14d }, // Open door 2
 
     { IMG_INV_OBJ, 33, 0x1bf00, 0x52 }, // Spell of Methuselah
     { IMG_INV_OBJ, 34, 0x1c000, 0x4b }, // Seed spell
@@ -569,9 +567,9 @@ static const imglist a2listCount[] = {
     { IMG_INV_OBJ, 65, 0x18a00, 0x6e }, // Letter
     { IMG_ROOM_OBJ, 67, 0x18b00, 0x54e }, // Mouldy old skeleton with a stake in the rib cage
     { IMG_INV_OBJ, 70, 0x19100, 0x68 }, // Century worth of dust
-    { IMG_ROOM_OBJ, 80, 0x19200, 0x1a8 },  // Mirror in room
-    { IMG_ROOM_OBJ, 81, 0x19500, 0x150 },  // other end of sheet
-    { IMG_ROOM_OBJ, 82, 0x19700, 0x206 },  // Coat-of-Arms (4) on wall
+    { IMG_ROOM_OBJ, 80, 0x19200, 0x1a8 }, // Mirror in room
+    { IMG_ROOM_OBJ, 81, 0x19500, 0x150 }, // other end of sheet
+    { IMG_ROOM_OBJ, 82, 0x19700, 0x206 }, // Coat-of-Arms (4) on wall
 
     { 0, 0, 0, 0 }
 };
@@ -778,27 +776,28 @@ GameIDType DetectApple2(uint8_t **sf, size_t *extent)
                 ExtractImagesFromApple2CompanionFile(companionfile, companionsize, isnib);
                 free(companionfile);
             } else if (USImages != NULL) {
-                free (USImages->imagedata);
-                free (USImages);
+                free(USImages->imagedata);
+                free(USImages);
                 USImages = NULL;
             }
         } else
             debug_print("Failed loading database\n");
-        free (datafile);
-        free (database);
+        free(datafile);
+        free(database);
         return result;
     } else {
-        free (datafile);
+        free(datafile);
         debug_print("Failed loading database\n");
         return UNKNOWN_GAME;
     }
 }
 
-static int StripParens(char sideA[], size_t length) {
+static int StripParens(char sideA[], size_t length)
+{
     int left_paren = 0;
     int right_paren = 0;
     size_t ppos = length - 1;
-    while(sideA[ppos] != '.' && ppos > 0)
+    while (sideA[ppos] != '.' && ppos > 0)
         ppos--;
     size_t extlen = length - ppos;
     if (length > 4) {
@@ -833,7 +832,8 @@ static int StripParens(char sideA[], size_t length) {
     return 0;
 }
 
-uint8_t *ReadA2DiskImageFile(const char *filename, size_t *filesize, int *isnib) {
+uint8_t *ReadA2DiskImageFile(const char *filename, size_t *filesize, int *isnib)
+{
     uint8_t *result = ReadFileIfExists(filename, filesize);
     if (result && *filesize > 4 && result[0] == 'W' && result[1] == 'O' && result[2] == 'Z') {
         uint8_t *result2 = woz2nib(result, filesize);
@@ -846,38 +846,39 @@ uint8_t *ReadA2DiskImageFile(const char *filename, size_t *filesize, int *isnib)
     return result;
 }
 
-uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize, int *isnib) {
+uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize, int *isnib)
+{
 
     char *sideB = MemAlloc(stringlen + 9);
     uint8_t *result = NULL;
 
     *isnib = 0;
     memcpy(sideB, game_file, stringlen + 1);
-    switch(type) {
-        case TYPE_A:
-            sideB[index] = 'A';
-            break;
-        case TYPE_B:
-            sideB[index] = 'B';
-            break;
-        case TYPE_1:
-            sideB[index] = '1';
-            break;
-        case TYPE_2:
-            sideB[index] = '2';
-            break;
-        case TYPE_ONE:
-            sideB[index] = 'o';
-            sideB[index + 1] = 'n';
-            sideB[index + 2] = 'e';
-            break;
-        case TYPE_TWO:
-            sideB[index] = 't';
-            sideB[index + 1] = 'w';
-            sideB[index + 2] = 'o';
-            break;
-        case TYPE_NONE:
-            break;
+    switch (type) {
+    case TYPE_A:
+        sideB[index] = 'A';
+        break;
+    case TYPE_B:
+        sideB[index] = 'B';
+        break;
+    case TYPE_1:
+        sideB[index] = '1';
+        break;
+    case TYPE_2:
+        sideB[index] = '2';
+        break;
+    case TYPE_ONE:
+        sideB[index] = 'o';
+        sideB[index + 1] = 'n';
+        sideB[index + 2] = 'e';
+        break;
+    case TYPE_TWO:
+        sideB[index] = 't';
+        sideB[index + 1] = 'w';
+        sideB[index + 2] = 'o';
+        break;
+    case TYPE_NONE:
+        break;
     }
 
     debug_print("looking for companion file \"%s\"\n", sideB);
@@ -892,7 +893,7 @@ uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t st
 
             // First we look for the period before the file extension
             size_t ppos = stringlen - 1;
-            while(sideB[ppos] != '.' && ppos > 0)
+            while (sideB[ppos] != '.' && ppos > 0)
                 ppos--;
             if (ppos < 1) {
                 free(sideB);
@@ -917,7 +918,8 @@ uint8_t *LookForA2CompanionFilename(int index, CompanionNameType type, size_t st
     return result;
 }
 
-uint8_t *GetApple2CompanionFile(size_t *size, int *isnib) {
+uint8_t *GetApple2CompanionFile(size_t *size, int *isnib)
+{
 
     *size = 0;
     *isnib = 0;
@@ -937,36 +939,35 @@ uint8_t *GetApple2CompanionFile(size_t *size, int *isnib) {
     char c;
     for (int i = (int)gamefilelen - 1; i >= 0 && game_file[i] != '/' && game_file[i] != '\\'; i--) {
         c = tolower(game_file[i]);
-        if (i > 3 && ((c == 'e' && game_file[i - 1] == 'd' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 's') ||
-                      (c == 'k' && game_file[i - 1] == 's' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 'd'))) {
+        if (i > 3 && ((c == 'e' && game_file[i - 1] == 'd' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 's') || (c == 'k' && game_file[i - 1] == 's' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 'd'))) {
             if (gamefilelen > i + 2) {
                 c = game_file[i + 1];
                 if (c == ' ' || c == '_') {
                     c = tolower(game_file[i + 2]);
                     CompanionNameType type = TYPE_NONE;
                     switch (c) {
-                        case 'a':
-                            type = TYPE_B;
-                            break;
-                        case 'b':
-                            type = TYPE_A;
-                            break;
-                        case 't':
-                            if (gamefilelen > i + 4 && game_file[i + 3] == 'w' && game_file[i + 4] == 'o') {
-                                type =  TYPE_ONE;
-                            }
-                            break;
-                        case 'o':
-                            if (gamefilelen > i + 4 && game_file[i + 3] == 'n' && game_file[i + 4] == 'e') {
-                                type = TYPE_TWO;
-                            }
-                            break;
-                        case '2':
-                            type= TYPE_1;
-                            break;
-                        case '1':
-                            type = TYPE_2;
-                            break;
+                    case 'a':
+                        type = TYPE_B;
+                        break;
+                    case 'b':
+                        type = TYPE_A;
+                        break;
+                    case 't':
+                        if (gamefilelen > i + 4 && game_file[i + 3] == 'w' && game_file[i + 4] == 'o') {
+                            type = TYPE_ONE;
+                        }
+                        break;
+                    case 'o':
+                        if (gamefilelen > i + 4 && game_file[i + 3] == 'n' && game_file[i + 4] == 'e') {
+                            type = TYPE_TWO;
+                        }
+                        break;
+                    case '2':
+                        type = TYPE_1;
+                        break;
+                    case '1':
+                        type = TYPE_2;
+                        break;
                     }
                     if (type != TYPE_NONE)
                         result = LookForA2CompanionFilename(i + 2, type, gamefilelen, size, isnib);
@@ -985,28 +986,27 @@ static int ExtractImagesFromApple2CompanionFile(uint8_t *data, size_t datasize, 
 
     const struct imglist *list;
 
-
-    switch(CurrentGame) {
-        case CLAYMORGUE_US:
-            list = a2listClaymorgue;
-            break;
-        case CLAYMORGUE_US_126:
-            list = a2listClaymorgue126;
-            break;
-        case HULK_US:
-            list = a2listHulk;
-            break;
-        case HULK_US_PREL:
-            list = a2listHulk126;
-            break;
-        case COUNT_US:
-            list = a2listCount;
-            break;
-        case VOODOO_CASTLE_US:
-            list = a2listVoodoo;
-            break;
-        default:
-            return 0;
+    switch (CurrentGame) {
+    case CLAYMORGUE_US:
+        list = a2listClaymorgue;
+        break;
+    case CLAYMORGUE_US_126:
+        list = a2listClaymorgue126;
+        break;
+    case HULK_US:
+        list = a2listHulk;
+        break;
+    case HULK_US_PREL:
+        list = a2listHulk126;
+        break;
+    case COUNT_US:
+        list = a2listCount;
+        break;
+    case VOODOO_CASTLE_US:
+        list = a2listVoodoo;
+        break;
+    default:
+        return 0;
     }
 
     struct USImage *image = new_image();
@@ -1020,8 +1020,7 @@ static int ExtractImagesFromApple2CompanionFile(uint8_t *data, size_t datasize, 
         InitNibImage(data, datasize);
     }
     // Now loop round for each image
-    for (outpic = 0; list[outpic].offset != 0; outpic++)
-    {
+    for (outpic = 0; list[outpic].offset != 0; outpic++) {
         size_t size = list[outpic].size + 4;
 
         image->usage = list[outpic].usage;

--- a/terps/scott/saga/apple2draw.c
+++ b/terps/scott/saga/apple2draw.c
@@ -21,7 +21,8 @@ uint8_t *descrambletable = NULL;
 static uint8_t *screenmem = NULL;
 static uint8_t lobyte = 0, hibyte = 0;
 
-void ClearApple2ScreenMem(void) {
+void ClearApple2ScreenMem(void)
+{
     if (!screenmem)
         return;
     memset(screenmem, 0, 0x2000);
@@ -55,7 +56,8 @@ static int PutByte(uint8_t work, uint8_t work2)
     return 1;
 }
 
-uint16_t CalcScreenAddress(uint8_t ypos) {
+uint16_t CalcScreenAddress(uint8_t ypos)
+{
     if (0xc0 + ypos >= 0x182)
         return 0;
     uint16_t result = descrambletable[ypos] + descrambletable[0xc0 + ypos] * 0x100 - 0x2000;
@@ -64,7 +66,8 @@ uint16_t CalcScreenAddress(uint8_t ypos) {
     return result;
 }
 
-int DrawScrambledApple2Image(uint8_t *ptr, size_t datasize) {
+int DrawScrambledApple2Image(uint8_t *ptr, size_t datasize)
+{
 
     if (screenmem == NULL) {
         screenmem = MemAlloc(0x2000);
@@ -141,7 +144,7 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
         return (result > 0);
     }
 
-    int work,work2;
+    int work, work2;
     int c;
     int i;
 
@@ -149,7 +152,8 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
 
     int countflag = (CurrentGame == COUNT_US);
 
-    x = 0; y = 0;
+    x = 0;
+    y = 0;
 
     if (!countflag) {
         // Get the offsets
@@ -162,7 +166,8 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
         xlen = *ptr++;
         ylen = *ptr++;
     } else {
-        xoff = 0; yoff = 0;
+        xoff = 0;
+        yoff = 0;
         xlen = 0;
         ylen = 0;
         while (xlen == 0 && ylen == 0) {
@@ -178,23 +183,19 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
 
     debug_print("xlen: %d ylen: %d\n", xlen, ylen);
 
-
-    while (ptr - origptr < datasize - 2)
-    {
+    while (ptr - origptr < datasize - 2) {
         // First get count
         c = *ptr++;
 
-        if ((c & 0x80) == 0x80 || countflag)
-        { // is a counter
+        if ((c & 0x80) == 0x80 || countflag) { // is a counter
             if (countflag) {
                 c -= 1;
             } else {
                 c &= 0x7f;
             }
-            work=*ptr++;
-            work2=*ptr++;
-            for (i = 0; i < c + 1 && ptr - origptr < datasize; i++)
-            {
+            work = *ptr++;
+            work2 = *ptr++;
+            for (i = 0; i < c + 1 && ptr - origptr < datasize; i++) {
                 if (PutByte(work, work2) == 0) {
                     debug_print("Reached end of screen memory at offset %lx\n", ptr - origptr);
                     return 1;
@@ -204,13 +205,10 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
                     return 1;
                 }
             }
-        }
-        else
-        {
+        } else {
             // Don't count on the next j characters
 
-            for (i = 0; i < c + 1 && ptr - origptr < datasize - 1; i++)
-            {
+            for (i = 0; i < c + 1 && ptr - origptr < datasize - 1; i++) {
                 work = *ptr++;
                 work2 = *ptr++;
                 if (PutByte(work, work2) == 0) {
@@ -227,11 +225,12 @@ int DrawApple2ImageFromData(uint8_t *ptr, size_t datasize)
     return 1;
 }
 
-int DrawApple2Image(USImage *image) {
+int DrawApple2Image(USImage *image)
+{
     if (image->usage == IMG_ROOM)
         ClearApple2ScreenMem();
     DrawApple2ImageFromData(image->imagedata, image->datasize);
-    debug_print("Drawing image with index %d, usage %d\n",image->index, image->usage);
+    debug_print("Drawing image with index %d, usage %d\n", image->index, image->usage);
     return 1;
 }
 
@@ -244,27 +243,27 @@ static void PutApplePixel(glsi32 xpos, glsi32 ypos, glui32 color)
     ypos += y_offset;
 
     glk_window_fill_rect(Graphics, color, xpos,
-                         ypos, pixel_size, pixel_size);
+        ypos, pixel_size, pixel_size);
 }
 
 /* The code below is borrowed from the MAME Apple 2 driver */
 
-#define BLACK   0
-#define PURPLE  0xD53EF9
-#define BLUE    0x458ff7
-#define ORANGE  0xd7762c
-#define GREEN   0x64d440
-#define WHITE   0xffffff
+#define BLACK 0
+#define PURPLE 0xD53EF9
+#define BLUE 0x458ff7
+#define ORANGE 0xd7762c
+#define GREEN 0x64d440
+#define WHITE 0xffffff
 
-static const int32_t hires_artifact_color_table[] =
-{
-    BLACK,  PURPLE, GREEN,  WHITE,
-    BLACK,  BLUE,   ORANGE, WHITE
+static const int32_t hires_artifact_color_table[] = {
+    BLACK, PURPLE, GREEN, WHITE,
+    BLACK, BLUE, ORANGE, WHITE
 };
 
 static int32_t *m_hires_artifact_map = NULL;
 
-static void generate_artifact_map(void) {
+static void generate_artifact_map(void)
+{
     /* generate hi-res artifact data */
     int i, j;
     uint16_t c;
@@ -273,26 +272,21 @@ static void generate_artifact_map(void) {
     m_hires_artifact_map = MemAlloc(sizeof(int32_t) * 8 * 2 * 2);
 
     /* build hires artifact map */
-    for (i = 0; i < 8; i++)
-    {
-        for (j = 0; j < 2; j++)
-        {
-            if (i & 0x02)
-            {
+    for (i = 0; i < 8; i++) {
+        for (j = 0; j < 2; j++) {
+            if (i & 0x02) {
                 if ((i & 0x05) != 0)
                     c = 3;
                 else
                     c = j ? 2 : 1;
-            }
-            else
-            {
+            } else {
                 if ((i & 0x05) == 0x05)
                     c = j ? 1 : 2;
                 else
                     c = 0;
             }
-            m_hires_artifact_map[ 0 + j*8 + i] = hires_artifact_color_table[(c + 0) % 8];
-            m_hires_artifact_map[16 + j*8 + i] = hires_artifact_color_table[(c + 4) % 8];
+            m_hires_artifact_map[0 + j * 8 + i] = hires_artifact_color_table[(c + 0) % 8];
+            m_hires_artifact_map[16 + j * 8 + i] = hires_artifact_color_table[(c + 4) % 8];
         }
     }
 }
@@ -309,27 +303,23 @@ void DrawApple2ImageFromVideoMem(void)
     vram_row[0] = 0;
     vram_row[41] = 0;
 
-    for (int row = 0; row < ImageHeight; row++)
-    {
-        for (int col = 0; col < 40; col++)
-        {
-            int const offset = ((((row/8) & 0x07) << 7) | (((row/8) & 0x18) * 5 + col)) | ((row & 7) << 10);
-            vram_row[1+col] = vram[offset];
+    for (int row = 0; row < ImageHeight; row++) {
+        for (int col = 0; col < 40; col++) {
+            int const offset = ((((row / 8) & 0x07) << 7) | (((row / 8) & 0x18) * 5 + col)) | ((row & 7) << 10);
+            vram_row[1 + col] = vram[offset];
         }
 
         int pixpos = 0;
 
-        for (int col = 0; col < 40; col++)
-        {
-            uint32_t w =    (((uint32_t) vram_row[col+0] & 0x7f) <<  0)
-            |   (((uint32_t) vram_row[col+1] & 0x7f) <<  7)
-            |   (((uint32_t) vram_row[col+2] & 0x7f) << 14);
+        for (int col = 0; col < 40; col++) {
+            uint32_t w = (((uint32_t)vram_row[col + 0] & 0x7f) << 0)
+                | (((uint32_t)vram_row[col + 1] & 0x7f) << 7)
+                | (((uint32_t)vram_row[col + 2] & 0x7f) << 14);
 
             artifact_map_ptr = &m_hires_artifact_map[((vram_row[col + 1] & 0x80) >> 7) * 16];
 
-            for (int b = 0; b < 7; b++)
-            {
-                int32_t const v = artifact_map_ptr[((w >> (b + 7-1)) & 0x07) | (((b ^ col) & 0x01) << 3)];
+            for (int b = 0; b < 7; b++) {
+                int32_t const v = artifact_map_ptr[((w >> (b + 7 - 1)) & 0x07) | (((b ^ col) & 0x01) << 3)];
                 PutApplePixel(pixpos++, row, v);
             }
         }

--- a/terps/scott/saga/atari8c64draw.c
+++ b/terps/scott/saga/atari8c64draw.c
@@ -7,12 +7,11 @@
 //
 //  Original code at https://github.com/tautology0/textadventuregraphics
 
-
 #include <stdio.h>
 #include <stdlib.h>
 
-#include "scott.h"
 #include "sagagraphics.h"
+#include "scott.h"
 
 extern int x, y, count;
 extern int xlen, ylen;
@@ -23,37 +22,44 @@ typedef uint8_t RGB[3];
 
 static void DrawA8C64Pixels(int pattern, int pattern2)
 {
-    int pix1,pix2,pix3,pix4;
+    int pix1, pix2, pix3, pix4;
 
-    if (x>(xlen - 3)*8)
-      return;
+    if (x > (xlen - 3) * 8)
+        return;
 
-    pix1 = (pattern & 0xc0)>>6;
-    pix2 = (pattern & 0x30)>>4;
-    pix3 = (pattern & 0x0c)>>2;
+    pix1 = (pattern & 0xc0) >> 6;
+    pix2 = (pattern & 0x30) >> 4;
+    pix3 = (pattern & 0x0c) >> 2;
     pix4 = (pattern & 0x03);
 
-    PutDoublePixel(x,y, pix1); x += 2;
-    PutDoublePixel(x,y, pix2); x += 2;
-    PutDoublePixel(x,y, pix3); x += 2;
-    PutDoublePixel(x,y, pix4); x += 2;
-    y++;
-    x-=8;
-
-    pix1=(pattern2 & 0xc0)>>6;
-    pix2=(pattern2 & 0x30)>>4;
-    pix3=(pattern2 & 0x0c)>>2;
-    pix4=(pattern2 & 0x03);
-
-    PutDoublePixel(x,y, pix1); x += 2;
-    PutDoublePixel(x,y, pix2); x += 2;
-    PutDoublePixel(x,y, pix3); x += 2;
-    PutDoublePixel(x,y, pix4); x += 2;
+    PutDoublePixel(x, y, pix1);
+    x += 2;
+    PutDoublePixel(x, y, pix2);
+    x += 2;
+    PutDoublePixel(x, y, pix3);
+    x += 2;
+    PutDoublePixel(x, y, pix4);
+    x += 2;
     y++;
     x -= 8;
 
-    if (y > ylen)
-    {
+    pix1 = (pattern2 & 0xc0) >> 6;
+    pix2 = (pattern2 & 0x30) >> 4;
+    pix3 = (pattern2 & 0x0c) >> 2;
+    pix4 = (pattern2 & 0x03);
+
+    PutDoublePixel(x, y, pix1);
+    x += 2;
+    PutDoublePixel(x, y, pix2);
+    x += 2;
+    PutDoublePixel(x, y, pix3);
+    x += 2;
+    PutDoublePixel(x, y, pix4);
+    x += 2;
+    y++;
+    x -= 8;
+
+    if (y > ylen) {
         x += 8;
         y = yoff;
     }
@@ -74,11 +80,14 @@ static const RGB grey = { 167, 167, 167 };
 static const RGB lgreen = { 192, 255, 185 };
 static const RGB lblue = { 162, 143, 255 };
 
+// clang-format off
+
 /* Atari 8-bit colors */
 RGB colors[256] = {
     { 0x00, 0x00, 0x00 }, // 0
     { 0x0e, 0x0e, 0x0e }, // 1
     { 0x1d, 0x1d, 0x1d }, // 2
+
     { 0x2c, 0x2c, 0x2c }, // 3
     { 0x3b, 0x3b, 0x3b }, // 4
     { 0x4a, 0x4a, 0x4a }, // 5
@@ -347,13 +356,14 @@ RGB colors[256] = {
     { 0xee, 0xd1, 0x46 }, // 254
 //    { 0xee, 0xe0, 0x55 }, // 255
     { 0xba, 0x86, 0x00 }
-
 };
 
-static void TranslateAtariColorRGB(int index, uint8_t value) {
-    SetColor(index,&colors[value]);
-}
+// clang-format on
 
+static void TranslateAtariColorRGB(int index, uint8_t value)
+{
+    SetColor(index, &colors[value]);
+}
 
 /*
  The values below are determined by looking at the games
@@ -361,120 +371,121 @@ static void TranslateAtariColorRGB(int index, uint8_t value) {
  I have no idea how the original interpreter calculates
  them. I might have made some mistakes. */
 
-static void TranslateC64Color(int index, uint8_t value) {
+static void TranslateC64Color(int index, uint8_t value)
+{
     debug_print("Color %d: %d\n", index, value);
-    switch(value) {
-        case 2:
-        case 3:
-        case 4:
-        case 8:
-        case 9:
-        case 10:
-        case 12:
-        case 14:
-        case 15:
-        case 255:
-        case 137:
-        case 142:
-            SetColor(index,&white);
-            break;
-        case 35:
-        case 36:
-        case 38:
-        case 40:
-        case 244:
-        case 246:
-        case 248:
-            SetColor(index,&brown);
-            break;
-        case 24:
-        case 26:
-        case 30:
-        case 46:
-        case 16:
-        case 230:
-        case 237:
-        case 238:
-        case 252:
-            SetColor(index,&yellow);
-            break;
-        case 50:
-        case 51:
-        case 52:
-        case 53:
-        case 54:
-        case 56:
-        case 58:
-        case 59:
-        case 60:
-        case 66:
-        case 62:
-            SetColor(index,&orange);
-            break;
-        case 67:
-        case 68:
-        case 69:
-        case 70:
-        case 71:
-            SetColor(index,&red);
-            break;
-        case 0:
-        case 77:
-        case 81:
-        case 84:
-        case 85:
-        case 86:
-        case 87:
-        case 97:
-        case 101:
-        case 102:
-        case 103:
-        case 105:
-        case 224:
-            SetColor(index,&purple);
-            break;
-        case 89:
-            SetColor(index,&lred);
-            break;
-        case 1:
-        case 7:
-        case 116:
-        case 135:
-        case 148:
-        case 151:
-            SetColor(index,&blue);
-            break;
-        case 110:
-        case 157:
-            SetColor(index,&lblue);
-            break;
-        case 161:
-            SetColor(index,&grey);
-            break;
-        case 17:
-        case 20:
-        case 179:
-        case 182:
-        case 183:
-        case 194:
-        case 195:
-        case 196:
-        case 197:
-        case 198:
-        case 199:
-        case 200:
-        case 212:
-        case 214:
-        case 215:
-        case 216:
-            SetColor(index,&green);
-            break;
-        case 201:
-            SetColor(index,&lgreen);
-            break;
-        default:
-            fprintf(stderr, "Unknown color %d ", value);
-            break;
+    switch (value) {
+    case 2:
+    case 3:
+    case 4:
+    case 8:
+    case 9:
+    case 10:
+    case 12:
+    case 14:
+    case 15:
+    case 255:
+    case 137:
+    case 142:
+        SetColor(index, &white);
+        break;
+    case 35:
+    case 36:
+    case 38:
+    case 40:
+    case 244:
+    case 246:
+    case 248:
+        SetColor(index, &brown);
+        break;
+    case 24:
+    case 26:
+    case 30:
+    case 46:
+    case 16:
+    case 230:
+    case 237:
+    case 238:
+    case 252:
+        SetColor(index, &yellow);
+        break;
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 56:
+    case 58:
+    case 59:
+    case 60:
+    case 66:
+    case 62:
+        SetColor(index, &orange);
+        break;
+    case 67:
+    case 68:
+    case 69:
+    case 70:
+    case 71:
+        SetColor(index, &red);
+        break;
+    case 0:
+    case 77:
+    case 81:
+    case 84:
+    case 85:
+    case 86:
+    case 87:
+    case 97:
+    case 101:
+    case 102:
+    case 103:
+    case 105:
+    case 224:
+        SetColor(index, &purple);
+        break;
+    case 89:
+        SetColor(index, &lred);
+        break;
+    case 1:
+    case 7:
+    case 116:
+    case 135:
+    case 148:
+    case 151:
+        SetColor(index, &blue);
+        break;
+    case 110:
+    case 157:
+        SetColor(index, &lblue);
+        break;
+    case 161:
+        SetColor(index, &grey);
+        break;
+    case 17:
+    case 20:
+    case 179:
+    case 182:
+    case 183:
+    case 194:
+    case 195:
+    case 196:
+    case 197:
+    case 198:
+    case 199:
+    case 200:
+    case 212:
+    case 214:
+    case 215:
+    case 216:
+        SetColor(index, &green);
+        break;
+    case 201:
+        SetColor(index, &lgreen);
+        break;
+    default:
+        fprintf(stderr, "Unknown color %d ", value);
+        break;
     }
 }
 
@@ -483,14 +494,15 @@ int DrawAtariC64Image(USImage *image)
     uint8_t *ptr = image->imagedata;
     size_t datasize = image->datasize;
 
-    int work,work2;
+    int work, work2;
     int c;
     int i;
     int countflag = (CurrentGame == COUNT_US || CurrentGame == VOODOO_CASTLE_US);
 
     uint8_t *origptr = ptr;
 
-    x = 0; y = 0;
+    x = 0;
+    y = 0;
 
     ptr += 2;
 
@@ -498,7 +510,6 @@ int DrawAtariC64Image(USImage *image)
     size = work + *ptr++ * 256;
     // Get the offset
     xoff = *ptr++ - 3;
-//    if (xoff < 0) xoff = 0;
     yoff = *ptr++;
     x = xoff * 8;
     y = yoff;
@@ -507,7 +518,8 @@ int DrawAtariC64Image(USImage *image)
     xlen = *ptr++;
 
     ylen = *ptr++;
-    if (countflag) ylen -= 2;
+    if (countflag)
+        ylen -= 2;
 
     glui32 curheight, curwidth;
     glk_window_get_size(Graphics, &curwidth, &curheight);
@@ -519,7 +531,7 @@ int DrawAtariC64Image(USImage *image)
         ImageWidth = xlen * 8 - 17 + left_margin;
         ImageHeight = ylen + 2;
 
-        if (image->index == 19 && image->systype == SYS_ATARI8 ) {
+        if (image->index == 19 && image->systype == SYS_ATARI8) {
             xlen++;
             ImageWidth = 308;
         }
@@ -538,15 +550,14 @@ int DrawAtariC64Image(USImage *image)
             winid_t parent = glk_window_get_parent(Graphics);
             if (parent)
                 glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                           optimal_height, NULL);
+                    optimal_height, NULL);
         }
     }
 
-    SetColor(0,&black);
+    SetColor(0, &black);
 
     // Get the palette
-    for (i = 1; i < 5; i++)
-    {
+    for (i = 1; i < 5; i++) {
         work = *ptr++;
         if (image->systype == SYS_C64)
             TranslateC64Color(i, work);
@@ -554,13 +565,11 @@ int DrawAtariC64Image(USImage *image)
             TranslateAtariColorRGB(i, work);
     }
 
-    while (ptr - origptr < datasize - 2)
-    {
+    while (ptr - origptr < datasize - 2) {
         // First get count
         c = *ptr++;
 
-        if (((c & 0x80) == 0x80) || countflag)
-        { // is a counter
+        if (((c & 0x80) == 0x80) || countflag) { // is a counter
             if (countflag) {
                 c -= 1;
             } else {
@@ -568,19 +577,15 @@ int DrawAtariC64Image(USImage *image)
             }
             work = *ptr++;
             work2 = *ptr++;
-            for (i = 0; i < c + 1; i++)
-            {
-                DrawA8C64Pixels(work,work2);
+            for (i = 0; i < c + 1; i++) {
+                DrawA8C64Pixels(work, work2);
             }
-        }
-        else
-        {
+        } else {
             // Don't count on the next c characters
-            for (i = 0; i < c + 1 && ptr - origptr < datasize - 1; i++)
-            {
-                work=*ptr++;
-                work2=*ptr++;
-                DrawA8C64Pixels(work,work2);
+            for (i = 0; i < c + 1 && ptr - origptr < datasize - 1; i++) {
+                work = *ptr++;
+                work2 = *ptr++;
+                DrawA8C64Pixels(work, work2);
             }
         }
     }

--- a/terps/scott/saga/atari8detect.c
+++ b/terps/scott/saga/atari8detect.c
@@ -10,27 +10,27 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "scott.h"
+#include "hulk.h"
 #include "saga.h"
 #include "sagagraphics.h"
+#include "scott.h"
 #include "scottdefines.h"
-#include "hulk.h"
 
-#include "scottgameinfo.h"
 #include "atari8c64draw.h"
 #include "atari8detect.h"
+#include "scottgameinfo.h"
 
 static const pairrec a8companionlist[][2] = {
-    {{ 0x16810, 0xa972, "S.A.G.A. 01 - Adventureland v5.0-416 (1982)(Adventure International)(US)(Side A)[!].atr", 87}, { 0x16810, 0x8be3, "S.A.G.A. 01 - Adventureland v5.0-416 (1982)(Adventure International)(US)(Side B)[!][cr CSS].atr", 95 }},
-    {{ 0x16810, 0x65a1, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side A)[f][m].atr", 93 }, { 0x16810, 0x5750, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side B)[cr CSS].atr", 95 }},
-    {{ 0x16810, 0x3074, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side A)[f][a].atr", 93 }, { 0x16810, 0x2429, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side B)[a][cr CSS].atr", 98 }},
-    {{ 0x16810, 0x4389, "S.A.G.A. 04 - Voodoo Castle v5.1-119 (1983)(Adventure International)(US)(Disk 1 of 2)[!].atr", 92 }, { 0x16810, 0x234f, "S.A.G.A. 04 - Voodoo Castle v5.1-119 (1983)(Adventure International)(US)(Disk 2 of 2)[!][cr CSS].atr", 100 }},
-    {{ 0x16810, 0xc2f5, "S.A.G.A. 05 - The Count v5.1-115 (1983)(Adventure International)(US)(Side A)[!].atr", 83}, { 0x16810, 0x3ebb, "S.A.G.A. 05 - The Count v5.1-115 (1983)(Adventure International)(US)(Side B)[!][cr CSS].atr", 91 }},
-    {{ 0x16810, 0x6ee8, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 1 of 2)[!][cr CSS].atr", 120 }, { 0x16810, 0xac42, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 2 of 2)[f][!].atr", 115 }},
-    {{ 0x16810, 0x1de8, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 1 of 2)[a][cr CSS].atr", 120 }, { 0x16810, 0x7c32, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 2 of 2)[a].atr", 112 }},
-    {{ 0x16810, 0x1de8, "S.A.G.A. #13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 1 of 2)[a][cr CSS].atr", 121 }, { 0x16810, 0x7c32, "S.A.G.A. #13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 2 of 2)[a].atr", 113 }},
+    { { 0x16810, 0xa972, "S.A.G.A. 01 - Adventureland v5.0-416 (1982)(Adventure International)(US)(Side A)[!].atr", 87 }, { 0x16810, 0x8be3, "S.A.G.A. 01 - Adventureland v5.0-416 (1982)(Adventure International)(US)(Side B)[!][cr CSS].atr", 95 } },
+    { { 0x16810, 0x65a1, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side A)[f][m].atr", 93 }, { 0x16810, 0x5750, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side B)[cr CSS].atr", 95 } },
+    { { 0x16810, 0x3074, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side A)[f][a].atr", 93 }, { 0x16810, 0x2429, "S.A.G.A. 02 - Pirate Adventure v5.0-408 (1982)(Adventure International)(US)(Side B)[a][cr CSS].atr", 98 } },
+    { { 0x16810, 0x4389, "S.A.G.A. 04 - Voodoo Castle v5.1-119 (1983)(Adventure International)(US)(Disk 1 of 2)[!].atr", 92 }, { 0x16810, 0x234f, "S.A.G.A. 04 - Voodoo Castle v5.1-119 (1983)(Adventure International)(US)(Disk 2 of 2)[!][cr CSS].atr", 100 } },
+    { { 0x16810, 0xc2f5, "S.A.G.A. 05 - The Count v5.1-115 (1983)(Adventure International)(US)(Side A)[!].atr", 83 }, { 0x16810, 0x3ebb, "S.A.G.A. 05 - The Count v5.1-115 (1983)(Adventure International)(US)(Side B)[!][cr CSS].atr", 91 } },
+    { { 0x16810, 0x6ee8, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 1 of 2)[!][cr CSS].atr", 120 }, { 0x16810, 0xac42, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 2 of 2)[f][!].atr", 115 } },
+    { { 0x16810, 0x1de8, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 1 of 2)[a][cr CSS].atr", 120 }, { 0x16810, 0x7c32, "S.A.G.A. 13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 2 of 2)[a].atr", 112 } },
+    { { 0x16810, 0x1de8, "S.A.G.A. #13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 1 of 2)[a][cr CSS].atr", 121 }, { 0x16810, 0x7c32, "S.A.G.A. #13 - The Sorcerer of Claymorgue Castle v5.1-125 (1983)(Adventure International)(US)(Disk 2 of 2)[a].atr", 113 } },
 
-    {{ 0,0, NULL }, { 0,0, NULL }}
+    { { 0, 0, NULL }, { 0, 0, NULL } }
 
 };
 
@@ -206,7 +206,7 @@ static const struct imglist listClaymorgue[] = {
     { IMG_ROOM, 30, 0x14c97 }, // (87) wizard's workshop
     { IMG_ROOM, 31, 0x158b3 }, // (88) vacant room
     { IMG_ROOM, 32, 0x15ccf }, // (89) real mess!
-    {0,0,0}
+    { 0, 0, 0 }
 };
 
 static const struct imglist listCount[] = {
@@ -283,7 +283,7 @@ static const struct imglist listCount[] = {
     { IMG_ROOM, 21, 0x136b3 }, // (70) workroom
     { IMG_ROOM, 22, 0x1400e }, // (71) LOT OF TROUBLE!
     { IMG_ROOM, 99, 0x14f97 }, // (72) Title
-    { IMG_ROOM_OBJ, 56, 0x16156 },  // 73
+    { IMG_ROOM_OBJ, 56, 0x16156 }, // 73
     { 0, 0, 0 }
 };
 
@@ -370,7 +370,6 @@ static const struct imglist listVoodoo[] = {
     { 0, 0, 0, }
 };
 
-
 static const CropList a8croplist[] = {
     { VOODOO_CASTLE_US, IMG_ROOM, 10, 8, 8 },
     { VOODOO_CASTLE_US, IMG_ROOM, 11, 8, 8 },
@@ -383,12 +382,12 @@ static const CropList a8croplist[] = {
     { 0, 0, 0, 0, 0 }
 };
 
-
-static int StripBrackets(char sideB[], size_t length) {
+static int StripBrackets(char sideB[], size_t length)
+{
     int left_bracket = 0;
     int right_bracket = 0;
     size_t ppos = length - 1;
-    while(sideB[ppos] != '.' && ppos > 0)
+    while (sideB[ppos] != '.' && ppos > 0)
         ppos--;
     size_t extlen = length - ppos;
     if (length > 4) {
@@ -421,37 +420,38 @@ static int StripBrackets(char sideB[], size_t length) {
     return 0;
 }
 
-static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize) {
+static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type, size_t stringlen, size_t *filesize)
+{
 
     char *sideB = MemAlloc(stringlen + 10);
     uint8_t *result = NULL;
 
     memcpy(sideB, game_file, stringlen + 1);
-    switch(type) {
-        case TYPE_A:
-            sideB[index] = 'A';
-            break;
-        case TYPE_B:
-            sideB[index] = 'B';
-            break;
-        case TYPE_1:
-            sideB[index] = '1';
-            break;
-        case TYPE_2:
-            sideB[index] = '2';
-            break;
-        case TYPE_ONE:
-            sideB[index] = 'o';
-            sideB[index + 1] = 'n';
-            sideB[index + 2] = 'e';
-            break;
-        case TYPE_TWO:
-            sideB[index] = 't';
-            sideB[index + 1] = 'w';
-            sideB[index + 2] = 'o';
-            break;
-        case TYPE_NONE:
-            break;
+    switch (type) {
+    case TYPE_A:
+        sideB[index] = 'A';
+        break;
+    case TYPE_B:
+        sideB[index] = 'B';
+        break;
+    case TYPE_1:
+        sideB[index] = '1';
+        break;
+    case TYPE_2:
+        sideB[index] = '2';
+        break;
+    case TYPE_ONE:
+        sideB[index] = 'o';
+        sideB[index + 1] = 'n';
+        sideB[index + 2] = 'e';
+        break;
+    case TYPE_TWO:
+        sideB[index] = 't';
+        sideB[index + 1] = 'w';
+        sideB[index + 2] = 'o';
+        break;
+    case TYPE_NONE:
+        break;
     }
 
     debug_print("looking for companion file \"%s\"\n", sideB);
@@ -465,7 +465,7 @@ static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type
         } else if (type == TYPE_A) {
             // First we look for the period before the file extension
             size_t ppos = stringlen - 1;
-            while(sideB[ppos] != '.' && ppos > 0)
+            while (sideB[ppos] != '.' && ppos > 0)
                 ppos--;
             if (ppos < 1) {
                 free(sideB);
@@ -491,7 +491,8 @@ static uint8_t *LookForAtari8CompanionFilename(int index, CompanionNameType type
     return result;
 }
 
-static uint8_t *GetAtari8CompanionFile(size_t *size) {
+static uint8_t *GetAtari8CompanionFile(size_t *size)
+{
 
     size_t gamefilelen = strlen(game_file);
     char *foundname = LookInDatabase(a8companionlist, gamefilelen);
@@ -506,36 +507,35 @@ static uint8_t *GetAtari8CompanionFile(size_t *size) {
     char c;
     for (int i = (int)gamefilelen - 1; i >= 0 && game_file[i] != '/' && game_file[i] != '\\'; i--) {
         c = tolower(game_file[i]);
-        if (i > 3 && ((c == 'e' && game_file[i - 1] == 'd' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 's') ||
-                      (c == 'k' && game_file[i - 1] == 's' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 'd'))) {
+        if (i > 3 && ((c == 'e' && game_file[i - 1] == 'd' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 's') || (c == 'k' && game_file[i - 1] == 's' && game_file[i - 2] == 'i' && tolower(game_file[i - 3]) == 'd'))) {
             if (gamefilelen > i + 2) {
                 c = game_file[i + 1];
                 if (c == ' ' || c == '_') {
                     c = tolower(game_file[i + 2]);
                     CompanionNameType type = TYPE_NONE;
                     switch (c) {
-                        case 'a':
-                            type = TYPE_B;
-                            break;
-                        case 'b':
-                            type = TYPE_A;
-                            break;
-                        case 't':
-                            if (gamefilelen > i + 4 && game_file[i + 3] == 'w' && game_file[i + 4] == 'o') {
-                                type =  TYPE_ONE;
-                            }
-                            break;
-                        case 'o':
-                            if (gamefilelen > i + 4 && game_file[i + 3] == 'n' && game_file[i + 4] == 'e') {
-                                type = TYPE_TWO;
-                            }
-                            break;
-                        case '2':
-                            type= TYPE_1;
-                            break;
-                        case '1':
-                            type = TYPE_2;
-                            break;
+                    case 'a':
+                        type = TYPE_B;
+                        break;
+                    case 'b':
+                        type = TYPE_A;
+                        break;
+                    case 't':
+                        if (gamefilelen > i + 4 && game_file[i + 3] == 'w' && game_file[i + 4] == 'o') {
+                            type = TYPE_ONE;
+                        }
+                        break;
+                    case 'o':
+                        if (gamefilelen > i + 4 && game_file[i + 3] == 'n' && game_file[i + 4] == 'e') {
+                            type = TYPE_TWO;
+                        }
+                        break;
+                    case '2':
+                        type = TYPE_1;
+                        break;
+                    case '1':
+                        type = TYPE_2;
+                        break;
                     }
                     if (type != TYPE_NONE)
                         result = LookForAtari8CompanionFilename(i + 2, type, gamefilelen, size);
@@ -548,36 +548,36 @@ static uint8_t *GetAtari8CompanionFile(size_t *size) {
     return NULL;
 }
 
-static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, uint8_t *otherdisk, size_t othersize) {
+static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, uint8_t *otherdisk, size_t othersize)
+{
     size_t size;
 
     int outpic;
 
     const struct imglist *list;
 
-    switch(CurrentGame) {
-        case CLAYMORGUE_US:
-            list = listClaymorgue;
-            break;
-        case COUNT_US:
-            list = listCount;
-            break;
-        case VOODOO_CASTLE_US:
-            list = listVoodoo;
-            break;
-        case HULK_US:
-            list = listHulk;
-            break;
-        default:
-            return 0;
+    switch (CurrentGame) {
+    case CLAYMORGUE_US:
+        list = listClaymorgue;
+        break;
+    case COUNT_US:
+        list = listCount;
+        break;
+    case VOODOO_CASTLE_US:
+        list = listVoodoo;
+        break;
+    case HULK_US:
+        list = listHulk;
+        break;
+    default:
+        return 0;
     }
 
     USImages = new_image();
     struct USImage *image = USImages;
 
     // Now loop round for each image
-    for (outpic = 0; list[outpic].offset != 0; outpic++)
-    {
+    for (outpic = 0; list[outpic].offset != 0; outpic++) {
         uint8_t *ptr = data + list[outpic].offset;
 
         size = *ptr++;
@@ -647,7 +647,6 @@ static int ExtractImagesFromAtariCompanionFile(uint8_t *data, size_t datasize, u
     return 1;
 }
 
-
 static const uint8_t atrheader[6] = { 0x96, 0x02, 0x80, 0x16, 0x80, 0x00 };
 
 GameIDType DetectAtari8(uint8_t **sf, size_t *extent)
@@ -683,7 +682,7 @@ GameIDType DetectAtari8(uint8_t **sf, size_t *extent)
             *extent = tempsize;
         }
     }
-    
+
     if (result != UNKNOWN_GAME) {
         CurrentSys = SYS_ATARI8;
         if (companionfile) {
@@ -695,4 +694,3 @@ GameIDType DetectAtari8(uint8_t **sf, size_t *extent)
 
     return result;
 }
-

--- a/terps/scott/saga/ciderpress.c
+++ b/terps/scott/saga/ciderpress.c
@@ -38,22 +38,26 @@ enum {
 
 const int kMaxSectors = 32;
 
+// clang-format off
+
 /* do we need a way to override these? */
 static const int kVTOCTrack = 17;
 static const int kVTOCSector = 0;
 static const int kCatalogEntryOffset = 0x0b;   // first entry in cat sect starts here
 static const int kCatalogEntrySize = 0x23;     // length in bytes of catalog entries
 static const int kCatalogEntriesPerSect = 7;   // #of entries per catalog sector
-static const int kEntryDeleted = 0xff;     // this is used for track# of deleted files
-static const int kEntryUnused = 0x00;      // this is track# in never-used entries
+static const int kEntryDeleted = 0xff;         // this is used for track# of deleted files
+static const int kEntryUnused = 0x00;          // this is track# in never-used entries
 static const int kMaxTSPairs = 0x7a;           // 122 entries for 256-byte sectors
 static const int kTSOffset = 0x0c;             // first T/S entry in a T/S list
+
+// clang-format on
 
 static const int kMaxTSIterations = 32;
 #define kMaxFileName 30
 #define kFileNameBufLen 31
 
-#define kMaxCatalogSectors 64    // two tracks on a 32-sector disk
+#define kMaxCatalogSectors 64 // two tracks on a 32-sector disk
 
 static size_t fLength = 143360;
 
@@ -61,10 +65,10 @@ static size_t fLength = 143360;
 #define kNumSectPerTrack 16 // Is this ever 13?
 #define kSectorSize 256
 
-#define kChunkSize62 86      // (0x56)
+#define kChunkSize62 86 // (0x56)
 
 #define kMaxNibbleTracks525 40 // max #of tracks on 5.25 nibble img
-#define kTrackAllocSize 6656   // max 5.25 nibble track len; for buffers
+#define kTrackAllocSize 6656 // max 5.25 nibble track len; for buffers
 
 /*
  * ==========================================================================
@@ -72,21 +76,21 @@ static size_t fLength = 143360;
  * ==========================================================================
  */
 
-
-
 /* a T/S pair */
 typedef struct TrackSector {
-    uint8_t    track;
-    uint8_t    sector;
+    uint8_t track;
+    uint8_t sector;
 } TrackSector;
 
 TrackSector fCatalogSectors[kMaxCatalogSectors];
+
+// clang-format off
 
 /*
  * Errors from the various disk image classes.
  */
 typedef enum DIError {
-    kDIErrNone                  = 0,
+    kDIErrNone = 0,
 
     /* I/O request errors (should renumber/rename to match GS/OS errors?) */
     kDIErrAccessDenied          = -10,
@@ -166,6 +170,8 @@ typedef enum DIError {
     kDIErrNufxLibInitFailed     = -110
 } DIError;
 
+// clang-format on
+
 struct ringbuf_t {
     uint8_t **buffer;
     size_t size; //of the buffer
@@ -175,7 +181,7 @@ struct ringbuf_t {
 // Opaque circular buffer structure
 typedef struct ringbuf_t ringbuf_t;
 // Handle type, the way users interact with the API
-typedef ringbuf_t* ringbuf_handle_t;
+typedef ringbuf_t *ringbuf_handle_t;
 
 /*
  * Nibble encode/decode description.  Use no pointers here, so we
@@ -185,31 +191,29 @@ typedef ringbuf_t* ringbuf_handle_t;
  * headers are standard or some wacky variant?
  */
 enum {
-    kNibbleAddrPrologLen = 3,       // d5 aa 96
-    kNibbleAddrEpilogLen = 3,       // de aa eb
-    kNibbleDataPrologLen = 3,       // d5 aa ad
-    kNibbleDataEpilogLen = 3        // de aa eb
+    kNibbleAddrPrologLen = 3, // d5 aa 96
+    kNibbleAddrEpilogLen = 3, // de aa eb
+    kNibbleDataPrologLen = 3, // d5 aa ad
+    kNibbleDataEpilogLen = 3 // de aa eb
 };
 
 typedef struct {
-    char            description[32];
-    short           numSectors;     // 13 or 16 (or 18?)
+    char description[32];
+    short numSectors; // 13 or 16 (or 18?)
 
-    uint8_t         addrProlog[kNibbleAddrPrologLen];
-    uint8_t         addrEpilog[kNibbleAddrEpilogLen];
-    uint8_t         addrChecksumSeed;
-    int             addrVerifyChecksum;
-    int             addrVerifyTrack;
-    int             addrEpilogVerifyCount;
+    uint8_t addrProlog[kNibbleAddrPrologLen];
+    uint8_t addrEpilog[kNibbleAddrEpilogLen];
+    uint8_t addrChecksumSeed;
+    int addrVerifyChecksum;
+    int addrVerifyTrack;
+    int addrEpilogVerifyCount;
 
-    uint8_t         dataProlog[kNibbleDataPrologLen];
-    uint8_t         dataEpilog[kNibbleDataEpilogLen];
-    uint8_t         dataChecksumSeed;
-    int             dataVerifyChecksum;
-    int             dataEpilogVerifyCount;
+    uint8_t dataProlog[kNibbleDataPrologLen];
+    uint8_t dataEpilog[kNibbleDataEpilogLen];
+    uint8_t dataChecksumSeed;
+    int dataVerifyChecksum;
+    int dataEpilogVerifyCount;
 } NibbleDescr;
-
-
 
 static const uint8_t kDiskBytes62[64] = {
     0x96, 0x97, 0x9a, 0x9b, 0x9d, 0x9e, 0x9f, 0xa6,
@@ -226,19 +230,18 @@ static const uint8_t kDiskBytes62[64] = {
 static uint8_t *kInvDiskBytes62 = NULL;
 #define kInvInvalidValue 0xff
 
-
-uint8_t *fNibbleTrackBuf = NULL;    // allocated on heap
+uint8_t *fNibbleTrackBuf = NULL; // allocated on heap
 
 int fNibbleTrackLoaded = -1; // track currently in buffer
 
 static uint8_t *rawdata = NULL;
 static size_t rawdatalen = 0;
 
-typedef enum {              // format of the image data stream
+typedef enum { // format of the image data stream
     kPhysicalFormatUnknown = 0,
     kPhysicalFormatSectors = 1, // sequential 256-byte sectors (13/16/32)
     kPhysicalFormatNib525_6656 = 2, // 5.25" disk ".nib" (6656 bytes/track)
-    kPhysicalFormatNib525_Var = 4,  // 5.25" disk (variable len, e.g. ".app")
+    kPhysicalFormatNib525_Var = 4, // 5.25" disk (variable len, e.g. ".app")
 } PhysicalFormat;
 
 const int kTrackLenNib525 = 6656;
@@ -258,9 +261,9 @@ struct A2FileDOS {
     int fCatTStrack;
     int fCatTSsector;
     int fCatEntryNum;
-    TrackSector* tsList;
+    TrackSector *tsList;
     int tsCount;
-    TrackSector* indexList;
+    TrackSector *indexList;
     int indexCount;
     int fOffset;
     int fOpenEOF;
@@ -287,12 +290,13 @@ static void *MemAlloc(size_t size)
     void *t = (void *)malloc(size);
     if (t == NULL) {
         fprintf(stderr, "Out of memory\n");
-        exit( 1 );
+        exit(1);
     }
     return (t);
 }
 
-static uint8_t access_ringbuf(ringbuf_handle_t ringbuf, int index) {
+static uint8_t access_ringbuf(ringbuf_handle_t ringbuf, int index)
+{
     if (ringbuf == NULL || ringbuf->initialized == 0 || ringbuf->buffer == NULL || *(ringbuf->buffer) == NULL) {
         debug_print("ERROR! Ringbuf not ready!\n");
         return -1;
@@ -328,7 +332,8 @@ static void CalcNibbleInvTables(void)
     }
 }
 
-static uint16_t ConvFrom44(uint8_t val1, uint8_t val2) {
+static uint16_t ConvFrom44(uint8_t val1, uint8_t val2)
+{
     return ((val1 << 1) | 0x01) & val2;
 }
 
@@ -336,14 +341,14 @@ static uint16_t ConvFrom44(uint8_t val1, uint8_t val2) {
  * Decode the values in the address field.
  */
 static void DecodeAddr(ringbuf_handle_t ringbuffer, int offset,
-                short* pVol, short* pTrack, short* pSector, short* pChksum)
+    short *pVol, short *pTrack, short *pSector, short *pChksum)
 {
     //unsigned int vol, track, sector, chksum;
 
-    *pVol = ConvFrom44(access_ringbuf(ringbuffer, offset), access_ringbuf(ringbuffer, offset+1));
-    *pTrack = ConvFrom44(access_ringbuf(ringbuffer, offset+2), access_ringbuf(ringbuffer, offset+3));
-    *pSector = ConvFrom44(access_ringbuf(ringbuffer, offset+4), access_ringbuf(ringbuffer, offset+5));
-    *pChksum = ConvFrom44(access_ringbuf(ringbuffer, offset+6), access_ringbuf(ringbuffer, offset+7));
+    *pVol = ConvFrom44(access_ringbuf(ringbuffer, offset), access_ringbuf(ringbuffer, offset + 1));
+    *pTrack = ConvFrom44(access_ringbuf(ringbuffer, offset + 2), access_ringbuf(ringbuffer, offset + 3));
+    *pSector = ConvFrom44(access_ringbuf(ringbuffer, offset + 4), access_ringbuf(ringbuffer, offset + 5));
+    *pChksum = ConvFrom44(access_ringbuf(ringbuffer, offset + 6), access_ringbuf(ringbuffer, offset + 7));
 }
 
 const NibbleDescr nibbleDescr = {
@@ -351,15 +356,15 @@ const NibbleDescr nibbleDescr = {
     16, // number of sectors
     { 0xd5, 0xaa, 0x96 }, // addrProlog
     { 0xde, 0xaa, 0xeb }, // addrEpilog
-    0x00,   // checksum seed
-    0,   // verify checksum
-    0,   // verify track
-    2,      // epilog verify count
+    0x00, // checksum seed
+    0, // verify checksum
+    0, // verify track
+    2, // epilog verify count
     { 0xd5, 0xaa, 0xad }, // dataProlog
     { 0xde, 0xaa, 0xeb }, // dataEpilog
-    0x00,   // checksum seed
-    0,   // verify checksum
-    2,      // epilog verify count
+    0x00, // checksum seed
+    0, // verify checksum
+    2, // epilog verify count
 };
 
 const NibbleDescr *pNibbleDescr = &nibbleDescr;
@@ -370,11 +375,11 @@ const NibbleDescr *pNibbleDescr = &nibbleDescr;
  * Returns the index start on success or -1 on failure.
  */
 static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
-                           int sector, int* pVol)
+    int sector, int *pVol)
 {
     //DIError dierr;
     long trackLen = ringbuffer->size;
-    const int kMaxDataReach = trackLen;       // fairly arbitrary
+    const int kMaxDataReach = trackLen; // fairly arbitrary
 
     assert(sector >= 0 && sector < 16);
 
@@ -383,21 +388,17 @@ static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
     for (i = 0; i < trackLen; i++) {
         int foundAddr = 0;
 
-        if (access_ringbuf(ringbuffer, i) == pNibbleDescr->addrProlog[0] &&
-            access_ringbuf(ringbuffer, i+1) == pNibbleDescr->addrProlog[1] &&
-            access_ringbuf(ringbuffer, i+2) == pNibbleDescr->addrProlog[2])
-        {
+        if (access_ringbuf(ringbuffer, i) == pNibbleDescr->addrProlog[0] && access_ringbuf(ringbuffer, i + 1) == pNibbleDescr->addrProlog[1] && access_ringbuf(ringbuffer, i + 2) == pNibbleDescr->addrProlog[2]) {
             foundAddr = 1;
         }
-
 
         if (foundAddr) {
             //i += 3;
 
             /* found the address header, decode the address */
             short hdrVol, hdrTrack, hdrSector, hdrChksum;
-            DecodeAddr(ringbuffer, i+3, &hdrVol, &hdrTrack, &hdrSector,
-                       &hdrChksum);
+            DecodeAddr(ringbuffer, i + 3, &hdrVol, &hdrTrack, &hdrSector,
+                &hdrChksum);
 
             if (pNibbleDescr->addrVerifyTrack && track != hdrTrack) {
                 debug_print("Track mismatch");
@@ -406,9 +407,7 @@ static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
             }
 
             if (pNibbleDescr->addrVerifyChecksum) {
-                if ((pNibbleDescr->addrChecksumSeed ^
-                     hdrVol ^ hdrTrack ^ hdrSector ^ hdrChksum) != 0)
-                {
+                if ((pNibbleDescr->addrChecksumSeed ^ hdrVol ^ hdrTrack ^ hdrSector ^ hdrChksum) != 0) {
                     debug_print("   Addr checksum mismatch (want T=%d,S=%d, got T=%d,S=%d)", track, sector, hdrTrack, hdrSector);
                     continue;
                 }
@@ -418,7 +417,7 @@ static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
 
             int j;
             for (j = 0; j < pNibbleDescr->addrEpilogVerifyCount; j++) {
-                if (access_ringbuf(ringbuffer, i+8+j) != pNibbleDescr->addrEpilog[j]) {
+                if (access_ringbuf(ringbuffer, i + 8 + j) != pNibbleDescr->addrEpilog[j]) {
                     //debug_print("   Bad epilog byte %d (%02x vs %02x)",
                     //    j, buffer[i+8+j], pNibbleDescr->addrEpilog[j]);
                     break;
@@ -429,7 +428,7 @@ static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
 
 #ifdef NIB_VERBOSE_DEBUG
             debug_print("    Good header, T=%d,S=%d (looking for T=%d,S=%d)",
-                        hdrTrack, hdrSector, track, sector);
+                hdrTrack, hdrSector, track, sector);
 #endif
 
             if (sector != hdrSector)
@@ -441,10 +440,7 @@ static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
              * field of the next sector.
              */
             for (j = 0; j < kMaxDataReach; j++) {
-                if (access_ringbuf(ringbuffer, i + j) == pNibbleDescr->dataProlog[0] &&
-                    access_ringbuf(ringbuffer, i + j + 1) == pNibbleDescr->dataProlog[1] &&
-                    access_ringbuf(ringbuffer, i + j + 2) == pNibbleDescr->dataProlog[2])
-                {
+                if (access_ringbuf(ringbuffer, i + j) == pNibbleDescr->dataProlog[0] && access_ringbuf(ringbuffer, i + j + 1) == pNibbleDescr->dataProlog[1] && access_ringbuf(ringbuffer, i + j + 2) == pNibbleDescr->dataProlog[2]) {
                     *pVol = hdrVol;
                     int idx = i + j + 3;
                     while (idx >= ringbuffer->size)
@@ -465,9 +461,9 @@ static int FindNibbleSectorStart(ringbuf_handle_t ringbuffer, int track,
  * Decode 6&2 encoding.
  */
 static DIError DecodeNibbleData(ringbuf_handle_t ringbuffer, int idx,
-                         uint8_t* sctBuf)
+    uint8_t *sctBuf)
 {
-    uint8_t twos[kChunkSize62 * 3];   // 258
+    uint8_t twos[kChunkSize62 * 3]; // 258
     int chksum = pNibbleDescr->dataChecksumSeed;
     uint8_t decodedVal;
     int i;
@@ -483,12 +479,9 @@ static DIError DecodeNibbleData(ringbuf_handle_t ringbuffer, int idx,
         assert(decodedVal < sizeof(kDiskBytes62));
 
         chksum ^= decodedVal;
-        twos[i] =
-        ((chksum & 0x01) << 1) | ((chksum & 0x02) >> 1);
-        twos[i + kChunkSize62] =
-        ((chksum & 0x04) >> 1) | ((chksum & 0x08) >> 3);
-        twos[i + kChunkSize62*2] =
-        ((chksum & 0x10) >> 3) | ((chksum & 0x20) >> 5);
+        twos[i] = ((chksum & 0x01) << 1) | ((chksum & 0x02) >> 1);
+        twos[i + kChunkSize62] = ((chksum & 0x04) >> 1) | ((chksum & 0x08) >> 3);
+        twos[i + kChunkSize62 * 2] = ((chksum & 0x10) >> 3) | ((chksum & 0x20) >> 5);
     }
 
     for (i = 0; i < 256; i++) {
@@ -519,7 +512,6 @@ static DIError DecodeNibbleData(ringbuf_handle_t ringbuffer, int idx,
     return kDIErrNone;
 }
 
-
 /*
  * Copy a chunk of bytes out of the disk image.
  *
@@ -527,8 +519,8 @@ static DIError DecodeNibbleData(ringbuf_handle_t ringbuffer, int idx,
  */
 static DIError CopyBytesOut(void *buf, size_t offset, int size)
 {
-//    if (offset + size > rawdatalen)
-//        return kDIErrDataUnderrun;
+    //    if (offset + size > rawdatalen)
+    //        return kDIErrDataUnderrun;
     memcpy(buf, rawdata + offset, size);
     return kDIErrNone;
 }
@@ -536,7 +528,7 @@ static DIError CopyBytesOut(void *buf, size_t offset, int size)
 /*
  * Handle sector order conversions.
  */
-static DIError CalcSectorAndOffset(long track, int sector, size_t* pOffset, int* pNewSector)
+static DIError CalcSectorAndOffset(long track, int sector, size_t *pOffset, int *pNewSector)
 {
     /*
      * Sector order conversions.  No table is needed for Copy ][+ format,
@@ -546,7 +538,6 @@ static DIError CalcSectorAndOffset(long track, int sector, size_t* pOffset, int*
     static const int dos2raw[16] = {
         0, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 15
     };
-
 
     if (track < 0 || track >= kNumTracks) {
         debug_print(" DI read invalid track %ld", track);
@@ -588,7 +579,7 @@ static DIError CalcSectorAndOffset(long track, int sector, size_t* pOffset, int*
 /*
  * Load a nibble track into our track buffer.
  */
-static DIError LoadNibbleTrack(long track, long* pTrackLen)
+static DIError LoadNibbleTrack(long track, long *pTrackLen)
 {
     DIError dierr = kDIErrNone;
     long offset;
@@ -671,7 +662,7 @@ static DIError ReadNibbleSector(long track, int sector, uint8_t *buf)
     ringbuffer->initialized = 1;
 
     sectorIdx = FindNibbleSectorStart(ringbuffer, track, sector,
-                                      &vol);
+        &vol);
     if (sectorIdx < 0) {
         return kDIErrSectorUnreadable;
     }
@@ -681,7 +672,8 @@ static DIError ReadNibbleSector(long track, int sector, uint8_t *buf)
     return dierr;
 }
 
-void InitNibImage(uint8_t *data, size_t datasize) {
+void InitNibImage(uint8_t *data, size_t datasize)
+{
     if (kInvDiskBytes62 == NULL)
         CalcNibbleInvTables();
 
@@ -692,14 +684,16 @@ void InitNibImage(uint8_t *data, size_t datasize) {
     physical = kPhysicalFormatNib525_6656;
 }
 
-void InitDskImage(uint8_t *data, size_t datasize) {
+void InitDskImage(uint8_t *data, size_t datasize)
+{
     rawdata = data;
     rawdatalen = datasize;
 
     physical = kPhysicalFormatSectors;
 }
 
-void FreeDiskImage(void) {
+void FreeDiskImage(void)
+{
     rawdata = NULL;
     rawdatalen = 0;
     fNibbleTrackLoaded = -1;
@@ -719,8 +713,8 @@ void FreeDiskImage(void) {
     lastfile = NULL;
 }
 
-
-uint8_t *ReadImageFromNib(size_t offset, size_t size, uint8_t *data, size_t datasize) {
+uint8_t *ReadImageFromNib(size_t offset, size_t size, uint8_t *data, size_t datasize)
+{
     uint8_t *result = MemAlloc(size);
 
     rawdata = data;
@@ -777,7 +771,7 @@ static DIError ReadTrackSector(long track, int sector, void *buf)
         return kDIErrInvalidArg;
 
     dierr = CalcSectorAndOffset(track, sector,
-                                &offset, &newSector);
+        &offset, &newSector);
     if (dierr != kDIErrNone)
         return dierr;
 
@@ -791,7 +785,8 @@ static DIError ReadTrackSector(long track, int sector, void *buf)
     return dierr;
 }
 
-static void AddFileToList(A2FileDOS *file) {
+static void AddFileToList(A2FileDOS *file)
+{
     if (firstfile == NULL) {
         firstfile = file;
     } else if (lastfile == NULL) {
@@ -813,7 +808,8 @@ static void AddFileToList(A2FileDOS *file) {
  *
  * We modify the first "len" bytes of "buf" in place.
  */
-static void LowerASCII(uint8_t filename[kFileNameBufLen]) {
+static void LowerASCII(uint8_t filename[kFileNameBufLen])
+{
 
     int len = kMaxFileName;
     uint8_t *buf = filename;
@@ -835,7 +831,8 @@ static void LowerASCII(uint8_t filename[kFileNameBufLen]) {
  *
  * Assumes the filename has already been converted to low ASCII.
  */
-static void TrimTrailingSpaces(uint8_t filename[kFileNameBufLen]) {
+static void TrimTrailingSpaces(uint8_t filename[kFileNameBufLen])
+{
     uint8_t *lastspc = filename + strlen((char *)filename);
 
     assert(*lastspc == '\0');
@@ -845,9 +842,8 @@ static void TrimTrailingSpaces(uint8_t filename[kFileNameBufLen]) {
             break;
     }
 
-    *(lastspc+1) = '\0';
+    *(lastspc + 1) = '\0';
 }
-
 
 /*
  * "Fix" a DOS3.3 filename.  Convert DOS-ASCII to normal ASCII, and strip
@@ -877,34 +873,30 @@ static void FixFilename(uint8_t filename[kFileNameBufLen])
  * entries have been copied.  If it looks to be partially valid, only the
  * valid parts are copied out, with the rest zeroed.
  */
-static DIError ExtractTSPairs(A2FileDOS *DOSFile, const uint8_t* sctBuf, TrackSector* tsList,
-                                  int* pLastNonZero)
+static DIError ExtractTSPairs(A2FileDOS *DOSFile, const uint8_t *sctBuf, TrackSector *tsList,
+    int *pLastNonZero)
 {
     DIError dierr = kDIErrNone;
-//    const DiskImg* pDiskImg = fpDiskFS->GetDiskImg();
-    const uint8_t* ptr;
+    //    const DiskImg* pDiskImg = fpDiskFS->GetDiskImg();
+    const uint8_t *ptr;
     int i, track, sector;
 
     *pLastNonZero = -1;
     memset(tsList, 0, sizeof(TrackSector) * kMaxTSPairs);
 
-    ptr = &sctBuf[kTSOffset];       // offset of first T/S entry (0x0c)
+    ptr = &sctBuf[kTSOffset]; // offset of first T/S entry (0x0c)
 
     for (i = 0; i < kMaxTSPairs; i++) {
         track = *ptr++;
         sector = *ptr++;
 
-        if (dierr == kDIErrNone &&
-            (track >= kNumTracks ||
-             sector >= kNumSectPerTrack ||
-             (track == 0 && sector != 0)))
-        {
+        if (dierr == kDIErrNone && (track >= kNumTracks || sector >= kNumSectPerTrack || (track == 0 && sector != 0))) {
             debug_print(" DOS33 invalid T/S %d,%d in '%s'\n", track, sector,
-                    DOSFile->fFileName);
+                DOSFile->fFileName);
 
-            if (i > 0 && tsList[i-1].track == 0 && tsList[i-1].sector == 0) {
+            if (i > 0 && tsList[i - 1].track == 0 && tsList[i - 1].sector == 0) {
                 debug_print("  T/S list looks partially valid\n");
-                goto bail;  // quit immediately
+                goto bail; // quit immediately
             } else {
                 dierr = kDIErrBadFile;
                 // keep going, just so caller has the full set to stare at
@@ -921,7 +913,6 @@ static DIError ExtractTSPairs(A2FileDOS *DOSFile, const uint8_t* sctBuf, TrackSe
 bail:
     return dierr;
 }
-
 
 const int kDefaultTSAlloc = 2;
 const int kDefaultIndexAlloc = 8;
@@ -952,8 +943,8 @@ static DIError LoadTSList(A2FileDOS *DOSFile)
 {
     DIError dierr = kDIErrNone;
 
-    TrackSector* tsList = NULL;
-    TrackSector* indexList = NULL;
+    TrackSector *tsList = NULL;
+    TrackSector *indexList = NULL;
     int tsCount, tsAlloc;
     int indexCount, indexAlloc;
     uint8_t sctBuf[kSectorSize];
@@ -973,11 +964,9 @@ static DIError LoadTSList(A2FileDOS *DOSFile)
     /* get the first T/S sector for this file */
     track = DOSFile->fTSListTrack;
     sector = DOSFile->fTSListSector;
-    if (track >= kNumTracks ||
-        sector >= kNumSectPerTrack)
-    {
+    if (track >= kNumTracks || sector >= kNumSectPerTrack) {
         debug_print(" DOS33 invalid initial T/S %d,%d in '%s'\n", track, sector,
-                DOSFile->fFileName);
+            DOSFile->fFileName);
         dierr = kDIErrBadFile;
         goto bail;
     }
@@ -995,7 +984,7 @@ static DIError LoadTSList(A2FileDOS *DOSFile)
          */
         if (indexCount == indexAlloc) {
             debug_print("+++ expanding index list\n");
-            TrackSector* newList;
+            TrackSector *newList;
             indexAlloc += kDefaultIndexAlloc;
             newList = MemAlloc(indexAlloc * sizeof(TrackSector));
             memcpy(newList, indexList, indexCount * sizeof(TrackSector));
@@ -1013,21 +1002,19 @@ static DIError LoadTSList(A2FileDOS *DOSFile)
         /* grab next track/sector */
         track = sctBuf[0x01];
         sector = sctBuf[0x02];
-        sectorOffset = sctBuf[0x05] +  sctBuf[0x06] * 256;
+        sectorOffset = sctBuf[0x05] + sctBuf[0x06] * 256;
 
         /* if T/S link is bogus, whole sector is probably bad */
-        if (track >= kNumTracks ||
-            sector >= kNumSectPerTrack)
-        {
+        if (track >= kNumTracks || sector >= kNumSectPerTrack) {
             // bogus T/S, mark file as damaged and stop
             debug_print(" DOS33 invalid T/S link %d,%d in '%s'\n", track, sector,
-                 DOSFile->fFileName);
+                DOSFile->fFileName);
             dierr = kDIErrBadFile;
             goto bail;
         }
         if ((sectorOffset % kMaxTSPairs) != 0) {
             debug_print(" DOS33 invalid T/S header sector offset %u in '%s'\n",
-                 sectorOffset,  DOSFile->fFileName);
+                sectorOffset, DOSFile->fFileName);
             // not fatal, just weird
         }
 
@@ -1037,7 +1024,7 @@ static DIError LoadTSList(A2FileDOS *DOSFile)
          */
         if (tsCount + kMaxTSPairs > tsAlloc) {
             debug_print("+++ expanding ts list\n");
-            TrackSector* newList;
+            TrackSector *newList;
             tsAlloc += kMaxTSPairs * kDefaultTSAlloc;
             newList = MemAlloc(tsAlloc * sizeof(TrackSector));
             memcpy(newList, tsList, tsCount * sizeof(TrackSector));
@@ -1065,10 +1052,10 @@ static DIError LoadTSList(A2FileDOS *DOSFile)
                 //LOGI(" DOS33 odd -- last T/S sector of '%s' was empty",
                 //  GetPathName());
             }
-            tsCount += lastNonZero +1;
+            tsCount += lastNonZero + 1;
         }
 
-        iterations++;       // watch for infinite loops
+        iterations++; // watch for infinite loops
     } while (!(track == 0 && sector == 0) && iterations < kMaxTSIterations);
 
     if (iterations == kMaxTSIterations) {
@@ -1101,7 +1088,7 @@ bail:
 static DIError Read(A2FileDOS *pFile, uint8_t *buf, size_t len, size_t *pActual)
 {
     debug_print(" DOS reading %lu bytes from '%s' (offset=%ld)\n",
-         (unsigned long) len, pFile->fFileName, (long) pFile->fOffset);
+        (unsigned long)len, pFile->fFileName, (long)pFile->fOffset);
 
     /*
      * Don't allow them to read past the end of the file.  The length value
@@ -1111,7 +1098,7 @@ static DIError Read(A2FileDOS *pFile, uint8_t *buf, size_t len, size_t *pActual)
     if (pFile->fOffset + (long)len > pFile->fOpenEOF) {
         if (pActual == NULL)
             return kDIErrDataUnderrun;
-        len = (size_t) (pFile->fOpenEOF - pFile->fOffset);
+        len = (size_t)(pFile->fOpenEOF - pFile->fOffset);
     }
     if (pActual != NULL)
         *pActual = len;
@@ -1120,8 +1107,8 @@ static DIError Read(A2FileDOS *pFile, uint8_t *buf, size_t len, size_t *pActual)
     DIError dierr = kDIErrNone;
     uint8_t sctBuf[kSectorSize];
     size_t actualOffset = pFile->fOffset; //+ pFile->fDataOffset;   // adjust for embedded len
-    int tsIndex = (int) (actualOffset / kSectorSize);
-    int bufOffset = (int) (actualOffset % kSectorSize);        // (& 0xff)
+    int tsIndex = (int)(actualOffset / kSectorSize);
+    int bufOffset = (int)(actualOffset % kSectorSize); // (& 0xff)
     size_t thisCount;
 
     if (len == 0)
@@ -1134,7 +1121,7 @@ static DIError Read(A2FileDOS *pFile, uint8_t *buf, size_t len, size_t *pActual)
     while (len) {
         if (tsIndex >= pFile->tsCount) {
             /* should've caught this earlier */
-            debug_print(" DOS ran off the end (fTSCount=%d). len == %zu\n",  pFile->tsCount, len);
+            debug_print(" DOS ran off the end (fTSCount=%d). len == %zu\n", pFile->tsCount, len);
             return kDIErrDataUnderrun;
         }
 
@@ -1165,13 +1152,10 @@ static DIError Read(A2FileDOS *pFile, uint8_t *buf, size_t len, size_t *pActual)
     return dierr;
 }
 
-
-
-
 /*
  * Set up state for this file.
  */
-static DIError Open(A2FileDOS* pOpenFile)
+static DIError Open(A2FileDOS *pOpenFile)
 {
     DIError dierr = kDIErrNone;
 
@@ -1190,11 +1174,9 @@ static DIError Open(A2FileDOS* pOpenFile)
 //    pOpenFile = NULL;
 //
 bail:
-//    delete pOpenFile;
+    //    delete pOpenFile;
     return dierr;
 }
-
-
 
 /*
  * Process the list of files in one sector of the catalog.
@@ -1203,10 +1185,10 @@ bail:
  * (We only use "catTrack" and "catSect" to fill out some fields.)
  */
 static DIError ProcessCatalogSector(int catTrack, int catSect,
-                             const uint8_t* sctBuf)
+    const uint8_t *sctBuf)
 {
-    A2FileDOS* pFile;
-    const uint8_t* pEntry;
+    A2FileDOS *pFile;
+    const uint8_t *pEntry;
     int i;
 
     pEntry = &sctBuf[kCatalogEntryOffset];
@@ -1221,19 +1203,35 @@ static DIError ProcessCatalogSector(int catTrack, int catSect,
             pFile->fTSListSector = pEntry[0x01];
             pFile->fLocked = (pEntry[0x02] & 0x80) != 0;
             switch (pEntry[0x02] & 0x7f) {
-                case 0x00:  pFile->fFileType = FILETYPE_T;    break;
-                case 0x01:  pFile->fFileType = FILETYPE_I;    break;
-                case 0x02:  pFile->fFileType = FILETYPE_A;    break;
-                case 0x04:  pFile->fFileType = FILETYPE_B;    break;
-                case 0x08:  pFile->fFileType = FILETYPE_S;    break;
-                case 0x10:  pFile->fFileType = FILETYPE_R;    break;
-                case 0x20:  pFile->fFileType = FILETYPE_A;    break;
-                case 0x40:  pFile->fFileType = FILETYPE_B;    break;
-                default:
-                    /* some odd arrangement of bit flags? */
-                    debug_print(" DOS33 peculiar filetype byte 0x%02x\n", pEntry[0x02]);
-                    pFile->fFileType = FILETYPE_UNKNOWN;
-                    break;
+            case 0x00:
+                pFile->fFileType = FILETYPE_T;
+                break;
+            case 0x01:
+                pFile->fFileType = FILETYPE_I;
+                break;
+            case 0x02:
+                pFile->fFileType = FILETYPE_A;
+                break;
+            case 0x04:
+                pFile->fFileType = FILETYPE_B;
+                break;
+            case 0x08:
+                pFile->fFileType = FILETYPE_S;
+                break;
+            case 0x10:
+                pFile->fFileType = FILETYPE_R;
+                break;
+            case 0x20:
+                pFile->fFileType = FILETYPE_A;
+                break;
+            case 0x40:
+                pFile->fFileType = FILETYPE_B;
+                break;
+            default:
+                /* some odd arrangement of bit flags? */
+                debug_print(" DOS33 peculiar filetype byte 0x%02x\n", pEntry[0x02]);
+                pFile->fFileType = FILETYPE_UNKNOWN;
+                break;
             }
 
             memcpy(pFile->fRawFileName, &pEntry[0x03], kMaxFileName);
@@ -1246,7 +1244,7 @@ static DIError ProcessCatalogSector(int catTrack, int catSect,
             debug_print("File name: %s\n", pFile->fFileName);
 
             pFile->fLengthInSectors = pEntry[0x21];
-            pFile->fLengthInSectors |= (uint16_t) pEntry[0x22] << 8;
+            pFile->fLengthInSectors |= (uint16_t)pEntry[0x22] << 8;
 
             pFile->fCatTStrack = catTrack;
             pFile->fCatTSsector = catSect;
@@ -1293,11 +1291,11 @@ static DIError ReadVTOC(void)
 
     if (fVTOCNumTracks != kNumTracks) {
         debug_print(" DOS33 warning: VTOC numtracks %d vs %d\n",
-             fVTOCNumTracks, kNumTracks);
+            fVTOCNumTracks, kNumTracks);
     }
     if (fVTOCNumSectors != kNumSectPerTrack) {
         debug_print(" DOS33 warning: VTOC numsect %d vs %d\n",
-             fVTOCNumSectors, kNumSectPerTrack);
+            fVTOCNumSectors, kNumSectPerTrack);
     }
 
 bail:
@@ -1327,8 +1325,7 @@ static DIError ReadCatalog(void)
 
     memset(fCatalogSectors, 0, sizeof(fCatalogSectors));
 
-    while (catTrack != 0 && catSect != 0 && iterations < kMaxCatalogSectors)
-    {
+    while (catTrack != 0 && catSect != 0 && iterations < kMaxCatalogSectors) {
         dierr = ReadTrackSector(catTrack, catSect, sctBuf);
         if (dierr != kDIErrNone)
             goto bail;
@@ -1338,7 +1335,7 @@ static DIError ReadCatalog(void)
          */
         if (catTrack == sctBuf[0x01] && catSect == sctBuf[0x02]) {
             debug_print(" DOS detected self-reference on cat (%d,%d)\n",
-                 catTrack, catSect);
+                catTrack, catSect);
             break;
         }
 
@@ -1347,9 +1344,7 @@ static DIError ReadCatalog(void)
          * broken, there's a very good chance that this isn't really a
          * catalog sector, so we want to bail out now.
          */
-        if (sctBuf[0x01] >= kNumTracks ||
-            sctBuf[0x02] >= kNumSectPerTrack)
-        {
+        if (sctBuf[0x01] >= kNumTracks || sctBuf[0x02] >= kNumSectPerTrack) {
             debug_print(" DOS bailing out early on catalog read due to funky T/S\n");
             break;
         }
@@ -1364,8 +1359,7 @@ static DIError ReadCatalog(void)
         catTrack = sctBuf[0x01];
         catSect = sctBuf[0x02];
 
-        iterations++;       // watch for infinite loops
-
+        iterations++; // watch for infinite loops
     }
     if (iterations >= kMaxCatalogSectors) {
         dierr = kDIErrDirectoryLoop;
@@ -1376,7 +1370,8 @@ bail:
     return dierr;
 }
 
-static A2FileDOS *find_file_named(char *name) {
+static A2FileDOS *find_file_named(char *name)
+{
     debug_print("find_file_named: \"%s\"\n", name);
     A2FileDOS *file = firstfile;
     while (file != NULL) {
@@ -1388,7 +1383,8 @@ static A2FileDOS *find_file_named(char *name) {
     return file;
 }
 
-static A2FileDOS *find_SAGA_database(void) {
+static A2FileDOS *find_SAGA_database(void)
+{
     A2FileDOS *file = firstfile;
     while (file != NULL) {
         char *name = (char *)file->fFileName;
@@ -1399,8 +1395,7 @@ static A2FileDOS *find_SAGA_database(void) {
             break;
         if (strcmp("THE INCREDIBLE HULK", name) == 0)
             break;
-        if (name[0] == 'A' && name[2] == '.' &&
-            name[3] == 'D' && name[4] == 'A' && name[5] == 'T') {
+        if (name[0] == 'A' && name[2] == '.' && name[3] == 'D' && name[4] == 'A' && name[5] == 'T') {
             break; //A(adventure number).DAT
         }
         file = file->next;
@@ -1463,4 +1458,3 @@ uint8_t *ReadApple2DOSFile(uint8_t *data, size_t *len, uint8_t **invimg, size_t 
 
     return buf;
 }
-

--- a/terps/scott/saga/pcdraw.c
+++ b/terps/scott/saga/pcdraw.c
@@ -12,8 +12,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "scott.h"
 #include "sagagraphics.h"
+#include "scott.h"
 
 int x = 0, y = 0, at_last_line = 0;
 
@@ -25,14 +25,15 @@ int skipy = 1;
 
 extern char *DirPath;
 
-uint8_t *FindImageFile(const char *shortname, size_t *datasize) {
+uint8_t *FindImageFile(const char *shortname, size_t *datasize)
+{
     *datasize = 0;
     uint8_t *data = NULL;
     size_t pathlen = strlen(DirPath) + strlen(shortname) + 5;
     char *filename = MemAlloc(pathlen);
     int n = snprintf(filename, pathlen, "%s%s.PAK", DirPath, shortname);
     if (n > 0) {
-        FILE *infile=fopen(filename,"rb");
+        FILE *infile = fopen(filename, "rb");
         if (infile) {
             fseek(infile, 0, SEEK_END);
             size_t length = ftell(infile);
@@ -53,35 +54,42 @@ uint8_t *FindImageFile(const char *shortname, size_t *datasize) {
 
 static void DrawDOSPixels(int pattern)
 {
-    int pix1,pix2,pix3,pix4;
+    int pix1, pix2, pix3, pix4;
     // Now get colors
-    pix1=(pattern & 0xc0)>>6;
-    pix2=(pattern & 0x30)>>4;
-    pix3=(pattern & 0x0c)>>2;
-    pix4=(pattern & 0x03);
+    pix1 = (pattern & 0xc0) >> 6;
+    pix2 = (pattern & 0x30) >> 4;
+    pix3 = (pattern & 0x0c) >> 2;
+    pix4 = (pattern & 0x03);
 
     if (!skipy) {
-        PutDoublePixel(x,y, pix1); x += 2;
-        PutDoublePixel(x,y, pix2); x += 2;
-        PutDoublePixel(x,y, pix3); x += 2;
-        PutDoublePixel(x,y, pix4); x += 2;
+        PutDoublePixel(x, y, pix1);
+        x += 2;
+        PutDoublePixel(x, y, pix2);
+        x += 2;
+        PutDoublePixel(x, y, pix3);
+        x += 2;
+        PutDoublePixel(x, y, pix4);
+        x += 2;
     } else {
-        PutPixel(x,y, pix1); x++;
-        PutPixel(x,y, pix2); x++;
-        PutPixel(x,y, pix3); x++;
-        PutPixel(x,y, pix4); x++;
+        PutPixel(x, y, pix1);
+        x++;
+        PutPixel(x, y, pix2);
+        x++;
+        PutPixel(x, y, pix3);
+        x++;
+        PutPixel(x, y, pix4);
+        x++;
     }
 
-    if (x>=xlen+xoff)
-    {
-        y+=2;
-        x=xoff;
+    if (x >= xlen + xoff) {
+        y += 2;
+        x = xoff;
         ycount++;
     }
-    if (ycount>ylen) {
-        y=yoff + 1;
+    if (ycount > ylen) {
+        y = yoff + 1;
         at_last_line++;
-        ycount=0;
+        ycount = 0;
     }
 }
 
@@ -94,31 +102,36 @@ int DrawDOSImage(USImage *image)
 
     debug_print("DrawDOSImage: usage:%d index:%d\n", image->usage, image->index);
 
-
-    x=0;
-    y=0;
+    x = 0;
+    y = 0;
     at_last_line = 0;
 
-    xlen=0;
-    ylen=0;
-    xoff=0; yoff=0;
-    ycount=0;
-    skipy=1;
+    xlen = 0;
+    ylen = 0;
+    xoff = 0;
+    yoff = 0;
+    ycount = 0;
+    skipy = 1;
 
     int work;
     int c;
     int i;
     int rawoffset;
+
+    // clang-format off
+
     RGB black =   { 0,0,0 };
     RGB magenta = { 255,0,255 };
     RGB cyan =    { 0,255,255 };
     RGB white =   { 255,255,255 };
 
+    // clang-format on
+
     /* set up the palette */
-    SetColor(0,&black);
-    SetColor(1,&cyan);
-    SetColor(2,&magenta);
-    SetColor(3,&white);
+    SetColor(0, &black);
+    SetColor(1, &cyan);
+    SetColor(2, &magenta);
+    SetColor(3, &white);
 
     uint8_t *ptr = image->imagedata;
     uint8_t *origptr = ptr;
@@ -131,17 +144,18 @@ int DrawDOSImage(USImage *image)
     // Get whether it is lined
     ptr = origptr + 0x0d;
     work = *ptr++;
-    if (work == 0xff) skipy=0;
+    if (work == 0xff)
+        skipy = 0;
 
     // Get the offset
     ptr = origptr + 0x0f;
     work = *ptr++;
     rawoffset = work + (*ptr * 256);
-    xoff=((rawoffset % 80)*4)-24;
-    yoff=rawoffset / 40;
+    xoff = ((rawoffset % 80) * 4) - 24;
+    yoff = rawoffset / 40;
     yoff -= (yoff & 1);
-    x=xoff;
-    y=yoff;
+    x = xoff;
+    y = yoff;
 
     // Get the y length
     ptr = origptr + 0x11;
@@ -155,30 +169,25 @@ int DrawDOSImage(USImage *image)
     xlen = *ptr * 4;
 
     ptr = origptr + 0x17;
-    while (ptr - origptr < size)
-    {
+    while (ptr - origptr < size) {
         // First get count
         c = *ptr++;
 
-        if ((c & 0x80) == 0x80)
-        { // is a counter
+        if ((c & 0x80) == 0x80) { // is a counter
             work = *ptr++;
             c &= 0x7f;
-            for (i=0;i<c+1;i++)
-            {
+            for (i = 0; i < c + 1; i++) {
                 DrawDOSPixels(work);
             }
-        }
-        else
-        {
+        } else {
             // Don't count on the next j characters
-            for (i=0;i<c+1;i++)
-            {
+            for (i = 0; i < c + 1; i++) {
                 work = *ptr++;
                 DrawDOSPixels(work);
             }
         }
-        if (at_last_line > 1) break;
+        if (at_last_line > 1)
+            break;
     }
     return 1;
 }

--- a/terps/scott/saga/saga.c
+++ b/terps/scott/saga/saga.c
@@ -5,19 +5,20 @@
 //  Created by Petter Sjölund on 2022-09-29.
 //
 
-#include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "scott.h"
-#include "detectgame.h"
-#include "sagagraphics.h"
-#include "pcdraw.h"
-#include "atari8c64draw.h"
 #include "apple2draw.h"
+#include "atari8c64draw.h"
+#include "detectgame.h"
+#include "pcdraw.h"
+#include "sagagraphics.h"
+#include "scott.h"
 
 #include "saga.h"
 
+// clang-format off
 
 static const char *DOSFilenames[] =
   { "B01024R", "B01044I", "R0109",   "R0190",
@@ -35,7 +36,10 @@ static const char *DOSFilenames[] =
     "R0187",   "B01022R", "B01040R", "R0103",  "R0188",
     "B01023I", "B01042I", "R0104",   "R0189",  NULL };
 
-int LoadDOSImages(void) {
+// clang-format on
+
+int LoadDOSImages(void)
+{
     USImages = new_image();
 
     struct USImage *image = USImages;
@@ -105,12 +109,12 @@ uint8_t *ReadUSDictionary(uint8_t *ptr)
             Nouns[wordnum] = MemAlloc(charindex + 1);
             memcpy((char *)Nouns[wordnum], dictword, charindex + 1);
             debug_print("Nouns %d: \"%s\"\n", wordnum,
-                    Nouns[wordnum]);
+                Nouns[wordnum]);
         } else {
             Verbs[wordnum - nn] = MemAlloc(charindex + 1);
             memcpy((char *)Verbs[wordnum - nn], dictword, charindex + 1);
             debug_print("Verbs %d: \"%s\"\n", wordnum - nn,
-                    Verbs[wordnum - nn]);
+                Verbs[wordnum - nn]);
         }
         wordnum++;
 
@@ -123,7 +127,8 @@ uint8_t *ReadUSDictionary(uint8_t *ptr)
     return ptr;
 }
 
-int DrawUSImage(USImage *image) {
+int DrawUSImage(USImage *image)
+{
     last_image_index = image->index;
     if (image->systype == SYS_MSDOS)
         return DrawDOSImage(image);
@@ -134,7 +139,8 @@ int DrawUSImage(USImage *image) {
     return 0;
 }
 
-void DrawInventoryImages(void) {
+void DrawInventoryImages(void)
+{
     struct USImage *image = USImages;
     if (image != NULL) {
         do {
@@ -146,7 +152,8 @@ void DrawInventoryImages(void) {
     }
 }
 
-void DrawRoomObjectImages(void) {
+void DrawRoomObjectImages(void)
+{
     struct USImage *image = USImages;
     if (image != NULL) {
         do {
@@ -158,7 +165,8 @@ void DrawRoomObjectImages(void) {
     }
 }
 
-int DrawUSRoom(int room) {
+int DrawUSRoom(int room)
+{
     struct USImage *image = USImages;
     if (image != NULL) {
         do {
@@ -171,7 +179,8 @@ int DrawUSRoom(int room) {
     return 0;
 }
 
-void DrawUSRoomObject(int item) {
+void DrawUSRoomObject(int item)
+{
     struct USImage *image = USImages;
     if (image != NULL) {
         do {
@@ -196,28 +205,28 @@ void LookUS(void)
 
     if (CurrentGame == HULK_US && USImages && USImages->systype != SYS_APPLE2)
         switch (MyLoc) {
-            case 5: // Tunnel going outside
-            case 6:
-                room = 3;
-                break;
-            case 7: // Field
-            case 8:
-                room = 4;
-                break;
-            case 10: // Hole
-            case 11:
-                room = 9;
-                break;
-            case 13: // Dome
-            case 14:
-                room = 2;
-                break;
-            case 17: // warp
-            case 18:
-                room = 16;
-                break;
-            default:
-                break;
+        case 5: // Tunnel going outside
+        case 6:
+            room = 3;
+            break;
+        case 7: // Field
+        case 8:
+            room = 4;
+            break;
+        case 10: // Hole
+        case 11:
+            room = 9;
+            break;
+        case 13: // Dome
+        case 14:
+            room = 2;
+            break;
+        case 17: // warp
+        case 18:
+            room = 16;
+            break;
+        default:
+            break;
         }
 
     if (!DrawUSRoom(room)) {
@@ -290,11 +299,12 @@ static int SanityCheckScottFreeHeader(int ni, int na, int nw, int nr, int mc)
     return 1;
 }
 
-uint8_t *Skip(uint8_t *ptr, int count, uint8_t *eof) {
+uint8_t *Skip(uint8_t *ptr, int count, uint8_t *eof)
+{
 #if (DEBUG_PRINT)
     for (int i = 0; i < count && ptr + i + 1 < eof; i += 2) {
-        uint16_t val =  ptr[i] + ptr[i+1] * 0x100;
-        debug_print("Unknown value %d: %d (%x)\n", i/2, val, val);
+        uint16_t val = ptr[i] + ptr[i + 1] * 0x100;
+        debug_print("Unknown value %d: %d (%x)\n", i / 2, val, val);
     }
 #endif
     return ptr + count;
@@ -317,7 +327,7 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     if (dict_start) {
         file_baseline_offset = dict_start - info.start_of_dictionary - 645;
         debug_print("LoadBinaryDatabase: file baseline offset:%d\n",
-                file_baseline_offset);
+            file_baseline_offset);
         offset = info.start_of_header + file_baseline_offset;
         ptr = SeekToPos(data, offset);
     } else {
@@ -357,7 +367,7 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     ptr = ReadHeader(ptr);
 
     ParseHeader(header, US_HEADER, &ni, &na, &nw, &nr, &mc, &pr, &tr,
-                &wl, &lt, &mn, &trm);
+        &wl, &lt, &mn, &trm);
 
     PrintHeaderInfo(header, ni, na, nw, nr, mc, pr, tr, wl, lt, mn, trm);
 
@@ -496,7 +506,7 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     }
 
     // Image strings lookup table
-    ptr = Skip(ptr, (ni + 1) * 4,  data + length);
+    ptr = Skip(ptr, (ni + 1) * 4, data + length);
 
 #pragma mark Actions
 
@@ -609,7 +619,6 @@ GameIDType LoadBinaryDatabase(uint8_t *data, size_t length, struct GameInfo info
     return info.gameID;
 }
 
-
 uint8_t *ReadFileIfExists(const char *name, size_t *size)
 {
     FILE *fptr = fopen(name, "r");
@@ -635,7 +644,8 @@ uint8_t *ReadFileIfExists(const char *name, size_t *size)
     return result;
 }
 
-int CompareFilenames(const char *str1, size_t length1, const char *str2, size_t length2) {
+int CompareFilenames(const char *str1, size_t length1, const char *str2, size_t length2)
+{
     while (length1 > 0 && str1[length1] != '.') {
         length1--;
     }
@@ -653,7 +663,8 @@ int CompareFilenames(const char *str1, size_t length1, const char *str2, size_t 
     return 1;
 }
 
-const char *AddGameFileExtension(const char *filename, size_t gamefilelen, size_t *stringlength) {
+const char *AddGameFileExtension(const char *filename, size_t gamefilelen, size_t *stringlength)
+{
     char *new = NULL;
     size_t extpos = gamefilelen;
     while (extpos && game_file[extpos] != '.')
@@ -672,7 +683,8 @@ const char *AddGameFileExtension(const char *filename, size_t gamefilelen, size_
     return new;
 }
 
-const char *LookForCompanionFilenameInDatabase(const pairrec list[][2], size_t stringlen, size_t *stringlength2) {
+const char *LookForCompanionFilenameInDatabase(const pairrec list[][2], size_t stringlen, size_t *stringlength2)
+{
 
     for (int i = 0; list[i][0].filename != NULL; i++) {
         *stringlength2 = list[i][0].stringlength;
@@ -703,7 +715,8 @@ const char *LookForCompanionFilenameInDatabase(const pairrec list[][2], size_t s
     return NULL;
 }
 
-char *LookInDatabase(const pairrec list[][2], size_t stringlen) {
+char *LookInDatabase(const pairrec list[][2], size_t stringlen)
+{
     size_t resultlen;
     const char *foundname = LookForCompanionFilenameInDatabase(list, stringlen, &resultlen);
     if (foundname != NULL) {

--- a/terps/scott/saga/sagagraphics.c
+++ b/terps/scott/saga/sagagraphics.c
@@ -23,11 +23,13 @@ PALETTE pal;
 
 struct USImage *USImages = NULL;
 
-int has_graphics(void) {
+int has_graphics(void)
+{
     return (USImages != NULL);
 }
 
-USImage *new_image(void) {
+USImage *new_image(void)
+{
     struct USImage *new = MemAlloc(sizeof(USImage));
     new->index = -1;
     new->datasize = 0;
@@ -48,7 +50,8 @@ void SetColor(int32_t index, const RGB *color)
     pal[index][2] = (*color)[2];
 }
 
-void SetRGB(int32_t index, int red, int green, int blue) {
+void SetRGB(int32_t index, int red, int green, int blue)
+{
     red = red * 35.7;
     green = green * 35.7;
     blue = blue * 35.7;
@@ -66,7 +69,7 @@ void PutPixel(glsi32 xpos, glsi32 ypos, int32_t color)
     glui32 glk_color = ((pal[color][0] << 16)) | ((pal[color][1] << 8)) | (pal[color][2]);
 
     glk_window_fill_rect(Graphics, glk_color, xpos * pixel_size + x_offset,
-                         ypos * pixel_size + y_offset, pixel_size, pixel_size);
+        ypos * pixel_size + y_offset, pixel_size, pixel_size);
 }
 
 void PutDoublePixel(glsi32 xpos, glsi32 ypos, int32_t color)
@@ -77,10 +80,11 @@ void PutDoublePixel(glsi32 xpos, glsi32 ypos, int32_t color)
     glui32 glk_color = ((pal[color][0] << 16)) | ((pal[color][1] << 8)) | (pal[color][2]);
 
     glk_window_fill_rect(Graphics, glk_color, xpos * pixel_size + x_offset,
-                         ypos * pixel_size + y_offset, pixel_size * 2, pixel_size);
+        ypos * pixel_size + y_offset, pixel_size * 2, pixel_size);
 }
 
-int issagaimg(const char *name) {
+int issagaimg(const char *name)
+{
     if (name == NULL)
         return 0;
     size_t len = strlen(name);
@@ -88,11 +92,10 @@ int issagaimg(const char *name) {
         return 0;
     char c = name[0];
     if (c == 'R' || c == 'B' || c == 'S') {
-        for(int i = 1; i < 4; i++)
+        for (int i = 1; i < 4; i++)
             if (!isdigit(name[i]))
                 return 0;
         return 1;
     }
     return 0;
 }
-

--- a/terps/scott/scott.c
+++ b/terps/scott/scott.c
@@ -43,25 +43,25 @@
 
 #include "glk.h"
 #include "glkstart.h"
-#include "sagagraphics.h"
 #include "saga.h"
+#include "sagagraphics.h"
 #include "titleimage.h"
 
 #include "detectgame.h"
 #include "layouttext.h"
+#include "line_drawing.h"
 #include "restorestate.h"
 #include "sagadraw.h"
-#include "line_drawing.h"
 
-#include "ti99_4a_terp.h"
 #include "parser.h"
+#include "ti99_4a_terp.h"
 
+#include "apple2draw.h"
 #include "game_specific.h"
 #include "gremlins.h"
 #include "hulk.h"
 #include "robinofsherwood.h"
 #include "seasofblood.h"
-#include "apple2draw.h"
 
 #include "bsd.h"
 #include "scott.h"
@@ -172,53 +172,54 @@ void Display(winid_t w, const char *fmt, ...)
     free(unistring);
 }
 
-void UpdateSettings(void) {
+void UpdateSettings(void)
+{
 #ifdef SPATTERLIGHT
-	if (gli_sa_delays)
-		Options &= ~NO_DELAYS;
-	else
-		Options |= NO_DELAYS;
+    if (gli_sa_delays)
+        Options &= ~NO_DELAYS;
+    else
+        Options |= NO_DELAYS;
 
-	switch(gli_sa_inventory) {
-		case 0:
-			Options &= ~(FORCE_INVENTORY | FORCE_INVENTORY_OFF);
-			break;
-		case 1:
-			Options = (Options | FORCE_INVENTORY) & ~FORCE_INVENTORY_OFF;
-			break;
-		case 2:
-			Options = (Options | FORCE_INVENTORY_OFF) & ~FORCE_INVENTORY;
-			break;
-	}
+    switch (gli_sa_inventory) {
+    case 0:
+        Options &= ~(FORCE_INVENTORY | FORCE_INVENTORY_OFF);
+        break;
+    case 1:
+        Options = (Options | FORCE_INVENTORY) & ~FORCE_INVENTORY_OFF;
+        break;
+    case 2:
+        Options = (Options | FORCE_INVENTORY_OFF) & ~FORCE_INVENTORY;
+        break;
+    }
 
-	switch(gli_sa_palette) {
-		case 0:
-			Options &= ~(FORCE_PALETTE_ZX | FORCE_PALETTE_C64);
-			break;
-		case 1:
-			Options = (Options | FORCE_PALETTE_ZX) & ~FORCE_PALETTE_C64;
-			break;
-		case 2:
-			Options = (Options | FORCE_PALETTE_C64) & ~FORCE_PALETTE_ZX;
-			break;
-	}
+    switch (gli_sa_palette) {
+    case 0:
+        Options &= ~(FORCE_PALETTE_ZX | FORCE_PALETTE_C64);
+        break;
+    case 1:
+        Options = (Options | FORCE_PALETTE_ZX) & ~FORCE_PALETTE_C64;
+        break;
+    case 2:
+        Options = (Options | FORCE_PALETTE_C64) & ~FORCE_PALETTE_ZX;
+        break;
+    }
 #endif
 
     if (DrawingVector())
-        glk_request_timer_events(20);        
+        glk_request_timer_events(20);
 
-	palette_type previous_pal = palchosen;
-	if (Options & FORCE_PALETTE_ZX)
-		palchosen = ZXOPT;
+    palette_type previous_pal = palchosen;
+    if (Options & FORCE_PALETTE_ZX)
+        palchosen = ZXOPT;
     else if (Options & FORCE_PALETTE_C64) {
         if (Game->picture_format_version == 99)
             palchosen = C64A;
         else
             palchosen = C64B;
     } else
-		palchosen = Game->palette;
+        palchosen = Game->palette;
     if (palchosen != previous_pal) {
-		DefinePalette();
+        DefinePalette();
         if (VectorState != NO_VECTOR_IMAGE)
             DrawSomeVectorPixels(1);
     }
@@ -266,7 +267,7 @@ static void FlushRoomDescription(char *buf)
         if (!(bottomheight < 3 && TopHeight < rows)) {
             glk_window_get_size(Top, &TopWidth, &TopHeight);
             glk_window_set_arrangement(o2, winmethod_Above | winmethod_Fixed, rows,
-                                       Top);
+                Top);
         } else {
             print_delimiter = 0;
         }
@@ -296,7 +297,7 @@ static void FlushRoomDescription(char *buf)
         if (line < rows - 1) {
             glk_window_get_size(Top, &TopWidth, &TopHeight);
             glk_window_set_arrangement(o2, winmethod_Above | winmethod_Fixed,
-                                       MIN(rows - 1, TopHeight - 1), Top);
+                MIN(rows - 1, TopHeight - 1), Top);
         }
 
         free(text_with_breaks);
@@ -319,7 +320,8 @@ static void FlushRoomDescription(char *buf)
     }
 }
 
-static void UpdateUSInventory(void) {
+static void UpdateUSInventory(void)
+{
     char *buf = MemAlloc(1000);
     buf = memset(buf, 0, 1000);
     room_description_stream = glk_stream_open_memory(buf, 1000, filemode_Write, 0);
@@ -330,15 +332,15 @@ static void UpdateUSInventory(void) {
 
 void Updates(event_t ev)
 {
-	if (ev.type == evtype_Arrange) {
-		UpdateSettings();
+    if (ev.type == evtype_Arrange) {
+        UpdateSettings();
 
         VectorState = NO_VECTOR_IMAGE;
 
         CloseGraphicsWindow();
-		OpenGraphicsWindow();
+        OpenGraphicsWindow();
 
-		if (split_screen) {
+        if (split_screen) {
             if (showing_inventory == 1) {
                 UpdateUSInventory();
             } else {
@@ -352,8 +354,8 @@ void Updates(event_t ev)
                         DrawImage(last_image_index);
                 }
             }
-		}
-	} else if (ev.type == evtype_Timer) {
+        }
+    } else if (ev.type == evtype_Timer) {
         switch (Game->type) {
         case SHERWOOD_VARIANT:
             UpdateRobinOfSherwoodAnimations();
@@ -460,8 +462,8 @@ glui32 OptimalPictureSize(glui32 *width, glui32 *height)
 void OpenGraphicsWindow(void)
 {
 #ifdef SPATTERLIGHT
-	if (!gli_enable_graphics)
-		return;
+    if (!gli_enable_graphics)
+        return;
 #endif
     glui32 graphwidth, graphheight, optimal_width, optimal_height;
 
@@ -482,16 +484,15 @@ void OpenGraphicsWindow(void)
             winid_t parent = glk_window_get_parent(Graphics);
             if (parent)
                 glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                           optimal_height, NULL);
+                    optimal_height, NULL);
         }
 
-	/* Set the graphics window background to match
+        /* Set the graphics window background to match
      * the main window background, best as we can,
      * and clear the window.
      */
         glui32 background_color;
-        if (Bottom && glk_style_measure(Bottom, style_Normal, stylehint_BackColor,
-                &background_color)) {
+        if (Bottom && glk_style_measure(Bottom, style_Normal, stylehint_BackColor, &background_color)) {
             glk_window_set_background_color(Graphics, background_color);
             glk_window_clear(Graphics);
         }
@@ -509,7 +510,7 @@ void OpenGraphicsWindow(void)
         winid_t parent = glk_window_get_parent(Graphics);
         if (parent)
             glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                       optimal_height, NULL);
+                optimal_height, NULL);
     }
     right_margin = optimal_width + x_offset;
 }
@@ -525,7 +526,8 @@ void CloseGraphicsWindow(void)
     }
 }
 
-static void CleanupAndExit(void) {
+static void CleanupAndExit(void)
+{
     if (Transcript)
         glk_stream_close(Transcript, NULL);
     if (DrawingVector()) {
@@ -638,19 +640,19 @@ static char *ReadString(FILE *f)
         if (c == '`')
             c = '"'; /* pdd */
 
-		/* Ensure a valid Glk newline is sent. */
-		if (c == '\n')
-			tmp[ct++] = 10;
-		/* Special case: assume CR is part of CRLF in a
+        /* Ensure a valid Glk newline is sent. */
+        if (c == '\n')
+            tmp[ct++] = 10;
+        /* Special case: assume CR is part of CRLF in a
 		 * DOS-formatted file, and ignore it.
 		 */
-		else if (c == 13)
-			;
-		/* Pass only ASCII to Glk; the other reasonable option
+        else if (c == 13)
+            ;
+        /* Pass only ASCII to Glk; the other reasonable option
 		 * would be to pass Latin-1, but it's probably safe to
 		 * assume that Scott Adams games are ASCII only.
 		 */
-		else if ((c >= 32 && c <= 126))
+        else if ((c >= 32 && c <= 126))
             tmp[ct++] = c;
         else
             tmp[ct++] = '?';
@@ -901,7 +903,7 @@ GameIDType LoadDatabase(FILE *f, int loud)
         debug_print("No extra value in file. This is not Hulk.\n");
     }
 
-	fclose(f);
+    fclose(f);
     if (ct == 703 && LoadDOSImages()) {
         CurrentSys = SYS_MSDOS;
         return HULK_US;
@@ -926,8 +928,8 @@ void DrawBlack(void)
 void DrawImage(int image)
 {
 #ifdef SPATTERLIGHT
-	if (!gli_enable_graphics)
-		return;
+    if (!gli_enable_graphics)
+        return;
 #endif
     OpenGraphicsWindow();
     if (Graphics == NULL) {
@@ -943,13 +945,12 @@ void DrawImage(int image)
 void DrawRoomImage(void)
 {
     if (CurrentGame == ADVENTURELAND || CurrentGame == ADVENTURELAND_C64) {
-		AdventurelandDarkness();
+        AdventurelandDarkness();
     }
 
     int dark = ((BitFlags & (1 << DARKBIT)) && Items[LIGHT_SOURCE].Location != CARRIED && Items[LIGHT_SOURCE].Location != MyLoc);
 
-    if (dark && Graphics != NULL &&
-        (Rooms[MyLoc].Image != 255 || Game->type == US_VARIANT)) {
+    if (dark && Graphics != NULL && (Rooms[MyLoc].Image != 255 || Game->type == US_VARIANT)) {
         vector_image_shown = -1;
         VectorState = NO_VECTOR_IMAGE;
         glk_request_timer_events(0);
@@ -969,20 +970,20 @@ void DrawRoomImage(void)
     }
 
     switch (CurrentGame) {
-        case SEAS_OF_BLOOD:
-        case SEAS_OF_BLOOD_C64:
-            SeasOfBloodRoomImage();
-            return;
-        case ROBIN_OF_SHERWOOD:
-        case ROBIN_OF_SHERWOOD_C64:
-            RobinOfSherwoodLook();
-            return;
-        case HULK:
-        case HULK_C64:
-            HulkLook();
-            return;
-        default:
-            break;
+    case SEAS_OF_BLOOD:
+    case SEAS_OF_BLOOD_C64:
+        SeasOfBloodRoomImage();
+        return;
+    case ROBIN_OF_SHERWOOD:
+    case ROBIN_OF_SHERWOOD_C64:
+        RobinOfSherwoodLook();
+        return;
+    case HULK:
+    case HULK_C64:
+        HulkLook();
+        return;
+    default:
+        break;
     }
 
     if (Rooms[MyLoc].Image == 255) {
@@ -1083,16 +1084,16 @@ static void ListExits(void)
 
 static int ItemEndsWithPeriod(int item)
 {
-	if (item < 0 || item > GameHeader.NumItems)
-		return 0;
-	const char *desc = Items[item].Text;
-	if (desc != NULL && desc[0] != 0) {
-		const char lastchar = desc[strlen(desc) - 1];
-		if (lastchar == '.' || lastchar == '!') {
-			return 1;
-		}
-	}
-	return 0;
+    if (item < 0 || item > GameHeader.NumItems)
+        return 0;
+    const char *desc = Items[item].Text;
+    if (desc != NULL && desc[0] != 0) {
+        const char lastchar = desc[strlen(desc) - 1];
+        if (lastchar == '.' || lastchar == '!') {
+            return 1;
+        }
+    }
+    return 0;
 }
 
 void Look(void)
@@ -1119,7 +1120,7 @@ void Look(void)
     if ((BitFlags & (1 << DARKBIT)) && Items[LIGHT_SOURCE].Location != CARRIED && Items[LIGHT_SOURCE].Location != MyLoc) {
         WriteToRoomDescriptionStream("%s", sys[TOO_DARK_TO_SEE]);
         FlushRoomDescription(buf);
-		return;
+        return;
     }
 
     r = &Rooms[MyLoc];
@@ -1296,7 +1297,7 @@ static void RestartGame(void)
     StopTime = 0;
     glk_window_clear(Bottom);
     OpenTopWindow();
-	should_restart = 0;
+    should_restart = 0;
 }
 
 static void TranscriptOn(void)
@@ -1479,7 +1480,8 @@ void HitEnter(void)
     return;
 }
 
-static void WriteToLowerWindow(const char *fmt, ...) {
+static void WriteToLowerWindow(const char *fmt, ...)
+{
     va_list ap;
     char msg[2048];
 
@@ -1518,7 +1520,7 @@ void ListInventory(int upper)
             if (lastitem > -1 && (Options & (TRS80_STYLE | SPECTRUM_STYLE)) == 0) {
                 print_function("%s", sys[ITEM_DELIMITER]);
             }
-			lastitem = i;
+            lastitem = i;
             print_function("%s", Items[i].Text);
             if (Options & (TRS80_STYLE | SPECTRUM_STYLE)) {
                 print_function("%s", sys[ITEM_DELIMITER]);
@@ -1528,11 +1530,11 @@ void ListInventory(int upper)
     }
     if (lastitem == -1)
         print_function("%s", sys[NOTHING]);
-	else if (Options & TI994A_STYLE) {
-		if (!ItemEndsWithPeriod(lastitem))
+    else if (Options & TI994A_STYLE) {
+        if (!ItemEndsWithPeriod(lastitem))
             print_function(".");
         print_function(" ");
-	}
+    }
     if (upper) {
         WriteToRoomDescriptionStream("\n");
     } else if (Transcript) {
@@ -1545,7 +1547,7 @@ static void LookWithPause(void)
     char fc = Rooms[MyLoc].Text[0];
     if (Rooms[MyLoc].Text == NULL || MyLoc == 0 || fc == 0 || fc == '.' || fc == ' ')
         return;
-	should_look_in_transcript = 1;
+    should_look_in_transcript = 1;
     pause_next_room_description = 1;
     Look();
 }
@@ -1578,9 +1580,9 @@ int PrintScore(void)
     if (n == GameHeader.Treasures) {
         Output(sys[YOUVE_SOLVED_IT]);
         DoneIt();
-		return 1;
+        return 1;
     }
-	return 0;
+    return 0;
 }
 
 void PrintNoun(void)
@@ -1592,91 +1594,91 @@ void PrintNoun(void)
 
 void MoveItemAToLocOfItemB(int itemA, int itemB)
 {
-	Items[itemA].Location = Items[itemB].Location;
-	if (Items[itemB].Location == MyLoc)
-		should_look_in_transcript = 1;
+    Items[itemA].Location = Items[itemB].Location;
+    if (Items[itemB].Location == MyLoc)
+        should_look_in_transcript = 1;
 }
 
 void GoToStoredLoc(void)
 {
 #ifdef DEBUG_ACTIONS
-	debug_print("switch location to stored location (%d) (%s).\n",
-			SavedRoom, Rooms[SavedRoom].Text);
+    debug_print("switch location to stored location (%d) (%s).\n",
+        SavedRoom, Rooms[SavedRoom].Text);
 #endif
-	int t = MyLoc;
-	MyLoc = SavedRoom;
-	SavedRoom = t;
-	should_look_in_transcript = 1;
+    int t = MyLoc;
+    MyLoc = SavedRoom;
+    SavedRoom = t;
+    should_look_in_transcript = 1;
 }
 
 void SwapLocAndRoomflag(int index)
 {
 #ifdef DEBUG_ACTIONS
-	debug_print("swap location<->roomflag[%d]\n", index);
+    debug_print("swap location<->roomflag[%d]\n", index);
 #endif
-	int temp = MyLoc;
-	MyLoc = RoomSaved[index];
-	RoomSaved[index] = temp;
-	should_look_in_transcript = 1;
-	Look();
+    int temp = MyLoc;
+    MyLoc = RoomSaved[index];
+    RoomSaved[index] = temp;
+    should_look_in_transcript = 1;
+    Look();
 }
 
 void SwapItemLocations(int itemA, int itemB)
 {
-	int temp = Items[itemA].Location;
-	Items[itemA].Location = Items[itemB].Location;
-	Items[itemB].Location = temp;
-	if (Items[itemA].Location == MyLoc || Items[itemB].Location == MyLoc)
-		should_look_in_transcript = 1;
+    int temp = Items[itemA].Location;
+    Items[itemA].Location = Items[itemB].Location;
+    Items[itemB].Location = temp;
+    if (Items[itemA].Location == MyLoc || Items[itemB].Location == MyLoc)
+        should_look_in_transcript = 1;
 }
 
 void PutItemAInRoomB(int itemA, int roomB)
 {
 #ifdef DEBUG_ACTIONS
-	debug_print("Item %d (%s) is put in room %d (%s). MyLoc: %d (%s)\n",
-			itemA, Items[itemA].Text, roomB, Rooms[roomB].Text, MyLoc,
-			Rooms[MyLoc].Text);
+    debug_print("Item %d (%s) is put in room %d (%s). MyLoc: %d (%s)\n",
+        itemA, Items[itemA].Text, roomB, Rooms[roomB].Text, MyLoc,
+        Rooms[MyLoc].Text);
 #endif
     if (Items[itemA].Location == MyLoc)
         LookWithPause();
-	Items[itemA].Location = roomB;
+    Items[itemA].Location = roomB;
 }
 
 void SwapCounters(int index)
 {
 #ifdef DEBUG_ACTIONS
-	debug_print(
-			"Select a counter. Current counter is swapped with backup "
-			"counter %d\n",
-			index);
+    debug_print(
+        "Select a counter. Current counter is swapped with backup "
+        "counter %d\n",
+        index);
 #endif
-	if (index > 15) {
-		debug_print("ERROR! parameter out of range. Max 15, got %d\n", index);
-		index = 15;
-	}
-	int temp = CurrentCounter;
+    if (index > 15) {
+        debug_print("ERROR! parameter out of range. Max 15, got %d\n", index);
+        index = 15;
+    }
+    int temp = CurrentCounter;
 
-	CurrentCounter = Counters[index];
-	Counters[index] = temp;
+    CurrentCounter = Counters[index];
+    Counters[index] = temp;
 #ifdef DEBUG_ACTIONS
-	debug_print("Value of new selected counter is %d\n",
-			CurrentCounter);
+    debug_print("Value of new selected counter is %d\n",
+        CurrentCounter);
 #endif
 }
 
 void PrintMessage(int index)
 {
 #ifdef DEBUG_ACTIONS
-	debug_print("Print message %d: \"%s\"\n", index,
-			Messages[index]);
+    debug_print("Print message %d: \"%s\"\n", index,
+        Messages[index]);
 #endif
-	const char *message = Messages[index];
-	if (message != NULL && message[0] != 0) {
-		Output(message);
-		const char lastchar = message[strlen(message) - 1];
-		if (lastchar != 13 && lastchar != 10)
-			Output(sys[MESSAGE_DELIMITER]);
-	}
+    const char *message = Messages[index];
+    if (message != NULL && message[0] != 0) {
+        Output(message);
+        const char lastchar = message[strlen(message) - 1];
+        if (lastchar != 13 && lastchar != 10)
+            Output(sys[MESSAGE_DELIMITER]);
+    }
 }
 
 void PlayerIsDead(void)
@@ -1696,7 +1698,7 @@ static ActionResultType PerformLine(int ct)
 #endif
     int continuation = 0, dead = 0;
     int param[5], pptr = 0;
-	int p;
+    int p;
     int act[4];
     int cc = 0;
     while (cc < 5) {
@@ -1793,52 +1795,52 @@ static ActionResultType PerformLine(int ct)
             debug_print("Is %s neither carried nor in room?\n", Items[dv].Text);
 #endif
             if (Items[dv].Location == CARRIED || Items[dv].Location == MyLoc)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 13:
-                if (dv > GameHeader.NumItems + 1)
-                    Fatal("Broken database!");
+            if (dv > GameHeader.NumItems + 1)
+                Fatal("Broken database!");
 #ifdef DEBUG_ACTIONS
             debug_print("Is %s (%d) in play?\n", Items[dv].Text, dv);
 #endif
             if (Items[dv].Location == 0)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 14:
 #ifdef DEBUG_ACTIONS
             debug_print("Is %s NOT in play?\n", Items[dv].Text);
 #endif
             if (Items[dv].Location)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 15:
 #ifdef DEBUG_ACTIONS
             debug_print("Is CurrentCounter <= %d?\n", dv);
 #endif
             if (CurrentCounter > dv)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 16:
 #ifdef DEBUG_ACTIONS
             debug_print("Is CurrentCounter > %d?\n", dv);
 #endif
             if (CurrentCounter <= dv)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 17:
 #ifdef DEBUG_ACTIONS
             debug_print("Is %s still in initial room?\n", Items[dv].Text);
 #endif
             if (Items[dv].Location != Items[dv].InitialLoc)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 18:
 #ifdef DEBUG_ACTIONS
             debug_print("Has %s been moved?\n", Items[dv].Text);
 #endif
             if (Items[dv].Location == Items[dv].InitialLoc)
-               return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         case 19: /* Only seen in Brian Howarth games so far */
 #ifdef DEBUG_ACTIONS
             debug_print("Is current counter == %d?\n", dv);
@@ -1846,8 +1848,8 @@ static ActionResultType PerformLine(int ct)
                 debug_print("Nope, current counter is %d\n", CurrentCounter);
 #endif
             if (CurrentCounter != dv)
-				return ACT_FAILURE;
-				break;
+                return ACT_FAILURE;
+            break;
         }
 #ifdef DEBUG_ACTIONS
         debug_print("YES\n");
@@ -1872,9 +1874,9 @@ static ActionResultType PerformLine(int ct)
         debug_print("Performing action %d: ", act[cc]);
 #endif
         if (act[cc] >= 1 && act[cc] < 52) {
-			PrintMessage(act[cc]);
+            PrintMessage(act[cc]);
         } else if (act[cc] > 101) {
-			PrintMessage(act[cc] - 50);
+            PrintMessage(act[cc] - 50);
         } else
             switch (act[cc]) {
             case 0: /* NOP */
@@ -1892,7 +1894,7 @@ static ActionResultType PerformLine(int ct)
                     Items[param[pptr]].Text);
 #endif
                 Items[param[pptr++]].Location = MyLoc;
-				should_look_in_transcript = 1;
+                should_look_in_transcript = 1;
                 break;
             case 54:
 #ifdef DEBUG_ACTIONS
@@ -1900,7 +1902,7 @@ static ActionResultType PerformLine(int ct)
                     Rooms[param[pptr]].Text);
 #endif
                 MyLoc = param[pptr++];
-				should_look_in_transcript = 1;
+                should_look_in_transcript = 1;
                 Look();
                 break;
             case 55:
@@ -1941,30 +1943,30 @@ static ActionResultType PerformLine(int ct)
                 break;
             case 62:
                 p = param[pptr++];
-				PutItemAInRoomB(p, param[pptr++]);
+                PutItemAInRoomB(p, param[pptr++]);
                 break;
             case 63:
 #ifdef DEBUG_ACTIONS
                 debug_print("Game over.\n");
 #endif
                 DoneIt();
-				dead = 1;
+                dead = 1;
                 break;
             case 64:
                 break;
             case 65:
                 dead = PrintScore();
-				StopTime = 2;
+                StopTime = 2;
                 break;
             case 66:
-				if (Game->type == SEAS_OF_BLOOD_VARIANT)
-					AdventureSheet();
-				else
-					ListInventory(0);
-                    if (Game->type == US_VARIANT && has_graphics()) {
-                        UpdateUSInventory();
-                    }
-				StopTime = 2;
+                if (Game->type == SEAS_OF_BLOOD_VARIANT)
+                    AdventureSheet();
+                else
+                    ListInventory(0);
+                if (Game->type == US_VARIANT && has_graphics()) {
+                    UpdateUSInventory();
+                }
+                StopTime = 2;
                 break;
             case 67:
                 BitFlags |= (1 << 0);
@@ -1982,11 +1984,11 @@ static ActionResultType PerformLine(int ct)
                 break;
             case 71:
                 SaveGame();
-				StopTime = 2;
+                StopTime = 2;
                 break;
             case 72:
                 p = param[pptr++];
-				SwapItemLocations(p, param[pptr++]);
+                SwapItemLocations(p, param[pptr++]);
                 break;
             case 73:
 #ifdef DEBUG_ACTIONS
@@ -1998,8 +2000,8 @@ static ActionResultType PerformLine(int ct)
                 Items[param[pptr++]].Location = CARRIED;
                 break;
             case 75:
-				p = param[pptr++];
-				MoveItemAToLocOfItemB(p, param[pptr++]);
+                p = param[pptr++];
+                MoveItemAToLocOfItemB(p, param[pptr++]);
                 break;
             case 76: /* Looking at adventure .. */
 #ifdef DEBUG_ACTIONS
@@ -2007,7 +2009,7 @@ static ActionResultType PerformLine(int ct)
 #endif
                 if (split_screen)
                     Look();
-				should_look_in_transcript = 1;
+                should_look_in_transcript = 1;
                 break;
             case 77:
                 if (CurrentCounter >= 1)
@@ -2029,10 +2031,10 @@ static ActionResultType PerformLine(int ct)
                 CurrentCounter = param[pptr++];
                 break;
             case 80:
-				GoToStoredLoc();
+                GoToStoredLoc();
                 break;
             case 81:
-				SwapCounters(param[pptr++]);
+                SwapCounters(param[pptr++]);
                 break;
             case 82:
                 CurrentCounter += param[pptr++];
@@ -2056,7 +2058,7 @@ static ActionResultType PerformLine(int ct)
                     Output("\n");
                 break;
             case 87:
-				SwapLocAndRoomflag(param[pptr++]);
+                SwapLocAndRoomflag(param[pptr++]);
                 break;
             case 88:
 #ifdef DEBUG_ACTIONS
@@ -2068,7 +2070,7 @@ static ActionResultType PerformLine(int ct)
 #ifdef DEBUG_ACTIONS
                 debug_print("Action 89, parameter %d\n", param[pptr]);
 #endif
-				p = param[pptr++];
+                p = param[pptr++];
                 switch (CurrentGame) {
                 case SPIDERMAN:
                 case SPIDERMAN_C64:
@@ -2076,40 +2078,40 @@ static ActionResultType PerformLine(int ct)
                     break;
                 case SECRET_MISSION:
                 case SECRET_MISSION_C64:
-					SecretAction(p);
+                    SecretAction(p);
                     break;
                 case ADVENTURELAND:
                 case ADVENTURELAND_C64:
-					AdventurelandAction(p);
+                    AdventurelandAction(p);
                     break;
                 case SEAS_OF_BLOOD:
                 case SEAS_OF_BLOOD_C64:
-					BloodAction(p);
+                    BloodAction(p);
                     break;
                 case ROBIN_OF_SHERWOOD:
                 case ROBIN_OF_SHERWOOD_C64:
-					SherwoodAction(p);
+                    SherwoodAction(p);
                     break;
                 case GREMLINS:
                 case GREMLINS_SPANISH:
                 case GREMLINS_SPANISH_C64:
                 case GREMLINS_GERMAN:
                 case GREMLINS_GERMAN_C64:
-					GremlinsAction();
+                    GremlinsAction();
                     break;
                 default:
                     break;
                 }
                 break;
 
-			case 90:
+            case 90:
 #ifdef DEBUG_ACTIONS
                 debug_print("Draw Hulk image, parameter %d\n", param[pptr]);
 #endif
                 if (CurrentGame != HULK && CurrentGame != HULK_C64 && CurrentGame != HULK_US) {
                     pptr++;
                 } else if (!(BitFlags & (1 << DARKBIT)))
-					DrawHulkImage(param[pptr++]);
+                    DrawHulkImage(param[pptr++]);
                 break;
             default:
                 debug_print("Unknown action %d [Param begins %d %d]\n", act[cc],
@@ -2119,13 +2121,13 @@ static ActionResultType PerformLine(int ct)
         cc++;
     }
 
-	if (dead) {
-		return ACT_GAMEOVER;
-	} else if (continuation) {
+    if (dead) {
+        return ACT_GAMEOVER;
+    } else if (continuation) {
         return ACT_CONTINUE;
-	} else {
+    } else {
         return ACT_SUCCESS;
-	}
+    }
 }
 
 static void PrintTakenOrDropped(int index)
@@ -2136,17 +2138,16 @@ static void PrintTakenOrDropped(int index)
     if (last == 10 || last == 13)
         return;
     Output(" ");
-	if ((!(CurrentCommand->allflag & LASTALL))
-		|| split_screen == 0) {
-		Output("\n");
+    if ((!(CurrentCommand->allflag & LASTALL))
+        || split_screen == 0) {
+        Output("\n");
     }
 }
 
 static ExplicitResultType PerformActions(int vb, int no)
 {
     int dark = BitFlags & (1 << DARKBIT);
-    if (Items[LIGHT_SOURCE].Location == MyLoc ||
-        Items[LIGHT_SOURCE].Location == CARRIED)
+    if (Items[LIGHT_SOURCE].Location == MyLoc || Items[LIGHT_SOURCE].Location == CARRIED)
         dark = 0;
     int ct = 0;
     ExplicitResultType flag;
@@ -2171,7 +2172,7 @@ static ExplicitResultType PerformActions(int vb, int no)
             if (Options & (SPECTRUM_STYLE | TI994A_STYLE))
                 Output(sys[OK]);
             MyLoc = nl;
-			should_look_in_transcript = 1;
+            should_look_in_transcript = 1;
             if (CurrentCommand && CurrentCommand->next) {
                 LookWithPause();
             }
@@ -2231,8 +2232,8 @@ static ExplicitResultType PerformActions(int vb, int no)
                         flag = ER_SUCCESS;
                         if (flag2 == ACT_CONTINUE)
                             doagain = 1;
-						else if (flag2 == ACT_GAMEOVER)
-							return ER_SUCCESS;
+                        else if (flag2 == ACT_GAMEOVER)
+                            return ER_SUCCESS;
                         if (vb != 0 && doagain == 0)
                             return ER_SUCCESS;
                     }
@@ -2241,6 +2242,7 @@ static ExplicitResultType PerformActions(int vb, int no)
 
             ct++;
 
+            // clang-format off
       /* Previously this did not check ct against
        * GameHeader.NumActions and would read past the end of
        * Actions.  I don't know what should happen on the last
@@ -2248,12 +2250,14 @@ static ExplicitResultType PerformActions(int vb, int no)
        * past the end.
        * --Chris
        */
+            // clang-format on
+
             if (ct <= GameHeader.NumActions && Actions[ct].Vocab != 0)
                 doagain = 0;
         }
     } else {
         if (vb == 0) {
-			RunImplicitTI99Actions();
+            RunImplicitTI99Actions();
             return ER_NO_RESULT;
         } else {
             flag = RunExplicitTI99Actions(vb, no);
@@ -2458,7 +2462,7 @@ void glk_main(void)
     glk_stylehint_set(wintype_TextBuffer, style_User1, stylehint_Indentation, 20);
     glk_stylehint_set(wintype_TextBuffer, style_User1, stylehint_ParaIndentation,
         20);
-	glk_stylehint_set(wintype_TextBuffer, style_Preformatted, stylehint_Justification, stylehint_just_Centered);
+    glk_stylehint_set(wintype_TextBuffer, style_Preformatted, stylehint_Justification, stylehint_just_Centered);
 
     Bottom = glk_window_open(0, 0, 0, wintype_TextBuffer, GLK_BUFFER_ROCK);
     if (Bottom == NULL)
@@ -2485,7 +2489,7 @@ void glk_main(void)
     GameIDType game_type = DetectGame(game_file);
 
     if (game_type == UNKNOWN_GAME)
-		Fatal("Unsupported game!");
+        Fatal("Unsupported game!");
 
     if (game_type != SCOTTFREE && game_type != TI994A) {
         Options |= SPECTRUM_STYLE;
@@ -2515,7 +2519,7 @@ void glk_main(void)
         Display(Bottom, "In this adventure, you may abbreviate any word \
 by typing its first %d letters, and directions by typing \
 one letter.\n\nDo you want to restore previously saved game?\n",
-                GameHeader.WordLength);
+            GameHeader.WordLength);
         if (YesOrNo())
             LoadGame();
         ClearScreen();
@@ -2564,43 +2568,43 @@ Distributed under the GNU software license\n\n");
     OpenTopWindow();
 
 #ifdef SPATTERLIGHT
-	UpdateSettings();
+    UpdateSettings();
     if (gli_determinism)
         srand(1234);
     else
 #endif
         srand((unsigned int)time(NULL));
 
-	InitialState = SaveCurrentState();
+    InitialState = SaveCurrentState();
 
     while (1) {
         glk_tick();
 
-		if (should_restart)
-			RestartGame();
+        if (should_restart)
+            RestartGame();
 
         if (!StopTime)
             PerformActions(0, 0);
-		if (!(CurrentCommand && CurrentCommand->allflag && !(CurrentCommand->allflag & LASTALL))) {
-			print_look_to_transcript = should_look_in_transcript;
+        if (!(CurrentCommand && CurrentCommand->allflag && !(CurrentCommand->allflag & LASTALL))) {
+            print_look_to_transcript = should_look_in_transcript;
             Look();
-			print_look_to_transcript = should_look_in_transcript = 0;
-			if (!StopTime && !should_restart)
-				SaveUndo();
-		}
+            print_look_to_transcript = should_look_in_transcript = 0;
+            if (!StopTime && !should_restart)
+                SaveUndo();
+        }
 
-		if (should_restart)
-			continue;
+        if (should_restart)
+            continue;
 
-		if (GetInput(&vb, &no) == 1)
-			continue;
+        if (GetInput(&vb, &no) == 1)
+            continue;
 
         switch (PerformActions(vb, no)) {
         case ER_RAN_ALL_LINES_NO_MATCH:
-                if (!RecheckForExtraCommand()) {
-                    Output(sys[I_DONT_UNDERSTAND]);
-                    FreeCommands();
-                }
+            if (!RecheckForExtraCommand()) {
+                Output(sys[I_DONT_UNDERSTAND]);
+                FreeCommands();
+            }
             break;
         case ER_RAN_ALL_LINES:
             Output(sys[YOU_CANT_DO_THAT_YET]);
@@ -2623,7 +2627,7 @@ Distributed under the GNU software license\n\n");
             } else if (GameHeader.LightTime < 25) {
                 if (Items[LIGHT_SOURCE].Location == CARRIED || Items[LIGHT_SOURCE].Location == MyLoc) {
                     if ((Options & SCOTTLIGHT) || (Game->subtype & MYSTERIOUS)) {
-                        Display(Bottom, "%s %d %s\n",sys[LIGHT_RUNS_OUT_IN], GameHeader.LightTime, sys[TURNS]);
+                        Display(Bottom, "%s %d %s\n", sys[LIGHT_RUNS_OUT_IN], GameHeader.LightTime, sys[TURNS]);
                     } else {
                         if (GameHeader.LightTime % 5 == 0)
                             Output(sys[LIGHT_GROWING_DIM]);
@@ -2632,6 +2636,6 @@ Distributed under the GNU software license\n\n");
             }
         }
         if (StopTime)
-			StopTime--;
+            StopTime--;
     }
 }

--- a/terps/scott/scott.h
+++ b/terps/scott/scott.h
@@ -23,15 +23,18 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "scottdefines.h"
 #include "debugprint.h"
+#include "scottdefines.h"
 
+// clang-format off
 
 #define LIGHT_SOURCE 9         /* Always 9 how odd */
 #define CARRIED      255       /* Carried */
 #define DESTROYED    0         /* Destroyed */
 #define DARKBIT      15
 #define LIGHTOUTBIT  16        /* Light gone out */
+
+// clang-format on
 
 #define GLK_BUFFER_ROCK 1
 #define GLK_STATUS_ROCK 1010
@@ -53,9 +56,9 @@ typedef struct {
 } Header;
 
 typedef struct {
-	unsigned short Vocab;
-	unsigned short Condition[5];
-	unsigned short Subcommand[2];
+    unsigned short Vocab;
+    unsigned short Condition[5];
+    unsigned short Subcommand[2];
 } Action;
 
 typedef struct {
@@ -80,19 +83,23 @@ typedef struct {
     short Unknown;
 } Tail;
 
-#define YOUARE		1	/* You are not I am */
-#define SCOTTLIGHT	2	/* Authentic Scott Adams light messages */
-#define DEBUGGING	4	/* Info from database load */
-#define TRS80_STYLE	8	/* Display in style used on TRS-80 */
-#define PREHISTORIC_LAMP 16	/* Destroy the lamp (very old databases) */
-#define SPECTRUM_STYLE 32    /* Display in style used on ZX Spectrum */
-#define TI994A_STYLE 64     /* Display in style used on TI-99/4A */
-#define NO_DELAYS 128     /* Skip all pauses */
-#define FORCE_PALETTE_ZX 256     /* Force ZX Spectrum image palette */
-#define FORCE_PALETTE_C64 512     /* Force CBM 64 image palette */
-#define FORCE_INVENTORY 1024     /* Inventory in upper window always on */
+// clang-format off
+
+#define YOUARE                 1     /* You are not I am */
+#define SCOTTLIGHT             2     /* Authentic Scott Adams light messages */
+#define DEBUGGING              4     /* Info from database load */
+#define TRS80_STYLE            8     /* Display in style used on TRS-80 */
+#define PREHISTORIC_LAMP      16     /* Destroy the lamp (very old databases) */
+#define SPECTRUM_STYLE        32     /* Display in style used on ZX Spectrum */
+#define TI994A_STYLE          64     /* Display in style used on TI-99/4A */
+#define NO_DELAYS            128     /* Skip all pauses */
+#define FORCE_PALETTE_ZX     256     /* Force ZX Spectrum image palette */
+#define FORCE_PALETTE_C64    512     /* Force CBM 64 image palette */
+#define FORCE_INVENTORY     1024     /* Inventory in upper window always on */
 #define FORCE_INVENTORY_OFF 2048     /* Inventory in upper window always off */
-#define PC_STYLE 4096    /* Display in style used on IBM PC (MS-DOS) */
+#define PC_STYLE            4096     /* Display in style used on IBM PC (MS-DOS) */
+
+// clang-format on
 
 #define MAX_GAMEFILE_SIZE 250000
 
@@ -108,9 +115,9 @@ void Output(const char *a);
 void OutputNumber(int a);
 void Display(winid_t w, const char *fmt, ...)
 #ifdef __GNUC__
-__attribute__((__format__(__printf__, 2, 3)))
+    __attribute__((__format__(__printf__, 2, 3)))
 #endif
-;
+    ;
 void HitEnter(void);
 void Look(void);
 void DrawRoomImage(void);

--- a/terps/scott/scottdefines.h
+++ b/terps/scott/scottdefines.h
@@ -128,7 +128,6 @@ typedef enum {
     SYS_TI994A
 } MachineType;
 
-
 typedef enum {
     IMG_ROOM,
     IMG_ROOM_OBJ,
@@ -243,7 +242,15 @@ typedef enum {
     C64 = 0x8
 } Subtype;
 
-typedef enum { NO_PALETTE, ZX, ZXOPT, C64A, C64B, C64C, VGA } palette_type;
+typedef enum {
+    NO_PALETTE,
+    ZX,
+    ZXOPT,
+    C64A,
+    C64B,
+    C64C,
+    VGA
+} palette_type;
 
 typedef enum {
     NO_HEADER,

--- a/terps/scott/scottgameinfo.c
+++ b/terps/scott/scottgameinfo.c
@@ -9,6 +9,8 @@
 
 #include "scottdefines.h"
 
+// clang-format off
+
 const struct GameInfo games[] = {
     {
         "Pirate Adventure",
@@ -2598,10 +2600,10 @@ const struct GameInfo games[] = {
         91,  // Number of messages
     },
 
-    {
-        NULL
-    }
+    { NULL }
 };
+
+// clang-format on
 
 /* This is supposed to be the original ScottFree system
  messages in second person, as far as possible */

--- a/terps/scott/ti994a/load_ti99_4a.c
+++ b/terps/scott/ti994a/load_ti99_4a.c
@@ -10,14 +10,15 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "scott.h"
 #include "load_ti99_4a.h"
+#include "scott.h"
 
 #include "detectgame.h"
 #include "scottgameinfo.h"
 
-
 #define PACKED __attribute__((__packed__))
+
+// clang-format off
 
 struct DATAHEADER {
     uint8_t    num_objects;                         /* number of objects */
@@ -46,6 +47,8 @@ struct DATAHEADER {
     uint16_t   p_explicit            PACKED;        /* pointer to explicit action table */
     uint16_t   p_implicit            PACKED;        /* pointer to implicit actions */
 };
+
+// clang-format on
 
 int max_messages;
 int max_item_descr;
@@ -344,23 +347,23 @@ static uint8_t *LoadTitleScreen(void)
             if (c & 0x80) /* if not 7-bit ascii */
                 c = '?';
             switch (c) {
-                case '\\':
-                    c = ' ';
-                    break;
-                case '(':
-                    parens = 1;
-                    break;
-                case ')':
-                    if (!parens)
-                        c = '@';
-                    parens = 0;
-                    break;
-                case '|':
-                    if (*p != ' ')
-                        c = 12;
-                    break;
-                default:
-                    break;
+            case '\\':
+                c = ' ';
+                break;
+            case '(':
+                parens = 1;
+                break;
+            case ')':
+                if (!parens)
+                    c = '@';
+                parens = 0;
+                break;
+            case '|':
+                if (*p != ' ')
+                    c = 12;
+                break;
+            default:
+                break;
             }
             buf[offset++] = c;
             if (offset >= 3072)

--- a/terps/scott/ti994a/ti99_4a_terp.c
+++ b/terps/scott/ti994a/ti99_4a_terp.c
@@ -281,7 +281,7 @@ static ActionResultType PerformTI99Line(const uint8_t *action_line)
 #ifdef DEBUG_ACTIONS
             debug_print(
                 "Item %d (%s) is removed from the game (put in room 0).\n",
-                    *ptr, Items[*ptr].Text);
+                *ptr, Items[*ptr].Text);
 #endif
             Items[*(ptr++)].Location = 0;
             break;
@@ -371,7 +371,7 @@ static ActionResultType PerformTI99Line(const uint8_t *action_line)
 #ifdef DEBUG_ACTIONS
             fprintf(stderr,
                 "Player now carries item %d (%s).\n",
-                    *ptr, Items[*ptr].Text);
+                *ptr, Items[*ptr].Text);
 #endif
             Items[*(ptr++)].Location = CARRIED;
             break;
@@ -417,7 +417,7 @@ static ActionResultType PerformTI99Line(const uint8_t *action_line)
 #ifdef DEBUG_ACTIONS
             fprintf(stderr,
                 "%d is added to currentCounter. Result: %d\n",
-                    *ptr, CurrentCounter + *ptr);
+                *ptr, CurrentCounter + *ptr);
 #endif
             CurrentCounter += *(ptr++);
             break;

--- a/terps/scott/titleimage.c
+++ b/terps/scott/titleimage.c
@@ -8,11 +8,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "glk.h"
-#include "scott.h"
-#include "sagagraphics.h"
 #include "apple2draw.h"
+#include "glk.h"
 #include "saga.h"
+#include "sagagraphics.h"
+#include "scott.h"
 
 #ifdef SPATTERLIGHT
 #include "glkimp.h"
@@ -22,7 +22,8 @@
 
 glui32 OptimalPictureSize(glui32 *width, glui32 *height);
 
-void ResizeTitleImage(void) {
+void ResizeTitleImage(void)
+{
     glui32 graphwidth, graphheight, optimal_width, optimal_height;
 #ifdef SPATTERLIGHT
     glk_window_set_background_color(Graphics, gbgcol);
@@ -35,8 +36,8 @@ void ResizeTitleImage(void) {
     y_offset = ((int)graphheight - (int)optimal_height) / 3;
 }
 
-
-void DrawTitleImage(void) {
+void DrawTitleImage(void)
+{
     int storedwidth = ImageWidth;
     int storedheight = ImageHeight;
 #ifdef SPATTERLIGHT
@@ -54,7 +55,7 @@ void DrawTitleImage(void) {
     Bottom = FindGlkWindowWithRock(GLK_BUFFER_ROCK);
     if (Bottom) {
         glk_style_measure(Bottom, style_Normal, stylehint_BackColor,
-                          &background_color);
+            &background_color);
         glk_window_close(Bottom, NULL);
     }
 
@@ -64,7 +65,7 @@ void DrawTitleImage(void) {
         glk_request_char_event(Graphics);
     } else {
         Bottom = glk_window_open(Graphics, winmethod_Below | winmethod_Fixed,
-                              2, wintype_TextBuffer, GLK_BUFFER_ROCK);
+            2, wintype_TextBuffer, GLK_BUFFER_ROCK);
         glk_request_char_event(Bottom);
     }
 
@@ -72,7 +73,7 @@ void DrawTitleImage(void) {
         glk_window_set_background_color(Graphics, background_color);
         glk_window_clear(Graphics);
     }
-    
+
     ResizeTitleImage();
 
     if (DrawUSRoom(99)) {
@@ -115,7 +116,8 @@ void DrawTitleImage(void) {
     CloseGraphicsWindow();
 }
 
-void PrintTitleScreenBuffer(void) {
+void PrintTitleScreenBuffer(void)
+{
     glk_stream_set_current(glk_window_get_stream(Bottom));
     glk_set_style(style_User1);
     glk_window_clear(Graphics);
@@ -126,14 +128,15 @@ void PrintTitleScreenBuffer(void) {
     glk_window_clear(Graphics);
 }
 
-void PrintTitleScreenGrid(void) {
+void PrintTitleScreenGrid(void)
+{
     int title_length = strlen(title_screen);
     int rows = 0;
     for (int i = 0; i < title_length; i++)
         if (title_screen[i] == '\n')
             rows++;
     winid_t titlewin = glk_window_open(Bottom, winmethod_Above | winmethod_Fixed, rows + 2,
-                                       wintype_TextGrid, 0);
+        wintype_TextGrid, 0);
     glui32 width, height;
     glk_window_get_size(titlewin, &width, &height);
     if (width < 40 || height < rows + 2) {

--- a/terps/taylor/animations.c
+++ b/terps/taylor/animations.c
@@ -18,8 +18,9 @@
 // second copy of the image buffer.
 
 #include "sagadraw.h"
-#include "animations.h"
 #include "utility.h"
+
+#include "animations.h"
 
 #define UNFOLDING_SPACE 50
 #define STARS_ANIMATION_RATE 15
@@ -115,7 +116,8 @@ static void AnimateForcefield(void)
     }
 }
 
-static void FillCell(int cell, glui32 ink) {
+static void FillCell(int cell, glui32 ink)
+{
     int startx = (cell % 32) * 8;
     int starty = (cell / 32) * 8;
     for (int pixrow = 0; pixrow < 8; pixrow++) {
@@ -213,9 +215,9 @@ static int UpdateKaylethAnimationFrames(void) // Draw animation frame
         if (*ptr == 0xff)
             counter++;
         ptr++;
-    } while(counter < MyLoc);
+    } while (counter < MyLoc);
 
-    while(1) {
+    while (1) {
         if (*ptr == 0xff) {
             return 0;
         }
@@ -264,7 +266,8 @@ static int UpdateKaylethAnimationFrames(void) // Draw animation frame
     }
 }
 
-void UpdateKaylethAnimations(void) {
+void UpdateKaylethAnimations(void)
+{
     // This is an attempt to make the animation jerky like the original.
     ClickShelfStage++;
     if (ClickShelfStage == 9)
@@ -330,7 +333,8 @@ void UpdateRebelAnimations(void)
     }
 }
 
-void StartAnimations(void) {
+void StartAnimations(void)
+{
     if (BaseGame == REBEL_PLANET) {
         if (MyLoc == 1 && ObjectLoc[UNFOLDING_SPACE] == 1) {
             int rate = STARS_ANIMATION_RATE;
@@ -372,30 +376,30 @@ void StartAnimations(void) {
             else
                 speed = 13;
         }
-        switch(MyLoc) {
-            case 1:
-                speed = 14;
-                break;
-            case 2: // Conveyor belt
-                speed = 10;
-                break;
-            case 3: // Click shelves
-                if (CurrentGame == KAYLETH_64)
-                    speed = 80;
-                else
-                    speed = 40;
-                break;
-            case 53: // Twin peril forest
-                speed = 350;
-                break;
-            case 56: // Citadel of Zenron
+        switch (MyLoc) {
+        case 1:
+            speed = 14;
+            break;
+        case 2: // Conveyor belt
+            speed = 10;
+            break;
+        case 3: // Click shelves
+            if (CurrentGame == KAYLETH_64)
+                speed = 80;
+            else
                 speed = 40;
-                break;
-            case 36: // Guard dome
-                speed = 12;
-                break;
-            default:
-                break;
+            break;
+        case 53: // Twin peril forest
+            speed = 350;
+            break;
+        case 56: // Citadel of Zenron
+            speed = 40;
+            break;
+        case 36: // Guard dome
+            speed = 12;
+            break;
+        default:
+            break;
         }
         if (AnimationRunning != speed) {
             glk_request_timer_events(speed);
@@ -403,4 +407,3 @@ void StartAnimations(void) {
         }
     }
 }
-

--- a/terps/taylor/decompressz80.c
+++ b/terps/taylor/decompressz80.c
@@ -37,9 +37,9 @@
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 
 /* Sizes of some of the arrays in the snap structure */
@@ -330,7 +330,7 @@ static libspectrum_error get_machine_type(libspectrum_snap *snap, uint8_t type, 
 static libspectrum_error get_machine_type_v2(libspectrum_snap *snap,
     uint8_t type);
 static libspectrum_error get_machine_type_v3(libspectrum_snap *snap,
-                                             uint8_t type);
+    uint8_t type);
 static libspectrum_error get_machine_type_extension(libspectrum_snap *snap,
     uint8_t type);
 
@@ -505,9 +505,10 @@ uint8_t *DecompressZ80(uint8_t *raw_data, size_t *length)
                 memcpy(uncompressed + 0x8000, snap->pages[snap->out_128_memoryport], 0x4000);
                 offset += 0x4000;
             }
-            for(int i = 0; i < SNAPSHOT_RAM_PAGES && offset < 0x2001f - 0x4000; i++ ) {
+            for (int i = 0; i < SNAPSHOT_RAM_PAGES && offset < 0x2001f - 0x4000; i++) {
                 /* Already written pages 5, 2 and whatever's paged in */
-                if( i == 5 || i == 2 || i == snap->out_128_memoryport ) continue;
+                if (i == 5 || i == 2 || i == snap->out_128_memoryport)
+                    continue;
                 memcpy(uncompressed + offset, snap->pages[i], 0x4000);
                 offset += 0x4000;
             }
@@ -1074,73 +1075,73 @@ typedef enum libspectrum_id_t {
 
     /* These types present in all versions of libspectrum */
 
-    LIBSPECTRUM_ID_UNKNOWN = 0,        /* Unidentified file */
-    LIBSPECTRUM_ID_RECORDING_RZX,        /* RZX input recording */
-    LIBSPECTRUM_ID_SNAPSHOT_SNA,        /* .sna snapshot */
-    LIBSPECTRUM_ID_SNAPSHOT_Z80,        /* .z80 snapshot */
-    LIBSPECTRUM_ID_TAPE_TAP,        /* Z80-style .tap tape image */
-    LIBSPECTRUM_ID_TAPE_TZX,        /* TZX tape image */
+    LIBSPECTRUM_ID_UNKNOWN = 0, /* Unidentified file */
+    LIBSPECTRUM_ID_RECORDING_RZX, /* RZX input recording */
+    LIBSPECTRUM_ID_SNAPSHOT_SNA, /* .sna snapshot */
+    LIBSPECTRUM_ID_SNAPSHOT_Z80, /* .z80 snapshot */
+    LIBSPECTRUM_ID_TAPE_TAP, /* Z80-style .tap tape image */
+    LIBSPECTRUM_ID_TAPE_TZX, /* TZX tape image */
 
     /* Below here, present only in 0.1.1 and later */
 
     /* The next entry is deprecated in favour of the more specific
      LIBSPECTRUM_ID_DISK_CPC and LIBSPECTRUM_ID_DISK_ECPC */
-    LIBSPECTRUM_ID_DISK_DSK,        /* .dsk +3 disk image */
+    LIBSPECTRUM_ID_DISK_DSK, /* .dsk +3 disk image */
 
-    LIBSPECTRUM_ID_DISK_SCL,        /* .scl TR-DOS disk image */
-    LIBSPECTRUM_ID_DISK_TRD,        /* .trd TR-DOS disk image */
-    LIBSPECTRUM_ID_CARTRIDGE_DCK,        /* .dck Timex cartridge image */
+    LIBSPECTRUM_ID_DISK_SCL, /* .scl TR-DOS disk image */
+    LIBSPECTRUM_ID_DISK_TRD, /* .trd TR-DOS disk image */
+    LIBSPECTRUM_ID_CARTRIDGE_DCK, /* .dck Timex cartridge image */
 
     /* Below here, present only in 0.2.0 and later */
 
-    LIBSPECTRUM_ID_TAPE_WARAJEVO,        /* Warajevo-style .tap tape image */
+    LIBSPECTRUM_ID_TAPE_WARAJEVO, /* Warajevo-style .tap tape image */
 
-    LIBSPECTRUM_ID_SNAPSHOT_PLUSD,    /* DISCiPLE/+D snapshot */
-    LIBSPECTRUM_ID_SNAPSHOT_SP,        /* .sp snapshot */
-    LIBSPECTRUM_ID_SNAPSHOT_SNP,        /* .snp snapshot */
-    LIBSPECTRUM_ID_SNAPSHOT_ZXS,        /* .zxs snapshot (zx32) */
-    LIBSPECTRUM_ID_SNAPSHOT_SZX,        /* .szx snapshot (Spectaculator) */
+    LIBSPECTRUM_ID_SNAPSHOT_PLUSD, /* DISCiPLE/+D snapshot */
+    LIBSPECTRUM_ID_SNAPSHOT_SP, /* .sp snapshot */
+    LIBSPECTRUM_ID_SNAPSHOT_SNP, /* .snp snapshot */
+    LIBSPECTRUM_ID_SNAPSHOT_ZXS, /* .zxs snapshot (zx32) */
+    LIBSPECTRUM_ID_SNAPSHOT_SZX, /* .szx snapshot (Spectaculator) */
 
     /* Below here, present only in 0.2.1 and later */
 
-    LIBSPECTRUM_ID_COMPRESSED_BZ2,    /* bzip2 compressed file */
-    LIBSPECTRUM_ID_COMPRESSED_GZ,        /* gzip compressed file */
+    LIBSPECTRUM_ID_COMPRESSED_BZ2, /* bzip2 compressed file */
+    LIBSPECTRUM_ID_COMPRESSED_GZ, /* gzip compressed file */
 
     /* Below here, present only in 0.2.2 and later */
 
-    LIBSPECTRUM_ID_HARDDISK_HDF,        /* .hdf hard disk image */
-    LIBSPECTRUM_ID_CARTRIDGE_IF2,        /* .rom Interface 2 cartridge image */
+    LIBSPECTRUM_ID_HARDDISK_HDF, /* .hdf hard disk image */
+    LIBSPECTRUM_ID_CARTRIDGE_IF2, /* .rom Interface 2 cartridge image */
 
     /* Below here, present only in 0.3.0 and later */
 
-    LIBSPECTRUM_ID_MICRODRIVE_MDR,    /* .mdr microdrive cartridge */
-    LIBSPECTRUM_ID_TAPE_CSW,        /* .csw tape image */
-    LIBSPECTRUM_ID_TAPE_Z80EM,        /* Z80Em tape image */
+    LIBSPECTRUM_ID_MICRODRIVE_MDR, /* .mdr microdrive cartridge */
+    LIBSPECTRUM_ID_TAPE_CSW, /* .csw tape image */
+    LIBSPECTRUM_ID_TAPE_Z80EM, /* Z80Em tape image */
 
     /* Below here, present only in 0.4.0 and later */
 
-    LIBSPECTRUM_ID_TAPE_WAV,        /* .wav tape image */
-    LIBSPECTRUM_ID_TAPE_SPC,        /* SP-style .spc tape image */
-    LIBSPECTRUM_ID_TAPE_STA,        /* Speculator-style .sta tape image */
-    LIBSPECTRUM_ID_TAPE_LTP,        /* Nuclear ZX-style .ltp tape image */
-    LIBSPECTRUM_ID_COMPRESSED_XFD,    /* xfdmaster (Amiga) compressed file */
-    LIBSPECTRUM_ID_DISK_IMG,        /* .img DISCiPLE/+D disk image */
-    LIBSPECTRUM_ID_DISK_MGT,        /* .mgt DISCiPLE/+D disk image */
+    LIBSPECTRUM_ID_TAPE_WAV, /* .wav tape image */
+    LIBSPECTRUM_ID_TAPE_SPC, /* SP-style .spc tape image */
+    LIBSPECTRUM_ID_TAPE_STA, /* Speculator-style .sta tape image */
+    LIBSPECTRUM_ID_TAPE_LTP, /* Nuclear ZX-style .ltp tape image */
+    LIBSPECTRUM_ID_COMPRESSED_XFD, /* xfdmaster (Amiga) compressed file */
+    LIBSPECTRUM_ID_DISK_IMG, /* .img DISCiPLE/+D disk image */
+    LIBSPECTRUM_ID_DISK_MGT, /* .mgt DISCiPLE/+D disk image */
 
     /* Below here, present only in 0.5.0 and later */
 
-    LIBSPECTRUM_ID_DISK_UDI,        /* .udi generic disk image */
-    LIBSPECTRUM_ID_DISK_FDI,        /* .fdi generic disk image */
-    LIBSPECTRUM_ID_DISK_CPC,        /* .dsk plain CPC +3 disk image */
-    LIBSPECTRUM_ID_DISK_ECPC,        /* .dsk extended CPC +3 disk image */
-    LIBSPECTRUM_ID_DISK_SAD,        /* .sad generic disk image */
-    LIBSPECTRUM_ID_DISK_TD0,        /* .td0 generic disk image */
+    LIBSPECTRUM_ID_DISK_UDI, /* .udi generic disk image */
+    LIBSPECTRUM_ID_DISK_FDI, /* .fdi generic disk image */
+    LIBSPECTRUM_ID_DISK_CPC, /* .dsk plain CPC +3 disk image */
+    LIBSPECTRUM_ID_DISK_ECPC, /* .dsk extended CPC +3 disk image */
+    LIBSPECTRUM_ID_DISK_SAD, /* .sad generic disk image */
+    LIBSPECTRUM_ID_DISK_TD0, /* .td0 generic disk image */
 
-    LIBSPECTRUM_ID_DISK_OPD,        /* .opu/.opd Opus Discovery disk image */
+    LIBSPECTRUM_ID_DISK_OPD, /* .opu/.opd Opus Discovery disk image */
 
-    LIBSPECTRUM_ID_TAPE_PZX,        /* PZX tape image */
+    LIBSPECTRUM_ID_TAPE_PZX, /* PZX tape image */
 
-    LIBSPECTRUM_ID_AUX_POK,        /* POKE file */
+    LIBSPECTRUM_ID_AUX_POK, /* POKE file */
 
 } libspectrum_id_t;
 
@@ -1149,36 +1150,36 @@ typedef enum libspectrum_class_t {
 
     LIBSPECTRUM_CLASS_UNKNOWN,
 
-    LIBSPECTRUM_CLASS_CARTRIDGE_TIMEX,    /* Timex cartridges */
-    LIBSPECTRUM_CLASS_DISK_PLUS3,        /* +3 disk */
-    LIBSPECTRUM_CLASS_DISK_TRDOS,        /* TR-DOS disk */
-    LIBSPECTRUM_CLASS_DISK_OPUS,        /* Opus Discovery disk*/
-    LIBSPECTRUM_CLASS_RECORDING,        /* Input recording */
-    LIBSPECTRUM_CLASS_SNAPSHOT,        /* Snapshot */
-    LIBSPECTRUM_CLASS_TAPE,        /* Tape */
+    LIBSPECTRUM_CLASS_CARTRIDGE_TIMEX, /* Timex cartridges */
+    LIBSPECTRUM_CLASS_DISK_PLUS3, /* +3 disk */
+    LIBSPECTRUM_CLASS_DISK_TRDOS, /* TR-DOS disk */
+    LIBSPECTRUM_CLASS_DISK_OPUS, /* Opus Discovery disk*/
+    LIBSPECTRUM_CLASS_RECORDING, /* Input recording */
+    LIBSPECTRUM_CLASS_SNAPSHOT, /* Snapshot */
+    LIBSPECTRUM_CLASS_TAPE, /* Tape */
 
     /* Below here, present only in 0.2.1 and later */
 
-    LIBSPECTRUM_CLASS_COMPRESSED,        /* A compressed file */
+    LIBSPECTRUM_CLASS_COMPRESSED, /* A compressed file */
 
     /* Below here, present only in 0.2.2 and later */
 
-    LIBSPECTRUM_CLASS_HARDDISK,        /* A hard disk image */
-    LIBSPECTRUM_CLASS_CARTRIDGE_IF2,    /* Interface 2 cartridges */
+    LIBSPECTRUM_CLASS_HARDDISK, /* A hard disk image */
+    LIBSPECTRUM_CLASS_CARTRIDGE_IF2, /* Interface 2 cartridges */
 
     /* Below here, present only in 0.3.0 and later */
 
-    LIBSPECTRUM_CLASS_MICRODRIVE,        /* Microdrive cartridges */
+    LIBSPECTRUM_CLASS_MICRODRIVE, /* Microdrive cartridges */
 
     /* Below here, present only in 0.4.0 and later */
 
-    LIBSPECTRUM_CLASS_DISK_PLUSD,        /* DISCiPLE/+D disk image */
+    LIBSPECTRUM_CLASS_DISK_PLUSD, /* DISCiPLE/+D disk image */
 
     /* Below here, present only in 0.5.0 and later */
 
-    LIBSPECTRUM_CLASS_DISK_GENERIC,    /* generic disk image */
+    LIBSPECTRUM_CLASS_DISK_GENERIC, /* generic disk image */
 
-    LIBSPECTRUM_CLASS_AUXILIARY,            /* auxiliary supported file */
+    LIBSPECTRUM_CLASS_AUXILIARY, /* auxiliary supported file */
 
 } libspectrum_class_t;
 /* The various types of block available */
@@ -1236,96 +1237,97 @@ typedef struct libspectrum_tape_block libspectrum_tape_block;
 struct libspectrum_tape {
 
     /* All the blocks */
-    struct libspectrum_tape_block* blocks;
+    struct libspectrum_tape_block *blocks;
 
     /* The last block */
-    struct libspectrum_tape_block* last_block;
+    struct libspectrum_tape_block *last_block;
 };
 
 typedef struct libspectrum_tape libspectrum_tape;
 
-
 static libspectrum_error
 tzx_read_data(uint8_t **ptr, const uint8_t *end,
-              size_t *length, int bytes)
+    size_t *length, int bytes)
 {
-    int i; uint32_t multiplier = 0x01;
+    int i;
+    uint32_t multiplier = 0x01;
 
-    if( bytes < 0 ) {
+    if (bytes < 0) {
         bytes = -bytes;
     }
 
     (*length) = 0;
-    for( i=0; i<bytes; i++, multiplier *= 0x100 ) {
-        *length += **ptr * multiplier; (*ptr)++;
+    for (i = 0; i < bytes; i++, multiplier *= 0x100) {
+        *length += **ptr * multiplier;
+        (*ptr)++;
     }
 
     /* Have we got enough bytes left in buffer? */
-    if( ( end - (*ptr) ) < (ptrdiff_t)(*length) ) {
-        libspectrum_print_error( LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_data: not enough data in buffer" );
+    if ((end - (*ptr)) < (ptrdiff_t)(*length)) {
+        libspectrum_print_error(LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_data: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
     return LIBSPECTRUM_ERROR_NONE;
-
 }
 
 static libspectrum_error
 tzx_read_rom_block(uint8_t **ptr,
-                   const uint8_t *end, size_t *length)
+    const uint8_t *end, size_t *length)
 {
     /* Check there's enough left in the buffer for the pause and the
      data length */
-    if( end - (*ptr) < 4 ) {
-        libspectrum_print_error( LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_rom_block: not enough data in buffer" );
+    if (end - (*ptr) < 4) {
+        libspectrum_print_error(LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_rom_block: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
     (*ptr) += 2;
 
     /* And the data */
-    return tzx_read_data( ptr, end, length, 2);
+    return tzx_read_data(ptr, end, length, 2);
 }
 
 static libspectrum_error
 tzx_read_turbo_block(uint8_t **ptr,
-                     const uint8_t *end, size_t *length)
+    const uint8_t *end, size_t *length)
 {
     /* Check there's enough left in the buffer for all the metadata */
-    if(end - (*ptr) < 18 ) {
+    if (end - (*ptr) < 18) {
         libspectrum_print_error(
-                                LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_turbo_block: not enough data in buffer"
-                                );
+            LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_turbo_block: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
     (*ptr) += 15;
 
     /* Read the data in */
-    return tzx_read_data( ptr, end, length, 3);
+    return tzx_read_data(ptr, end, length, 3);
 }
 
 static libspectrum_error
-tzx_skip_data( uint8_t **ptr, const uint8_t *end,
-              int bytes)
+tzx_skip_data(uint8_t **ptr, const uint8_t *end,
+    int bytes)
 {
-    int i; uint32_t multiplier = 0x01;
+    int i;
+    uint32_t multiplier = 0x01;
     size_t length = 0;
 
-    if( bytes < 0 ) {
+    if (bytes < 0) {
         bytes = -bytes;
     }
 
-    for( i=0; i<bytes; i++, multiplier *= 0x100 ) {
-        length += **ptr * multiplier; (*ptr)++;
+    for (i = 0; i < bytes; i++, multiplier *= 0x100) {
+        length += **ptr * multiplier;
+        (*ptr)++;
     }
 
     /* Have we got enough bytes left in buffer? */
-    if( ( end - (*ptr) ) < (ptrdiff_t)length ) {
-        libspectrum_print_error( LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_data: not enough data in buffer" );
+    if ((end - (*ptr)) < (ptrdiff_t)length) {
+        libspectrum_print_error(LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_data: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
@@ -1340,9 +1342,9 @@ static libspectrum_error tzx_skip_rom_block(uint8_t **ptr, uint8_t *end)
 
     /* Check there's enough left in the buffer for the pause and the
      data length */
-    if( end - (*ptr) < 4 ) {
-        libspectrum_print_error( LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_rom_block: not enough data in buffer" );
+    if (end - (*ptr) < 4) {
+        libspectrum_print_error(LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_rom_block: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
@@ -1359,31 +1361,31 @@ static libspectrum_error tzx_skip_turbo_block(uint8_t **ptr, uint8_t *end)
     libspectrum_error error = LIBSPECTRUM_ERROR_NONE;
 
     /* Check there's enough left in the buffer for all the metadata */
-    if( end - (*ptr) < 18 ) {
+    if (end - (*ptr) < 18) {
         libspectrum_print_error(
-                                LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_turbo_block: not enough data in buffer"
-                                );
+            LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_turbo_block: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
     (*ptr) += 15;
 
     /* Read the data in */
-    error = tzx_skip_data( ptr, end, 3 );
+    error = tzx_skip_data(ptr, end, 3);
     return error;
 }
 
 static libspectrum_error tzx_skip_comment(uint8_t **ptr, uint8_t *end)
 {
     /* Check the length byte exists */
-    if( (*ptr) == end ) {
-        libspectrum_print_error( LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_comment: not enough data in buffer" );
+    if ((*ptr) == end) {
+        libspectrum_print_error(LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_comment: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
-    return tzx_skip_data( ptr, end, -1);;
+    return tzx_skip_data(ptr, end, -1);
+    ;
 }
 
 static libspectrum_error tzx_skip_archive_info(uint8_t **ptr, uint8_t *end)
@@ -1392,11 +1394,10 @@ static libspectrum_error tzx_skip_archive_info(uint8_t **ptr, uint8_t *end)
 
     /* Check there's enough left in the buffer for the length and the count
      byte */
-    if( end - (*ptr) < 3 ) {
+    if (end - (*ptr) < 3) {
         libspectrum_print_error(
-                                LIBSPECTRUM_ERROR_CORRUPT,
-                                "tzx_read_archive_info: not enough data in buffer"
-                                );
+            LIBSPECTRUM_ERROR_CORRUPT,
+            "tzx_read_archive_info: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
@@ -1411,36 +1412,39 @@ static libspectrum_error tzx_skip_to_block(int blockno, uint8_t **ptr, uint8_t *
 
     int currentblock = 0;
 
-    while( *ptr < end && currentblock < blockno) {
+    while (*ptr < end && currentblock < blockno) {
 
         /* Get the ID of the next block */
         libspectrum_tape_type id = **ptr;
         *ptr = *ptr + 1;
 
-        switch( id ) {
-            case LIBSPECTRUM_TAPE_BLOCK_ROM:
-                error = tzx_skip_rom_block(ptr, end );
-                if( error ) return error;
-                break;
-            case LIBSPECTRUM_TAPE_BLOCK_TURBO:
-                error = tzx_skip_turbo_block(ptr, end );
-                if( error ) return error;
-                break;
+        switch (id) {
+        case LIBSPECTRUM_TAPE_BLOCK_ROM:
+            error = tzx_skip_rom_block(ptr, end);
+            if (error)
+                return error;
+            break;
+        case LIBSPECTRUM_TAPE_BLOCK_TURBO:
+            error = tzx_skip_turbo_block(ptr, end);
+            if (error)
+                return error;
+            break;
 
-            case LIBSPECTRUM_TAPE_BLOCK_COMMENT:
-                error = tzx_skip_comment(ptr, end );
-                if( error ) return error;
-                break;
-            case LIBSPECTRUM_TAPE_BLOCK_ARCHIVE_INFO:
-                error = tzx_skip_archive_info(ptr, end );
-                if( error ) return error;
-                break;
-            default:    /* For now, don't handle anything else */
-                libspectrum_print_error(
-                                        LIBSPECTRUM_ERROR_UNKNOWN,
-                                        "tzx_skip_to_block: unknown block type 0x%02x", id
-                                        );
-                return LIBSPECTRUM_ERROR_UNKNOWN;
+        case LIBSPECTRUM_TAPE_BLOCK_COMMENT:
+            error = tzx_skip_comment(ptr, end);
+            if (error)
+                return error;
+            break;
+        case LIBSPECTRUM_TAPE_BLOCK_ARCHIVE_INFO:
+            error = tzx_skip_archive_info(ptr, end);
+            if (error)
+                return error;
+            break;
+        default: /* For now, don't handle anything else */
+            libspectrum_print_error(
+                LIBSPECTRUM_ERROR_UNKNOWN,
+                "tzx_skip_to_block: unknown block type 0x%02x", id);
+            return LIBSPECTRUM_ERROR_UNKNOWN;
         }
         currentblock++;
     }
@@ -1448,34 +1452,34 @@ static libspectrum_error tzx_skip_to_block(int blockno, uint8_t **ptr, uint8_t *
 }
 
 /* The .tzx file signature (first 8 bytes) */
-const char * const libspectrum_tzx_signature = "ZXTape!\x1a";
+const char *const libspectrum_tzx_signature = "ZXTape!\x1a";
 
 static libspectrum_error
 find_tzx_block(int blockno, uint8_t *srcbuf, uint8_t **result,
-               size_t *length )
+    size_t *length)
 {
 
     libspectrum_error error;
 
     uint8_t *ptr, *end;
-    size_t signature_length = strlen( libspectrum_tzx_signature );
+    size_t signature_length = strlen(libspectrum_tzx_signature);
 
-    ptr = srcbuf; end = srcbuf + *length;
+    ptr = srcbuf;
+    end = srcbuf + *length;
 
     /* Must be at least as many bytes as the signature, and the major/minor
      version numbers */
-    if( *length < signature_length + 2 ) {
+    if (*length < signature_length + 2) {
         libspectrum_print_error(
-                                LIBSPECTRUM_ERROR_CORRUPT,
-                                "libspectrum_tzx_create: not enough data in buffer"
-                                );
+            LIBSPECTRUM_ERROR_CORRUPT,
+            "libspectrum_tzx_create: not enough data in buffer");
         return LIBSPECTRUM_ERROR_CORRUPT;
     }
 
     /* Now check the signature */
-    if( memcmp( ptr, libspectrum_tzx_signature, signature_length ) ) {
-        libspectrum_print_error( LIBSPECTRUM_ERROR_SIGNATURE,
-                                "libspectrum_tzx_create: wrong signature" );
+    if (memcmp(ptr, libspectrum_tzx_signature, signature_length)) {
+        libspectrum_print_error(LIBSPECTRUM_ERROR_SIGNATURE,
+            "libspectrum_tzx_create: wrong signature");
         return LIBSPECTRUM_ERROR_SIGNATURE;
     }
     ptr += signature_length;
@@ -1490,46 +1494,48 @@ find_tzx_block(int blockno, uint8_t *srcbuf, uint8_t **result,
     /* Get the ID of the next block */
     libspectrum_tape_type id = *ptr++;
 
-    switch( id ) {
-        case LIBSPECTRUM_TAPE_BLOCK_ROM:
-            error = tzx_read_rom_block(&ptr, end, length );
-            if( error ) return error;
-            break;
-        case LIBSPECTRUM_TAPE_BLOCK_TURBO:
-            error = tzx_read_turbo_block(&ptr, end, length );
-            if( error ) return error;
-            break;
-        default:    /* For now, don't handle anything else */
-            libspectrum_print_error(
-                                    LIBSPECTRUM_ERROR_UNKNOWN,
-                                    "libspectrum_tzx_create: unknown block type 0x%02x", id
-                                    );
-            return LIBSPECTRUM_ERROR_UNKNOWN;
+    switch (id) {
+    case LIBSPECTRUM_TAPE_BLOCK_ROM:
+        error = tzx_read_rom_block(&ptr, end, length);
+        if (error)
+            return error;
+        break;
+    case LIBSPECTRUM_TAPE_BLOCK_TURBO:
+        error = tzx_read_turbo_block(&ptr, end, length);
+        if (error)
+            return error;
+        break;
+    default: /* For now, don't handle anything else */
+        libspectrum_print_error(
+            LIBSPECTRUM_ERROR_UNKNOWN,
+            "libspectrum_tzx_create: unknown block type 0x%02x", id);
+        return LIBSPECTRUM_ERROR_UNKNOWN;
     }
     *result = ptr;
     return LIBSPECTRUM_ERROR_NONE;
 }
 
 uint8_t *find_tap_block(int wantedindex, const uint8_t *buffer,
-                        size_t *length)
+    size_t *length)
 {
-    size_t data_length, buf_length; uint8_t *data;
+    size_t data_length, buf_length;
+    uint8_t *data;
 
     int blockindex = 0;
 
     const uint8_t *ptr, *end;
 
-    ptr = buffer; end = buffer + *length;
+    ptr = buffer;
+    end = buffer + *length;
 
-    while( ptr < end ) {
+    while (ptr < end) {
 
         /* If we've got less than two bytes for the length, something's
          gone wrong, so go home */
-        if( ( end - ptr ) < 2 ) {
+        if ((end - ptr) < 2) {
             libspectrum_print_error(
-                                    LIBSPECTRUM_ERROR_CORRUPT,
-                                    "libspectrum_tap_read: not enough data in buffer"
-                                    );
+                LIBSPECTRUM_ERROR_CORRUPT,
+                "libspectrum_tap_read: not enough data in buffer");
             return NULL;
         }
 
@@ -1537,23 +1543,22 @@ uint8_t *find_tap_block(int wantedindex, const uint8_t *buffer,
         data_length = ptr[0] + ptr[1] * 0x100;
         ptr += 2;
 
-            buf_length = data_length;
+        buf_length = data_length;
 
         /* Have we got enough bytes left in buffer? */
-        if( end - ptr < (ptrdiff_t)buf_length ) {
+        if (end - ptr < (ptrdiff_t)buf_length) {
             libspectrum_print_error(
-                                    LIBSPECTRUM_ERROR_CORRUPT,
-                                    "libspectrum_tap_read: not enough data in buffer"
-                                    );
+                LIBSPECTRUM_ERROR_CORRUPT,
+                "libspectrum_tap_read: not enough data in buffer");
             return NULL;
         }
 
         if (blockindex == wantedindex) {
             /* Allocate memory for the data */
-            data = libspectrum_new( uint8_t, data_length );
+            data = libspectrum_new(uint8_t, data_length);
 
             /* Copy the block data across */
-            memcpy( data, ptr + 1, buf_length - 1 );
+            memcpy(data, ptr + 1, buf_length - 1);
 
             *length = data_length - 2;
             return data;
@@ -1563,22 +1568,19 @@ uint8_t *find_tap_block(int wantedindex, const uint8_t *buffer,
 
         /* Move along the buffer */
         ptr += buf_length;
-
     }
 
     libspectrum_print_error(
-                            LIBSPECTRUM_ERROR_CORRUPT,
-                            "find_tap_block: could not find block %d", wantedindex
-                            );
+        LIBSPECTRUM_ERROR_CORRUPT,
+        "find_tap_block: could not find block %d", wantedindex);
     return NULL;
 }
-
 
 uint8_t *GetTZXBlock(int blockno, uint8_t *srcbuf, size_t *length)
 {
     uint8_t *ptr;
     libspectrum_error error = find_tzx_block(blockno, srcbuf, &ptr,
-                                             length );
+        length);
     if (error) {
         libspectrum_print_error(error, "get_tzx_block: could not read block %d\n", blockno);
         return NULL;
@@ -1590,4 +1592,3 @@ uint8_t *GetTZXBlock(int blockno, uint8_t *srcbuf, size_t *length)
     memcpy(result, ptr, *length);
     return result;
 }
-

--- a/terps/taylor/decompressz80.h
+++ b/terps/taylor/decompressz80.h
@@ -8,14 +8,14 @@
 #ifndef decompressz80_h
 #define decompressz80_h
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 /* Will return NULL on error or 0xc000 (49152) bytes of uncompressed raw data on
  * success */
 uint8_t *DecompressZ80(uint8_t *raw_data, size_t *length);
 uint8_t *find_tap_block(int wantedindex, const uint8_t *buffer,
-                        size_t *length);
+    size_t *length);
 
 uint8_t *GetTZXBlock(int blockno, uint8_t *srcbuf, size_t *length);
 

--- a/terps/taylor/extracommands.c
+++ b/terps/taylor/extracommands.c
@@ -5,14 +5,14 @@
 //  Created by Petter Sjölund on 2022-04-05.
 //
 
-#include <string.h>
-#include <stdint.h>
 #include <ctype.h>
+#include <stdint.h>
+#include <string.h>
 
+#include "extracommands.h"
+#include "parseinput.h"
 #include "restorestate.h"
 #include "utility.h"
-#include "parseinput.h"
-#include "extracommands.h"
 
 typedef enum {
     NO_COMMAND,
@@ -115,7 +115,6 @@ int YesOrNo(void);
 void SaveGame(void);
 int LoadGame(void);
 
-
 static void TranscriptOn(void)
 {
     frefid_t ref;
@@ -126,7 +125,7 @@ static void TranscriptOn(void)
     }
 
     ref = glk_fileref_create_by_prompt(fileusage_TextMode | fileusage_Transcript,
-                                       filemode_Write, 0);
+        filemode_Write, 0);
     if (ref == NULL)
         return;
 
@@ -141,7 +140,7 @@ static void TranscriptOn(void)
     char *start_of_transcript = "Start of transcript\n\n";
     glk_put_string_stream(Transcript, start_of_transcript);
     glk_put_string_stream(glk_window_get_stream(Bottom),
-                          "Transcript is now on.\n");
+        "Transcript is now on.\n");
 }
 
 static void TranscriptOff(void)
@@ -157,7 +156,7 @@ static void TranscriptOff(void)
     glk_stream_close(Transcript, NULL);
     Transcript = NULL;
     glk_put_string_stream(glk_window_get_stream(Bottom),
-                          "Transcript is now off.\n");
+        "Transcript is now off.\n");
 }
 
 static int ParseExtraCommand(char *p)
@@ -169,12 +168,12 @@ static int ParseExtraCommand(char *p)
         return NO_COMMAND;
     int j = 0;
     int found = 0;
-    while(ExtraCommands[j] != NULL) {
+    while (ExtraCommands[j] != NULL) {
         size_t commandlen = strlen(ExtraCommands[j]);
         if (commandlen == len) {
             char *c = p;
             found = 1;
-            for(int i = 0; i < len; i++) {
+            for (int i = 0; i < len; i++) {
                 if (tolower(*c++) != ExtraCommands[j][i]) {
                     found = 0;
                     break;
@@ -203,65 +202,65 @@ int TryExtraCommand(void)
     StopTime = 1;
     Redraw = 1;
     switch (verb) {
-        case RESTORE:
-            if (noun == NO_COMMAND || noun == GAME) {
-                LoadGame();
-                return 1;
+    case RESTORE:
+        if (noun == NO_COMMAND || noun == GAME) {
+            LoadGame();
+            return 1;
+        }
+        break;
+    case RESTART:
+        if (noun == NO_COMMAND || noun == GAME) {
+            Display(Bottom, "Restart? (Y/N) ");
+            if (YesOrNo()) {
+                ShouldRestart = 1;
             }
-            break;
-        case RESTART:
-            if (noun == NO_COMMAND || noun == GAME) {
-                Display(Bottom, "Restart? (Y/N) ");
-                if (YesOrNo()) {
-                    ShouldRestart = 1;
-                }
-                return 1;
-            }
-            break;
-        case SAVE_EXTR:
-            if (noun == NO_COMMAND || noun == GAME) {
-                SaveGame();
-                return 1;
-            }
-            break;
-        case UNDO:
-            if (noun == NO_COMMAND || noun == COMMAND) {
-                RestoreUndo(1);
-                return 1;
-            }
-            break;
-        case RAM:
-            if (noun == RESTORE) {
-                RamLoad();
-                return 1;
-            } else if (noun == SAVE_EXTR) {
-                RamSave(1);
-                return 1;
-            }
-            break;
-        case RAMSAVE_EXTR:
-            if (noun == NO_COMMAND) {
-                RamSave(1);
-                return 1;
-            }
-            break;
-        case RAMLOAD_EXTR:
-            if (noun == NO_COMMAND) {
-                RamLoad();
-                return 1;
-            }
-            break;
-        case SCRIPT:
-            if (noun == ON || noun == 0) {
-                TranscriptOn();
-                return 1;
-            } else if (noun == OFF) {
-                TranscriptOff();
-                return 1;
-            }
-            break;
-        default:
-            break;
+            return 1;
+        }
+        break;
+    case SAVE_EXTR:
+        if (noun == NO_COMMAND || noun == GAME) {
+            SaveGame();
+            return 1;
+        }
+        break;
+    case UNDO:
+        if (noun == NO_COMMAND || noun == COMMAND) {
+            RestoreUndo(1);
+            return 1;
+        }
+        break;
+    case RAM:
+        if (noun == RESTORE) {
+            RamLoad();
+            return 1;
+        } else if (noun == SAVE_EXTR) {
+            RamSave(1);
+            return 1;
+        }
+        break;
+    case RAMSAVE_EXTR:
+        if (noun == NO_COMMAND) {
+            RamSave(1);
+            return 1;
+        }
+        break;
+    case RAMLOAD_EXTR:
+        if (noun == NO_COMMAND) {
+            RamLoad();
+            return 1;
+        }
+        break;
+    case SCRIPT:
+        if (noun == ON || noun == 0) {
+            TranscriptOn();
+            return 1;
+        } else if (noun == OFF) {
+            TranscriptOff();
+            return 1;
+        }
+        break;
+    default:
+        break;
     }
 
     StopTime = 0;

--- a/terps/taylor/extracttape.c
+++ b/terps/taylor/extracttape.c
@@ -10,12 +10,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "taylor.h"
-#include "extracttape.h"
-#include "utility.h"
 #include "decompressz80.h"
 #include "decrypttotloader.h"
+#include "taylor.h"
+#include "utility.h"
 
+#include "extracttape.h"
 
 void ldir(uint8_t *mem, uint16_t DE, uint16_t HL, uint16_t BC)
 {
@@ -99,21 +99,24 @@ static uint8_t *ShrinkToSnaSize(uint8_t *uncompressed, uint8_t *image, size_t *l
     return uncompressed2;
 }
 
-uint8_t *AddTapBlock(uint8_t *image, uint8_t *uncompressed, size_t origlen, int blocknum, size_t offset) {
+uint8_t *AddTapBlock(uint8_t *image, uint8_t *uncompressed, size_t origlen, int blocknum, size_t offset)
+{
     size_t length = origlen;
     uint8_t *block = find_tap_block(blocknum, image, &length);
     memcpy(uncompressed + offset, block, length);
     return uncompressed;
 }
 
-uint8_t *AddTZXBlock(uint8_t *image, uint8_t *uncompressed, size_t origlen, int blocknum, size_t offset) {
+uint8_t *AddTZXBlock(uint8_t *image, uint8_t *uncompressed, size_t origlen, int blocknum, size_t offset)
+{
     size_t length = origlen;
     uint8_t *block = GetTZXBlock(blocknum, image, &length);
     memcpy(uncompressed + offset, block + 1, length - 2);
     return uncompressed;
 }
 
-uint8_t *ProcessFile(uint8_t *image, size_t *length) {
+uint8_t *ProcessFile(uint8_t *image, size_t *length)
+{
 
     int IsBrokenKayleth = 0;
 
@@ -131,79 +134,79 @@ uint8_t *ProcessFile(uint8_t *image, size_t *length) {
     } else {
         uint8_t *block;
         switch (*length) {
-            case 0xccca:
-                fprintf(stderr, "This is the Temple of Terror side A tzx\n");
-                block = GetTZXBlock(4, image, length);
-                if (block){
-                    uint8_t loacon = 0x9a;
-                    uncompressed = DeAlkatraz(block, NULL, 0x1b0c, 0x5B00, 0x9f64, &loacon, 0xcf, 0xcd, 0);
-                    lddr(uncompressed, 0xffff, 0xfc85, 0x9f8e);
-                    DeshuffleAlkatraz(uncompressed, 05, 0x5b8b, 0xfdd6);
-                    free(block);
-                    image = ShrinkToSnaSize(uncompressed, image, length);
-                } else {
-                    fprintf(stderr, "Could not extract block\n");
-                    return image;
-                }
-                break;
-            case 0xa000:
-                fprintf(stderr, "This is the Temple of Terror side B tzx\n");
-                image = DecryptToTSideB(image, length);
-                image = ShrinkToSnaSize(image, uncompressed, length);
-                break;
-            case 0xcadc:
-                fprintf(stderr, "This is Kayleth tzx\n");
-                block = GetTZXBlock(4, image, length);
-                if (block){
-                    uint8_t loacon = 0xce;
-                    uncompressed = DeAlkatraz(block, NULL, 0x172e, 0x5B00, 0xa004, &loacon, 0xeb, 0x8f, 0);
-                    lddr(uncompressed, 0xfd93, 0xfb02, 0x9e38);
-                    DeshuffleAlkatraz(uncompressed, 0x17, 0x5bf2, 0xfd90);
-                    free(block);
-                    image = ShrinkToSnaSize(uncompressed, image, length);
-                } else {
-                    fprintf(stderr, "Could not extract block\n");
-                    return image;
-                }
-                break;
-            case 0xcd17:
-            case 0xcd15:
-                fprintf(stderr, "This is Terraquake tzx\n");
-                block = GetTZXBlock(3, image, length);
-                if (block){
-                    uint8_t loacon = 0xe7;
-                    uncompressed = DeAlkatraz(block, NULL, 0x17eb, 0x5B00, 0x9f64, &loacon, 0x75, 0x55, 0);
-                    lddr(uncompressed, 0xfc80, 0xfa32, 0x9d38);
-                    DeshuffleAlkatraz(uncompressed, 0x03, 0x5b90, 0xfc80);
-                    free(block);
-                    image = ShrinkToSnaSize(uncompressed, image, length);
-                } else {
-                    fprintf(stderr, "Could not extract block\n");
-                    return image;
-                }
-                break;
-            case 0x104c4: // Blizzard Pass TAP
-                uncompressed = MemAlloc(0x2001f);
-                uncompressed = AddTapBlock(image, uncompressed, origlen, 11,  0x1801f);
-                uncompressed = AddTapBlock(image, uncompressed, origlen, 15,  0x801b);
-                uncompressed = AddTapBlock(image, uncompressed, origlen, 17,  0x401b);
-                uncompressed = AddTapBlock(image, uncompressed, origlen, 19,  0x1ee6);
-                uncompressed = AddTapBlock(image, uncompressed, origlen, 21,  0xbff7);
-                *length = 0x2001f;
-                free(image);
-                return uncompressed;
-            case 0x10428: // Blizzard Pass tzx
-                uncompressed = MemAlloc(0x2001f);
-                uncompressed = AddTZXBlock(image, uncompressed, origlen, 8,  0x1801f);
-                uncompressed = AddTZXBlock(image, uncompressed, origlen, 12, 0x801b);
-                uncompressed = AddTZXBlock(image, uncompressed, origlen, 14, 0x401b);
-                uncompressed = AddTZXBlock(image, uncompressed, origlen, 16, 0x1ee6);
-                uncompressed = AddTZXBlock(image, uncompressed, origlen, 18, 0xbff7);
-                *length = 0x2001f;
-                free(image);
-                return uncompressed;
-            default:
-                break;
+        case 0xccca:
+            fprintf(stderr, "This is the Temple of Terror side A tzx\n");
+            block = GetTZXBlock(4, image, length);
+            if (block) {
+                uint8_t loacon = 0x9a;
+                uncompressed = DeAlkatraz(block, NULL, 0x1b0c, 0x5B00, 0x9f64, &loacon, 0xcf, 0xcd, 0);
+                lddr(uncompressed, 0xffff, 0xfc85, 0x9f8e);
+                DeshuffleAlkatraz(uncompressed, 05, 0x5b8b, 0xfdd6);
+                free(block);
+                image = ShrinkToSnaSize(uncompressed, image, length);
+            } else {
+                fprintf(stderr, "Could not extract block\n");
+                return image;
+            }
+            break;
+        case 0xa000:
+            fprintf(stderr, "This is the Temple of Terror side B tzx\n");
+            image = DecryptToTSideB(image, length);
+            image = ShrinkToSnaSize(image, uncompressed, length);
+            break;
+        case 0xcadc:
+            fprintf(stderr, "This is Kayleth tzx\n");
+            block = GetTZXBlock(4, image, length);
+            if (block) {
+                uint8_t loacon = 0xce;
+                uncompressed = DeAlkatraz(block, NULL, 0x172e, 0x5B00, 0xa004, &loacon, 0xeb, 0x8f, 0);
+                lddr(uncompressed, 0xfd93, 0xfb02, 0x9e38);
+                DeshuffleAlkatraz(uncompressed, 0x17, 0x5bf2, 0xfd90);
+                free(block);
+                image = ShrinkToSnaSize(uncompressed, image, length);
+            } else {
+                fprintf(stderr, "Could not extract block\n");
+                return image;
+            }
+            break;
+        case 0xcd17:
+        case 0xcd15:
+            fprintf(stderr, "This is Terraquake tzx\n");
+            block = GetTZXBlock(3, image, length);
+            if (block) {
+                uint8_t loacon = 0xe7;
+                uncompressed = DeAlkatraz(block, NULL, 0x17eb, 0x5B00, 0x9f64, &loacon, 0x75, 0x55, 0);
+                lddr(uncompressed, 0xfc80, 0xfa32, 0x9d38);
+                DeshuffleAlkatraz(uncompressed, 0x03, 0x5b90, 0xfc80);
+                free(block);
+                image = ShrinkToSnaSize(uncompressed, image, length);
+            } else {
+                fprintf(stderr, "Could not extract block\n");
+                return image;
+            }
+            break;
+        case 0x104c4: // Blizzard Pass TAP
+            uncompressed = MemAlloc(0x2001f);
+            uncompressed = AddTapBlock(image, uncompressed, origlen, 11, 0x1801f);
+            uncompressed = AddTapBlock(image, uncompressed, origlen, 15, 0x801b);
+            uncompressed = AddTapBlock(image, uncompressed, origlen, 17, 0x401b);
+            uncompressed = AddTapBlock(image, uncompressed, origlen, 19, 0x1ee6);
+            uncompressed = AddTapBlock(image, uncompressed, origlen, 21, 0xbff7);
+            *length = 0x2001f;
+            free(image);
+            return uncompressed;
+        case 0x10428: // Blizzard Pass tzx
+            uncompressed = MemAlloc(0x2001f);
+            uncompressed = AddTZXBlock(image, uncompressed, origlen, 8, 0x1801f);
+            uncompressed = AddTZXBlock(image, uncompressed, origlen, 12, 0x801b);
+            uncompressed = AddTZXBlock(image, uncompressed, origlen, 14, 0x401b);
+            uncompressed = AddTZXBlock(image, uncompressed, origlen, 16, 0x1ee6);
+            uncompressed = AddTZXBlock(image, uncompressed, origlen, 18, 0xbff7);
+            *length = 0x2001f;
+            free(image);
+            return uncompressed;
+        default:
+            break;
         }
     }
 
@@ -220,4 +223,3 @@ uint8_t *ProcessFile(uint8_t *image, size_t *length) {
     }
     return image;
 }
-

--- a/terps/taylor/extracttape.h
+++ b/terps/taylor/extracttape.h
@@ -8,8 +8,8 @@
 #ifndef extracttape_h
 #define extracttape_h
 
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 
 uint8_t *GetTZXBlock(int blockno, uint8_t *srcbuf, size_t *length);
 uint8_t *DeAlkatraz(uint8_t *raw_data, uint8_t *target, size_t offset, uint16_t IX, uint16_t DE, uint8_t *loacon, uint8_t add1, uint8_t add2, int selfmodify);

--- a/terps/taylor/gameinfo.c
+++ b/terps/taylor/gameinfo.c
@@ -9,434 +9,434 @@
 
 #include "taylor.h"
 
+// clang-format off
 struct GameInfo games[NUMGAMES] = {
     {
         "Questprobe 3",
         QUESTPROBE3,
-        QUESTPROBE3_TYPE,                 // type
+        QUESTPROBE3_TYPE, // type
         QUESTPROBE3,
 
-        0x45F6,    // dictionary
-        0x4c8c,    // tokens
-        0x28a5,    // start_of_room_descriptions
-        0x2c7a,    // start_of_item_descriptions
-        0x3e10,    // automatics
-        0x3045,    // actions
-        0x50d4,    // start_of_room_connections
-        0x67ba,    // start_of_flags
-        0x50a3,    // start_of_item_locations
-        0x2000,    // start_of_messages
-        0,         // second message bank
+        0x45F6, // dictionary
+        0x4c8c, // tokens
+        0x28a5, // start_of_room_descriptions
+        0x2c7a, // start_of_item_descriptions
+        0x3e10, // automatics
+        0x3045, // actions
+        0x50d4, // start_of_room_connections
+        0x67ba, // start_of_flags
+        0x50a3, // start_of_item_locations
+        0x2000, // start_of_messages
+        0,      // second message bank
 
         0x6100, // start_of_characters;
         0x6916, // start_of_image_data;
         0x381c, // image patterns lookup table;
-        0x1c, // number of patterns
-        0x9f, // patterns end marker
+        0x001c, // number of patterns
+        0x009f, // patterns end marker
         0x878b, // start of room image instructions
-        57, // number_of_image blocks;
-        ZXOPT, // palette
+        57,     // number_of_image blocks;
+        ZXOPT   // palette
     },
 
     {
         "Questprobe 3 C64",
         QUESTPROBE3_64,
-        QUESTPROBE3_TYPE,                 // type
+        QUESTPROBE3_TYPE, // type
         QUESTPROBE3,
 
-        0x1187,    // dictionary
-        0x0003,    // tokens
-        0x09e7,    // start_of_room_descriptions
-        0x0dbc,    // start_of_item_descriptions
-        0x2641,    // automatics
-        0x1876,    // actions
-        0x1812,    // start_of_room_connections
-        0xc1bc,    // start_of_flags
-        0x2dfd,    // start_of_item_locations
-        0x0142,    // start_of_messages
-        0,         // second message bank
+        0x1187, // dictionary
+        0x0003, // tokens
+        0x09e7, // start_of_room_descriptions
+        0x0dbc, // start_of_item_descriptions
+        0x2641, // automatics
+        0x1876, // actions
+        0x1812, // start_of_room_connections
+        0xc1bc, // start_of_flags
+        0x2dfd, // start_of_item_locations
+        0x0142, // start_of_messages
+        0,      // second message bank
 
         0xbb02, // start_of_characters;
         0x6058, // start_of_image_data;
         0x381c, // image patterns lookup table;
-        0x1c, // number of patterns
-        0x9f, // patterns end marker
-        0x87a6 - 0x1B, // start of room image instructions
-        57, // number_of_image blocks;
-        C64A, // palette
+        0x001c, // number of patterns
+        0x009f, // patterns end marker
+        0x878b, // start of room image instructions
+        57,     // number_of_image blocks;
+        C64A    // palette
     },
 
     {
         "Rebel Planet",
         REBEL_PLANET,
-        REBEL_PLANET_TYPE,                 // type
+        REBEL_PLANET_TYPE, // type
         REBEL_PLANET,
 
-        0x3559,    // dictionary
-        0x7bda,    // tokens
-        0x5615,    // start_of_room_descriptions
-        0x7321,    // start_of_item_descriptions
-        0x3c9d,    // automatics
-        0x43e0,    // actions
-        0x33a3,    // start_of_room_connections
-        0x1ff8,    // start_of_flags
-        0x331e,    // start_of_item_locations
-        0x5e05,    // start_of_messages
-        0x6f19,    // second message bank
+        0x3559, // dictionary
+        0x7bda, // tokens
+        0x5615, // start_of_room_descriptions
+        0x7321, // start_of_item_descriptions
+        0x3c9d, // automatics
+        0x43e0, // actions
+        0x33a3, // start_of_room_connections
+        0x1ff8, // start_of_flags
+        0x331e, // start_of_item_locations
+        0x5e05, // start_of_messages
+        0x6f19, // second message bank
 
-        0x810e, // start_of_characters;
-        0x9139, // start_of_image_data;
-        0, // image patterns lookup table; •
-        0, // number of patterns •
-        0, // patterns end marker •
+        0x810e, // start_of_characters
+        0x9139, // start_of_image_data
+        0,      // image patterns lookup table
+        0,      // number of patterns
+        0,      // patterns end marker
         0x87a6, // start of room image instructions
-        167, // number_of_image blocks;
-        ZXOPT, // palette
+        167,    // number_of_image blocks
+        ZXOPT   // palette
     },
 
     {
         "Rebel Planet C64",
         REBEL_PLANET_64,
-        REBEL_PLANET_TYPE,                 // type
+        REBEL_PLANET_TYPE, // type
         REBEL_PLANET,
 
-        0x5e3d,    // dictionary
-        0x40c7,    // tokens
-        0x1b02,    // start_of_room_descriptions
-        0x380e,    // start_of_item_descriptions
-        0x6581,    // automatics
-        0x6cc4,    // actions
-        0x5c87,    // start_of_room_connections
-        0x198a,    // start_of_flags
-        0x5c02,    // start_of_item_locations
-        0x22f2,    // start_of_messages
-        0x3406,    // second message bank
+        0x5e3d, // dictionary
+        0x40c7, // tokens
+        0x1b02, // start_of_room_descriptions
+        0x380e, // start_of_item_descriptions
+        0x6581, // automatics
+        0x6cc4, // actions
+        0x5c87, // start_of_room_connections
+        0x198a, // start_of_flags
+        0x5c02, // start_of_item_locations
+        0x22f2, // start_of_messages
+        0x3406, // second message bank
 
         0xb78c, // start_of_characters
         0x7f02, // start_of_image_data
-        0, // image patterns lookup table
-        0, // number of patterns
-        0, // patterns end marker
+        0,      // image patterns lookup table
+        0,      // number of patterns
+        0,      // patterns end marker
         0xadea, // start of room image instructions
-        167, // number_of_image blocks
-        C64B, // palette
+        167,    // number_of_image blocks
+        C64B    // palette
     },
 
     {
         "Blizzard Pass",
         BLIZZARD_PASS,
-        BLIZZARD_PASS_TYPE,                 // type
+        BLIZZARD_PASS_TYPE, // type
         BLIZZARD_PASS,
 
-        0x6720,    // dictionary
-        0x71bc,    // tokens
-        0x35ce,    // start_of_room_descriptions
-        0x4ce6,    // start_of_item_descriptions
-        0x56d9,    // automatics
-        0x5a54,    // actions
-        0x6b67,    // start_of_room_connections
-        0x2051,    // start_of_flags
-        0x76a8,    // start_of_item_locations
-        0x3e26,    // start_of_messages
-        0,         // second message bank
+        0x6720, // dictionary
+        0x71bc, // tokens
+        0x35ce, // start_of_room_descriptions
+        0x4ce6, // start_of_item_descriptions
+        0x56d9, // automatics
+        0x5a54, // actions
+        0x6b67, // start_of_room_connections
+        0x2051, // start_of_flags
+        0x76a8, // start_of_item_locations
+        0x3e26, // start_of_messages
+        0,      // second message bank
 
         0x8350, // start_of_characters
         0x8708, // start_of_image_data
-        0, // image patterns lookup table
-        0, // number of patterns
-        0, // patterns end marker
+        0,      // image patterns lookup table
+        0,      // number of patterns
+        0,      // patterns end marker
         0x7798, // start of room image instructions
-        114, // number_of_image blocks;
-        ZXOPT, // palette
+        114,    // number_of_image blocks;
+        ZXOPT   // palette
     },
 
     {
         "Heman",
         HEMAN,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         HEMAN,
 
-        0x483A,    // dictionary
-        0x4ce0,    // tokens
-        0x5b36,    // start_of_room_descriptions
-        0x56a2,    // start_of_item_descriptions
-        0x45bf,    // automatics
-        0x37d8,    // actions
-        0x442f,    // start_of_room_connections
-        0x1e45,    // start_of_flags
-        0x43cb,    // start_of_item_locations
-        0x6665,    // start_of_messages
-        0x4fee,    // second message bank
+        0x483A, // dictionary
+        0x4ce0, // tokens
+        0x5b36, // start_of_room_descriptions
+        0x56a2, // start_of_item_descriptions
+        0x45bf, // automatics
+        0x37d8, // actions
+        0x442f, // start_of_room_connections
+        0x1e45, // start_of_flags
+        0x43cb, // start_of_item_locations
+        0x6665, // start_of_messages
+        0x4fee, // second message bank
 
         0x8603, // start_of_characters
         0x8d13, // start_of_image_data
         0x3703, // image patterns lookup table
-        0x1c, // number of patterns
-        0x9f, // patterns end marker
+        0x001c, // number of patterns
+        0x009f, // patterns end marker
         0x7adf, // start of room image instructions
-        139, // number_of_image blocks
-        ZXOPT, // palette
+        139,    // number_of_image blocks
+        ZXOPT   // palette
     },
 
     {
         "Heman C64",
         HEMAN_64,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         HEMAN,
 
-        0x116f,    // dictionary
-        0x1615,    // tokens
-        0x5c08,    // start_of_room_descriptions
-        0x798d,    // start_of_item_descriptions
-        0x0ef4,    // automatics
-        0x010d,    // actions
-        0x0d64,    // start_of_room_connections
-        0x2bbf,    // start_of_flags
-        0x0d00,    // start_of_item_locations
-        0x6737,    // start_of_messages
-        0x1923,    // second message bank
+        0x116f, // dictionary
+        0x1615, // tokens
+        0x5c08, // start_of_room_descriptions
+        0x798d, // start_of_item_descriptions
+        0x0ef4, // automatics
+        0x010d, // actions
+        0x0d64, // start_of_room_connections
+        0x2bbf, // start_of_flags
+        0x0d00, // start_of_item_locations
+        0x6737, // start_of_messages
+        0x1923, // second message bank
 
         0x8008, // start_of_characters;
         0x8718, // start_of_image_data;
-        0, // image patterns lookup table;
-        0, // number of patterns
-        0, // patterns end marker
+        0,      // image patterns lookup table;
+        0,      // number of patterns
+        0,      // patterns end marker
         0x4808, // start of room image instructions
-        139, // number_of_image blocks;
-        C64B, // palette
+        139,    // number_of_image blocks;
+        C64B    // palette
     },
 
     {
         "Temple of Terror",
         TEMPLE_OF_TERROR,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         TEMPLE_OF_TERROR,
 
-        0x4b9d,    // dictionary
-        0x50d4,    // tokens
-        0x53b3,    // start_of_room_descriptions
-        0x5c4f,    // start_of_item_descriptions
-        0x4804,    // automatics
-        0x38a4,    // actions
-        0x465c,    // start_of_room_connections
-        0x1e45,    // start_of_flags
-        0x4594,    // start_of_item_locations
-        0x667d,    // start_of_messages
-        0x75d0,    // second message bank
+        0x4b9d, // dictionary
+        0x50d4, // tokens
+        0x53b3, // start_of_room_descriptions
+        0x5c4f, // start_of_item_descriptions
+        0x4804, // automatics
+        0x38a4, // actions
+        0x465c, // start_of_room_connections
+        0x1e45, // start_of_flags
+        0x4594, // start_of_item_locations
+        0x667d, // start_of_messages
+        0x75d0, // second message bank
 
         0x83cb, // start_of_characters;
         0x8a33, // start_of_image_blocks;
         0x3837, // image patterns lookup table;
-        0x12, // number of patterns
-        0xaa, // patterns end marker
+        0x0012, // number of patterns
+        0x00aa, // patterns end marker
         0x7b75, // start of room image instructions
-        143, // number_of_image blocks;
-        ZXOPT, // palette
+        143,    // number_of_image blocks;
+        ZXOPT   // palette
     },
 
     {
         "Temple of Terror text only version",
         TOT_TEXT_ONLY,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         TEMPLE_OF_TERROR,
 
-        0x4ba2,    // dictionary
-        0x50d9,    // tokens
-        0x7a2a,    // start_of_room_descriptions
-        0x5419,    // start_of_item_descriptions
-        0x4809,    // automatics
-        0x38a9,    // actions
-        0x4661,    // start_of_room_connections
-        0x21bf,    // start_of_flags
-        0x4599,    // start_of_item_locations
-        0x5fd9,    // start_of_messages
-        0x73b7,    // second message bank
+        0x4ba2, // dictionary
+        0x50d9, // tokens
+        0x7a2a, // start_of_room_descriptions
+        0x5419, // start_of_item_descriptions
+        0x4809, // automatics
+        0x38a9, // actions
+        0x4661, // start_of_room_connections
+        0x21bf, // start_of_flags
+        0x4599, // start_of_item_locations
+        0x5fd9, // start_of_messages
+        0x73b7, // second message bank
 
-        0, // start_of_characters;
-        0, // start_of_image_blocks;
-        0, // image patterns lookup table;
-        0, // number of patterns
-        0, // patterns end marker
-        0, // start of room image instructions
-        0, // number_of_image blocks;
-        0, // palette
+        0,      // start_of_characters;
+        0,      // start_of_image_blocks;
+        0,      // image patterns lookup table;
+        0,      // number of patterns
+        0,      // patterns end marker
+        0,      // start of room image instructions
+        0,      // number_of_image blocks;
+        0       // palette
     },
 
     {
         "Temple of Terror combined version",
         TOT_HYBRID,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         TEMPLE_OF_TERROR,
 
-        0x4ba2,    // dictionary
-        0x50d9,    // tokens
-        0x7a2a,    // start_of_room_descriptions
-        0x5419,    // start_of_item_descriptions
-        0x4809,    // automatics
-        0x38a9,    // actions
-        0x4661,    // start_of_room_connections
-        0x21bf,    // start_of_flags
-        0x4599,    // start_of_item_locations
-        0x5fd9,    // start_of_messages
-        0x73b7,    // second message bank
+        0x4ba2, // dictionary
+        0x50d9, // tokens
+        0x7a2a, // start_of_room_descriptions
+        0x5419, // start_of_item_descriptions
+        0x4809, // automatics
+        0x38a9, // actions
+        0x4661, // start_of_room_connections
+        0x21bf, // start_of_flags
+        0x4599, // start_of_item_locations
+        0x5fd9, // start_of_messages
+        0x73b7, // second message bank
 
         0x83cb, // start_of_characters;
         0x8a33, // start_of_image_blocks;
         0x3837, // image patterns lookup table;
-        0x12, // number of patterns
-        0xaa, // patterns end marker
+        0x0012, // number of patterns
+        0x00aa, // patterns end marker
         0x7b75, // start of room image instructions
-        143, // number_of_image blocks;
-        ZXOPT, // palette
+        143,    // number_of_image blocks;
+        ZXOPT   // palette
     },
 
     {
         "Temple of Terror C64",
         TEMPLE_OF_TERROR_64,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         TEMPLE_OF_TERROR,
 
-        0x5b08,    // dictionary
-        0x603f,    // tokens
-        0x631e,    // start_of_room_descriptions
-        0x1301,    // start_of_item_descriptions
-        0x0f68,    // automatics
-        0x0008,    // actions
-        0x0dc0,    // start_of_room_connections
-        0x2aa6,    // start_of_flags
-        0x0cf8,    // start_of_item_locations
-        0x6bba,    // start_of_messages
-        0x7b0d,    // second message bank
+        0x5b08, // dictionary
+        0x603f, // tokens
+        0x631e, // start_of_room_descriptions
+        0x1301, // start_of_item_descriptions
+        0x0f68, // automatics
+        0x0008, // actions
+        0x0dc0, // start_of_room_connections
+        0x2aa6, // start_of_flags
+        0x0cf8, // start_of_item_locations
+        0x6bba, // start_of_messages
+        0x7b0d, // second message bank
 
         0x8048, // start_of_characters;
         0x86b0, // start_of_image_blocks;
-        0, // image patterns lookup table;
-        0, // number of patterns
-        0, // patterns end marker
+        0,      // image patterns lookup table;
+        0,      // number of patterns
+        0,      // patterns end marker
         0x4708, // start of room image instructions
-        143, // number_of_image blocks;
-        C64B, // palette
+        143,    // number_of_image blocks;
+        C64B    // palette
     },
 
     {
         "Temple of Terror C64 text only version",
         TOT_TEXT_ONLY_64,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         TEMPLE_OF_TERROR,
 
-        0x5001,    // dictionary
-        0x5538,    // tokens
-        0x7e89,    // start_of_room_descriptions
-        0x5878,    // start_of_item_descriptions
-        0x4c68,    // automatics
-        0x3d08,    // actions
-        0x4ac0,    // start_of_room_connections
-        0x0b95,    // start_of_flags
-        0x49f8,    // start_of_item_locations
-        0x6438,    // start_of_messages
-        0x7816,    // second message bank
+        0x5001, // dictionary
+        0x5538, // tokens
+        0x7e89, // start_of_room_descriptions
+        0x5878, // start_of_item_descriptions
+        0x4c68, // automatics
+        0x3d08, // actions
+        0x4ac0, // start_of_room_connections
+        0x0b95, // start_of_flags
+        0x49f8, // start_of_item_locations
+        0x6438, // start_of_messages
+        0x7816, // second message bank
 
-        0, // start_of_characters;
-        0, // start_of_image_blocks;
-        0, // image patterns lookup table;
-        0, // number of patterns
-        0, // patterns end marker
-        0, // start of room image instructions
-        0, // number_of_image blocks;
-        C64B, // palette
+        0,      // start_of_characters;
+        0,      // start_of_image_blocks;
+        0,      // image patterns lookup table;
+        0,      // number of patterns
+        0,      // patterns end marker
+        0,      // start of room image instructions
+        0,      // number_of_image blocks;
+        C64B    // palette
     },
 
     {
         "Temple of Terror C64 combined version",
         TOT_HYBRID_64,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         TEMPLE_OF_TERROR,
 
-        0x5001,    // dictionary
-        0x5538,    // tokens
-        0x7e89,    // start_of_room_descriptions
-        0x5878,    // start_of_item_descriptions
-        0x4c68,    // automatics
-        0x3d08,    // actions
-        0x4ac0,    // start_of_room_connections
-        0x0b95,    // start_of_flags
-        0x49f8,    // start_of_item_locations
-        0x6438,    // start_of_messages
-        0x7816,    // second message bank
+        0x5001, // dictionary
+        0x5538, // tokens
+        0x7e89, // start_of_room_descriptions
+        0x5878, // start_of_item_descriptions
+        0x4c68, // automatics
+        0x3d08, // actions
+        0x4ac0, // start_of_room_connections
+        0x0b95, // start_of_flags
+        0x49f8, // start_of_item_locations
+        0x6438, // start_of_messages
+        0x7816, // second message bank
 
         0x8888, // start_of_characters;
         0x8ef0, // start_of_image_blocks;
-        0, // image patterns lookup table;
-        0, // number of patterns
-        0, // patterns end marker
+        0,      // image patterns lookup table;
+        0,      // number of patterns
+        0,      // patterns end marker
         0x16ea, // start of room image instructions
-        143, // number_of_image blocks;
-        C64B, // palette
+        143,    // number_of_image blocks;
+        C64B    // palette
     },
 
     {
         "Kayleth",
         KAYLETH,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         KAYLETH,
 
-        0x5323,    // dictionary
-        0x7fee,    // tokens
-        0x6eb3,    // start_of_room_descriptions
-        0x7870,    // start_of_item_descriptions
-        0x4f4d,    // automatics
-        0x3a48,    // actions
-        0x4de0,    // start_of_room_connections
-        0x20f3,    // start_of_flags
-        0x4d5f,    // start_of_item_locations
-        0x5a99,    // start_of_messages
-        0x769d,    // second message bank
+        0x5323, // dictionary
+        0x7fee, // tokens
+        0x6eb3, // start_of_room_descriptions
+        0x7870, // start_of_item_descriptions
+        0x4f4d, // automatics
+        0x3a48, // actions
+        0x4de0, // start_of_room_connections
+        0x20f3, // start_of_flags
+        0x4d5f, // start_of_item_locations
+        0x5a99, // start_of_messages
+        0x769d, // second message bank
 
         0x95f0, // start_of_characters;
         0x9ce0, // start_of_image_blocks;
         0x38B6, // image patterns lookup table;
-        0x1f, // number of patterns
-        0x8e, // patterns end marker
+        0x1f,   // number of patterns
+        0x8e,   // patterns end marker
         0x8279, // start of room image instructions
-        210, // number_of_image blocks;
-        ZXOPT, // palette
+        210,    // number_of_image blocks;
+        ZXOPT   // palette
     },
 
     {
         "Kayleth C64",
         KAYLETH_64,
-        HEMAN_TYPE,                 // type
+        HEMAN_TYPE, // type
         KAYLETH,
 
-        0x175f,    // dictionary
-        0xbace,    // tokens
-        0xa993,    // start_of_room_descriptions
-        0xb350,    // start_of_item_descriptions
-        0x1389,    // automatics
-        0x8074,    // actions
-        0x940c,    // start_of_room_connections
-        0x2a81,    // start_of_flags
-        0x938b,    // start_of_item_locations
-        0x9579,    // start_of_messages
-        0xb17d,    // second message bank
+        0x175f, // dictionary
+        0xbace, // tokens
+        0xa993, // start_of_room_descriptions
+        0xb350, // start_of_item_descriptions
+        0x1389, // automatics
+        0x8074, // actions
+        0x940c, // start_of_room_connections
+        0x2a81, // start_of_flags
+        0x938b, // start_of_item_locations
+        0x9579, // start_of_messages
+        0xb17d, // second message bank
 
         0xc028, // start_of_characters;
         0x5b28, // start_of_image_blocks;
-        0, // image patterns lookup table;
-        0, // number of patterns
-        0, // patterns end marker
+        0,      // image patterns lookup table;
+        0,      // number of patterns
+        0,      // patterns end marker
         0x0012, // start of room image instructions
-        210, // number_of_image blocks;
-        C64B, // palette
+        210,    // number_of_image blocks;
+        C64B    // palette
     },
+// clang-format on
 
-    {
-        "Unknown game",
+    { "Unknown game",
         UNKNOWN_GAME,
         NO_TYPE,
         UNKNOWN_GAME,
-        0,0,0,0,0,0,0,0,
-        0,0,0,0,0,0,0,0,
-        0,0,0,0
-    }
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0 }
 };

--- a/terps/taylor/layouttext.c
+++ b/terps/taylor/layouttext.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "utility.h"
+
 #include "layouttext.h"
 
 static int FindBreak(const char *buf, int pos, int columns)

--- a/terps/taylor/loadtotpicture.c
+++ b/terps/taylor/loadtotpicture.c
@@ -10,26 +10,29 @@
 
 #include <stdlib.h>
 
-#include "loadtotpicture.h"
 #include "extracttape.h"
+#include "loadtotpicture.h"
 #include "utility.h"
 
 static uint8_t *mem;
 
-static uint16_t push(uint16_t reg, uint16_t SP) {
+static uint16_t push(uint16_t reg, uint16_t SP)
+{
     SP -= 2;
     mem[SP] = reg & 0xff;
     mem[SP + 1] = reg >> 8;
     return SP;
 }
 
-static uint16_t pop(uint16_t *SP) {
+static uint16_t pop(uint16_t *SP)
+{
     uint16_t reg = mem[*SP] + mem[*SP + 1] * 256;
     *SP += 2;
     return reg;
 }
 
-static int parity(uint8_t x) {
+static int parity(uint8_t x)
+{
     int bitsset = 0;
     for (int i = 0; i < 8; i++)
         if (x & (1 << i))
@@ -44,12 +47,14 @@ static int AddressIndex = 0;
 /* to a screen adress pulled from the list we create here */
 
 /* Here we add another screen address to the address list array */
-static void addtoarray(uint16_t val) {
+static void addtoarray(uint16_t val)
+{
     DrawAdresses[AddressIndex++] = val;
 }
 
 /* Here we add another attribute address to the address list array */
-static void addcolour(uint16_t addr, uint8_t IYh) { // COLOUR_LOAD
+static void addcolour(uint16_t addr, uint8_t IYh)
+{ // COLOUR_LOAD
     uint8_t msb = addr >> 8;
     if (!parity(IYh))
         msb = msb ^ 0xff; // CPL
@@ -62,7 +67,8 @@ static void addcolour(uint16_t addr, uint8_t IYh) { // COLOUR_LOAD
 
 /* Here we get the address in screen memory representing one line down */
 /* or up from addr, depending on the parity of the IYh variable */
-static uint16_t nextlineaddr(uint16_t addr, uint8_t IYh) {
+static uint16_t nextlineaddr(uint16_t addr, uint8_t IYh)
+{
     uint8_t msb = addr >> 8;
     uint8_t lsb = addr & 0xff;
     // byte down
@@ -89,7 +95,8 @@ static uint16_t nextlineaddr(uint16_t addr, uint8_t IYh) {
 uint16_t globalIY, globalBC, globalDE, globalHL;
 uint8_t globalA;
 
-static void registers_on_stack(uint8_t ack, uint16_t IY, uint16_t BC, uint16_t DE, uint16_t HL, uint8_t D) {
+static void registers_on_stack(uint8_t ack, uint16_t IY, uint16_t BC, uint16_t DE, uint16_t HL, uint8_t D)
+{
     uint16_t SP = D * 11 + 0xee57;
     // D can be 1, 2 or 3, selecting a different "slot" at 0xee62, 0xee6d or 0xee78 respectively
     SP = push(IY, SP);
@@ -101,7 +108,8 @@ static void registers_on_stack(uint8_t ack, uint16_t IY, uint16_t BC, uint16_t D
 }
 
 /* Here we determine in which direction to go for the next screen byte */
-static uint8_t styler(uint8_t ack, uint16_t *IY, uint16_t *HL, uint16_t *DE, uint16_t *BC) { // DIRECTION_OF_LOAD
+static uint8_t styler(uint8_t ack, uint16_t *IY, uint16_t *HL, uint16_t *DE, uint16_t *BC)
+{ // DIRECTION_OF_LOAD
     uint16_t SP = ack * 11 + 0xee4d;
     // A can be 1, 2 or 3, selecting a different "slot" at 0xee58, 0xee63 or 0xee6e, respectively
     uint16_t AF = pop(&SP);
@@ -157,7 +165,8 @@ static uint8_t styler(uint8_t ack, uint16_t *IY, uint16_t *HL, uint16_t *DE, uin
     return 0xff;
 }
 
-static void address_table(void) {
+static void address_table(void)
+{
     uint16_t IY = 0x032d;
     uint16_t IX = 0xeeab;
     uint16_t DE2, BC2, HL2;
@@ -195,7 +204,8 @@ static void address_table(void) {
     } while (counter != 0);
 }
 
-uint8_t *LoadAlkatrazPicture(uint8_t *memimage, uint8_t *file) {
+uint8_t *LoadAlkatrazPicture(uint8_t *memimage, uint8_t *file)
+{
     mem = memimage;
     DrawAdresses = MemAlloc(6912 * sizeof(uint16_t));
     address_table();

--- a/terps/taylor/parseinput.c
+++ b/terps/taylor/parseinput.c
@@ -5,16 +5,16 @@
 //  Created by Petter Sjölund on 2022-06-04.
 //
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "glk.h"
 
-#include "taylor.h"
-#include "utility.h"
 #include "extracommands.h"
 #include "parseinput.h"
+#include "taylor.h"
+#include "utility.h"
 
 // Input separated into word strings
 char **InputWordStrings = NULL;
@@ -27,7 +27,8 @@ int WordsInInput = 0;
 // The index in InputWordStrings of the next command
 int WordIndex = 0;
 
-void FreeInputWords(void) {
+void FreeInputWords(void)
+{
     WordIndex = 0;
     if (InputWordStrings != NULL) {
         for (int i = 0; i < WordsInInput && InputWordStrings[i] != NULL; i++) {
@@ -171,32 +172,32 @@ int ParseWord(char *p)
     unsigned char *words = FileImage + VerbBase;
     int i;
 
-    if(len >= 4) {
+    if (len >= 4) {
         memcpy(buf, p, 4);
         buf[4] = 0;
     } else {
         memcpy(buf, p, len);
         memset(buf + len, ' ', 4 - len);
     }
-    for(i = 0; i < 4; i++) {
-        if(buf[i] == 0)
+    for (i = 0; i < 4; i++) {
+        if (buf[i] == 0)
             break;
-        if(islower(buf[i]))
+        if (islower(buf[i]))
             buf[i] = toupper(buf[i]);
     }
-    while(*words != 126) {
-        if(memcmp(words, buf, 4) == 0)
+    while (*words != 126) {
+        if (memcmp(words, buf, 4) == 0)
             return words[4];
-        words+=5;
+        words += 5;
     }
 
     words = FileImage + VerbBase;
     for (i = 0; Abbreviations[i] != NULL; i++) {
-        if(memcmp(Abbreviations[i], buf, 4) == 0) {
-            while(*words != 126) {
-                if(memcmp(words, AbbreviationValue[i], 4) == 0)
+        if (memcmp(Abbreviations[i], buf, 4) == 0) {
+            while (*words != 126) {
+                if (memcmp(words, AbbreviationValue[i], 4) == 0)
                     return words[4];
-                words+=5;
+                words += 5;
             }
         }
     }
@@ -205,7 +206,8 @@ int ParseWord(char *p)
 
 static const char *Delimiters[] = { ",", ".", ";", "AND", "THEN", NULL };
 
-static int IsDelimiterWord(char *word) {
+static int IsDelimiterWord(char *word)
+{
     size_t len1 = strlen(word);
     for (int i = 0; Delimiters[i] != NULL; i++) {
         size_t len2 = strlen(Delimiters[i]);
@@ -224,7 +226,8 @@ static int IsDelimiterWord(char *word) {
     return 0;
 }
 
-static int FindNextCommandDelimiter(void) {
+static int FindNextCommandDelimiter(void)
+{
     if (WordIndex >= WordsInInput - 1 || WordsInInput < 2)
         return 0;
     while (++WordIndex < WordsInInput) {
@@ -258,8 +261,7 @@ void Parser(void)
 
     int wn = 0;
 
-    for (i = 0; i < 5 && WordIndex + i < WordsInInput; i++)
-    {
+    for (i = 0; i < 5 && WordIndex + i < WordsInInput; i++) {
         Word[wn] = ParseWord(InputWordStrings[WordIndex + i]);
         /* Hack for Blizzard Pass verbs */
         if (CurrentGame == BLIZZARD_PASS && wn == 0) {
@@ -281,7 +283,7 @@ void Parser(void)
             if (Word[1] == 106 && ObjectLoc[46] == MyLoc)
                 Word[1] = 121;
         }
-        if(Word[wn]) {
+        if (Word[wn]) {
             debug_print("Word %d is %d\n", wn, Word[wn]);
             WordPositions[wn] = WordIndex + i;
             wn++;
@@ -291,7 +293,7 @@ void Parser(void)
             debug_print("Word at position %d, %s, was not recognized\n", WordIndex + i, InputWordStrings[WordIndex + i]);
         }
     }
-    for(i = wn; i < 5; i++) {
+    for (i = wn; i < 5; i++) {
         Word[i] = 0;
         WordPositions[i] = 0;
     }

--- a/terps/taylor/player.c
+++ b/terps/taylor/player.c
@@ -5,30 +5,29 @@
 //  Created by Petter Sjölund on 2022-04-05.
 //
 
+#include <ctype.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
+#include <strings.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <stdarg.h>
-#include <strings.h>
 
 #include "glk.h"
 #ifdef SPATTERLIGHT
 #include "glkimp.h"
 #endif
-#include "glkstart.h"
-#include "restorestate.h"
-#include "decompressz80.h"
-#include "extracttape.h"
-#include "decrypttotloader.h"
-#include "utility.h"
-#include "sagadraw.h"
-#include "extracommands.h"
 #include "c64decrunch.h"
+#include "decompressz80.h"
+#include "decrypttotloader.h"
+#include "extracommands.h"
+#include "extracttape.h"
+#include "glkstart.h"
 #include "parseinput.h"
+#include "restorestate.h"
+#include "sagadraw.h"
+#include "utility.h"
 
 #include "taylor.h"
 
@@ -107,7 +106,7 @@ int DeferredGoto = 0;
  */
 static unsigned char WordMap[256][5];
 
-static char *Condition[]={
+static char *Condition[] = {
     "<ERROR>",
     "AT",
     "NOTAT",
@@ -142,7 +141,7 @@ static char *Condition[]={
     "COND31",
 };
 
-static char *Action[]={
+static char *Action[] = {
     "<ERROR>",
     "LOAD?",
     "QUIT",
@@ -151,7 +150,7 @@ static char *Action[]={
     "SAVE",
     "DROPALL",
     "LOOK",
-    "OK",		/* Guess */
+    "OK", /* Guess */
     "GET",
     "DROP",
     "GOTO",
@@ -168,12 +167,12 @@ static char *Action[]={
     "LET",
     "ADD",
     "SUB",
-    "PUT",		/* ?? */
+    "PUT", /* ?? */
     "SWAP",
     "SWAPF",
     "MEANS",
     "PUTWITH",
-    "BEEP",		/* Rebel Planet at least */
+    "BEEP", /* Rebel Planet at least */
     "REFRESH?",
     "RAMSAVE",
     "RAMLOAD",
@@ -200,27 +199,27 @@ static void LoadWordTable(void)
 {
     unsigned char *p = FileImage + VerbBase;
 
-    while(1) {
-        if(p[4] == 255)
+    while (1) {
+        if (p[4] == 255)
             break;
-        if(WordMap[p[4]][0] == 0)
+        if (WordMap[p[4]][0] == 0)
             memcpy(WordMap[p[4]], p, 4);
-        p+=5;
+        p += 5;
     }
 }
 
 static void PrintWord(unsigned char word)
 {
-    if(word == 126)
+    if (word == 126)
         fprintf(stderr, "*	  ");
-    else if(word == 0 || WordMap[word][0] == 0)
+    else if (word == 0 || WordMap[word][0] == 0)
         fprintf(stderr, "%-4d ", word);
     else {
         fprintf(stderr, "%c%c%c%c ",
-                WordMap[word][0],
-                WordMap[word][1],
-                WordMap[word][2],
-                WordMap[word][3]);
+            WordMap[word][0],
+            WordMap[word][1],
+            WordMap[word][2],
+            WordMap[word][3]);
     }
 }
 
@@ -261,7 +260,7 @@ static char Q3Condition[] = {
     0,
 };
 
-static char Q3Action[]={
+static char Q3Action[] = {
     ACTIONERROR,
     SWITCHINVENTORY, /* Swap inventory and dark flag */
     DIAGNOSE, /* Print Reed Richards' watch status message */
@@ -318,8 +317,8 @@ static char Q3Action[]={
 size_t FindCode(const char *x, size_t base, size_t len)
 {
     unsigned char *p = FileImage + base;
-    while(p < FileImage + FileImageLen - len) {
-        if(memcmp(p, x, len) == 0)
+    while (p < FileImage + FileImageLen - len) {
+        if (memcmp(p, x, len) == 0)
             return p - FileImage;
         p++;
     }
@@ -332,17 +331,18 @@ static size_t FindFlags(void)
 
     /* Questprobe */
     pos = FindCode("\xE7\x97\x51\x95\x5B\x7E\x5D\x7E\x76\x93", 0, 10);
-    if(pos == -1) {
+    if (pos == -1) {
         /* Look for the flag initial block copy */
-        pos = FindCode("\x01\x06\x00\xED\xB0\xC9\x00\xFD", 0,8 );
-        if(pos == -1) {
+        pos = FindCode("\x01\x06\x00\xED\xB0\xC9\x00\xFD", 0, 8);
+        if (pos == -1) {
             if (Game)
                 return Game->start_of_flags + FileBaselineOffset;
             else {
                 fprintf(stderr, "Cannot find initial flag data.\n");
                 glk_exit();
             }
-        } else return pos + 5;
+        } else
+            return pos + 5;
     }
     return pos + 11;
 }
@@ -354,13 +354,13 @@ static int LooksLikeTokens(size_t pos)
     unsigned char *p = FileImage + pos;
     int n = 0;
     int t = 0;
-    while(n < 512) {
+    while (n < 512) {
         unsigned char c = p[n] & 0x7F;
-        if(c >= 'a' && c <= 'z')
+        if (c >= 'a' && c <= 'z')
             t++;
         n++;
     }
-    if(t > 300)
+    if (t > 300)
         return 1;
     return 0;
 }
@@ -369,11 +369,11 @@ static void TokenClassify(size_t pos)
 {
     unsigned char *p = FileImage + pos;
     int n = 0;
-    while(n++ < 256) {
+    while (n++ < 256) {
         do {
-            if(*p == 0x5E || *p == 0x7E)
+            if (*p == 0x5E || *p == 0x7E)
                 Version = 0;
-        } while(!(*p++ & 0x80));
+        } while (!(*p++ & 0x80));
     }
 }
 
@@ -383,42 +383,42 @@ static size_t FindTokens(void)
     size_t pos = 0;
 
     if (Game)
-        switch(CurrentGame) {
-            case TOT_TEXT_ONLY_64:
-            case TOT_HYBRID_64:
-                if ((pos = FindCode("\x80\x59\x6f\x75\x20\x61\x72\x65\x20\x69", 0, 10)) != -1)
-                    return pos;
-                break;
-            case TEMPLE_OF_TERROR_64:
-                if ((pos = FindCode("\x80\x20\x54\x68\x65\x72\x65\x20\x69\x73", 0, 10)) != -1)
-                    return pos;
-                break;
-            case REBEL_PLANET_64:
-                if  ((pos = FindCode("\xa7\x2e\xfe\x20\xfe\x2c\xfe\x21\xfe\x3f", 0, 10)) != -1)
-                    return pos;
-                break;
-            case QUESTPROBE3_64:
-                if ((pos = FindCode("\x61\xa0\x64\xa0\x65\xa0\x67\xa0\x69\xa0", 0, 10)) != -1)
-                    return pos;
-                break;
-            case HEMAN_64:
-            case KAYLETH_64:
-                if ((pos = FindCode("\x80\x59\x6f\x75\x20\x61\x72\x65\x20\x69", 0, 10)) != -1)
-                    return pos;
-                break;
-            default:
-                break;
+        switch (CurrentGame) {
+        case TOT_TEXT_ONLY_64:
+        case TOT_HYBRID_64:
+            if ((pos = FindCode("\x80\x59\x6f\x75\x20\x61\x72\x65\x20\x69", 0, 10)) != -1)
+                return pos;
+            break;
+        case TEMPLE_OF_TERROR_64:
+            if ((pos = FindCode("\x80\x20\x54\x68\x65\x72\x65\x20\x69\x73", 0, 10)) != -1)
+                return pos;
+            break;
+        case REBEL_PLANET_64:
+            if ((pos = FindCode("\xa7\x2e\xfe\x20\xfe\x2c\xfe\x21\xfe\x3f", 0, 10)) != -1)
+                return pos;
+            break;
+        case QUESTPROBE3_64:
+            if ((pos = FindCode("\x61\xa0\x64\xa0\x65\xa0\x67\xa0\x69\xa0", 0, 10)) != -1)
+                return pos;
+            break;
+        case HEMAN_64:
+        case KAYLETH_64:
+            if ((pos = FindCode("\x80\x59\x6f\x75\x20\x61\x72\x65\x20\x69", 0, 10)) != -1)
+                return pos;
+            break;
+        default:
+            break;
         }
 
     do {
         pos = FindCode("\x47\xB7\x28\x0B\x2B\x23\xCB\x7E", pos + 1, 8);
-        if(pos == -1) {
+        if (pos == -1) {
             /* Questprobe */
             pos = FindCode("\x58\x58\x58\x58\xFF", 0, 5);
-            if(pos == -1) {
+            if (pos == -1) {
                 /* Last resort */
                 addr = FindCode("You are in ", 0, 11) - 1;
-                if(addr == -1) {
+                if (addr == -1) {
                     if (Game)
                         return Game->start_of_tokens + FileBaselineOffset;
                     fprintf(stderr, "Unable to find token table.\n");
@@ -428,8 +428,8 @@ static size_t FindTokens(void)
             } else
                 return pos + 6;
         }
-        addr = (FileImage[pos-1] <<8 | FileImage[pos-2]) - 0x4000 + FileBaselineOffset;
-    } while(LooksLikeTokens(addr) == 0);
+        addr = (FileImage[pos - 1] << 8 | FileImage[pos - 2]) - 0x4000 + FileBaselineOffset;
+    } while (LooksLikeTokens(addr) == 0);
     TokenClassify(addr);
     return addr;
 }
@@ -450,8 +450,7 @@ void WriteToRoomDescriptionStream(const char *fmt, ...)
 
 static void OutWrite(char c)
 {
-    if(isalpha(c) && Upper)
-    {
+    if (isalpha(c) && Upper) {
         c = toupper(c);
         Upper = 0;
     }
@@ -460,9 +459,9 @@ static void OutWrite(char c)
 
 void OutFlush(void)
 {
-    if(LastChar)
+    if (LastChar)
         OutWrite(LastChar);
-    if(PendSpace && LastChar != '\n' && !FirstAfterInput)
+    if (PendSpace && LastChar != '\n' && !FirstAfterInput)
         OutWrite(' ');
     LastChar = 0;
     PendSpace = 0;
@@ -490,7 +489,7 @@ int JustWrotePeriod = 0;
 
 void OutChar(char c)
 {
-    if(c == ']')
+    if (c == ']')
         c = '\n';
 
     if (c == '.') {
@@ -502,7 +501,7 @@ void OutChar(char c)
         }
         PendSpace = 0;
     } else {
-        if (periods && !JustWrotePeriod && c !=',' && c != '?' && c != '!') {
+        if (periods && !JustWrotePeriod && c != ',' && c != '?' && c != '!') {
             if (periods == 2)
                 periods = 1;
             for (int i = 0; i < periods; i++) {
@@ -517,7 +516,7 @@ void OutChar(char c)
         periods = 0;
     }
 
-    if(c == ' ') {
+    if (c == ' ') {
         PendSpace = 1;
         return;
     }
@@ -530,7 +529,7 @@ void OutChar(char c)
         }
         PendSpace = 0;
     }
-    if(LastChar) {
+    if (LastChar) {
         if (isspace(LastChar))
             PendSpace = 0;
         if (LastChar == '.' && JustWrotePeriod) {
@@ -539,7 +538,7 @@ void OutChar(char c)
             OutWrite(LastChar);
         }
     }
-    if(PendSpace) {
+    if (PendSpace) {
         if (JustWrotePeriod && BaseGame != KAYLETH)
             Upper = 1;
         OutWrite(' ');
@@ -564,7 +563,7 @@ static void OutKillSpace()
 
 void OutString(char *p)
 {
-    while(*p)
+    while (*p)
         OutChar(*p++);
 }
 
@@ -574,8 +573,8 @@ static unsigned char *TokenText(unsigned char n)
     if (Version == QUESTPROBE3_TYPE)
         n -= 0x7b;
 
-    while(n > 0 && p < EndOfData) {
-        while((*p & 0x80) == 0)
+    while (n > 0 && p < EndOfData) {
+        while ((*p & 0x80) == 0)
             p++;
         n--;
         p++;
@@ -583,7 +582,8 @@ static unsigned char *TokenText(unsigned char n)
     return p;
 }
 
-void Q3PrintChar(uint8_t c) { // Print character
+void Q3PrintChar(uint8_t c)
+{ // Print character
     if (c == 0x0d)
         return;
 
@@ -617,7 +617,7 @@ static void PrintToken(unsigned char n)
             Q3PrintChar(c & 0x7F);
         else
             OutChar(c & 0x7F);
-    } while(p < EndOfData && !(c & 0x80));
+    } while (p < EndOfData && !(c & 0x80));
 }
 
 static void Q3PrintText(unsigned char *p, int n)
@@ -629,7 +629,7 @@ static void Q3PrintText(unsigned char *p, int n)
         n--;
         p++;
     }
-    do  {
+    do {
         if (*p == 0x18)
             return;
         if (*p >= 0x7b) // if c is >= 0x7b it is a token
@@ -641,15 +641,15 @@ static void Q3PrintText(unsigned char *p, int n)
 
 static void PrintText1(unsigned char *p, int n)
 {
-    while(n > 0) {
-        while(p < EndOfData && *p != 0x7E && *p != 0x5E)
+    while (n > 0) {
+        while (p < EndOfData && *p != 0x7E && *p != 0x5E)
             p++;
         n--;
         p++;
     }
-    while(p < EndOfData && *p != 0x7E && *p != 0x5E)
+    while (p < EndOfData && *p != 0x7E && *p != 0x5E)
         PrintToken(*p++);
-    if(*p == 0x5E) {
+    if (*p == 0x5E) {
         PendSpace = 1;
     }
 }
@@ -666,13 +666,13 @@ static void PrintText0(unsigned char *p, int n)
         return;
     unsigned char *t = NULL;
     unsigned char c;
-    while(1) {
-        if(t == NULL)
+    while (1) {
+        if (t == NULL)
             t = TokenText(*p++);
         c = *t & 0x7F;
-        if(c == 0x5E || c == 0x7E) {
-            if(n == 0) {
-                if(c == 0x5E) {
+        if (c == 0x5E || c == 0x7E) {
+            if (n == 0) {
+                if (c == 0x5E) {
                     PendSpace = 1;
                 }
                 return;
@@ -685,18 +685,18 @@ static void PrintText0(unsigned char *p, int n)
             }
             OutChar(c);
         }
-        if(t >= EndOfData || (*t++ & 0x80))
+        if (t >= EndOfData || (*t++ & 0x80))
             t = NULL;
     }
 }
 
 static void PrintText(unsigned char *p, int n)
 {
-    if (Version == REBEL_PLANET_TYPE) {	/* In stream end markers */
+    if (Version == REBEL_PLANET_TYPE) { /* In stream end markers */
         PrintText0(p, n);
     } else if (Version == QUESTPROBE3_TYPE) {
         Q3PrintText(p, n);
-    } else {			/* Out of stream end markers (faster) */
+    } else { /* Out of stream end markers (faster) */
         PrintText1(p, n);
     }
 }
@@ -753,16 +753,14 @@ static void PrintRoom(unsigned char room)
     PrintText(p, room);
 }
 
-
 static void PrintNumber(unsigned char n)
 {
     char buf[4];
     char *p = buf;
     snprintf(buf, sizeof buf, "%d", (int)n);
-    while(*p)
+    while (*p)
         OutChar(*p++);
 }
-
 
 static unsigned char Destroyed()
 {
@@ -803,14 +801,15 @@ static int CarryItem(void)
     if (Version == QUESTPROBE3_TYPE)
         return 1;
     /* Flag 5: items carried, flag 4: max carried */
-    if(Flag[5] == Flag[4] && CurrentGame != BLIZZARD_PASS)
+    if (Flag[5] == Flag[4] && CurrentGame != BLIZZARD_PASS)
         return 0;
-    if(Flag[5] < 255)
+    if (Flag[5] < 255)
         Flag[5]++;
     return 1;
 }
 
-static int DarkFlag(void) {
+static int DarkFlag(void)
+{
     if (Version == QUESTPROBE3_TYPE)
         return 43;
     return 1;
@@ -818,14 +817,14 @@ static int DarkFlag(void) {
 
 static void DropItem(void)
 {
-    if(Version != QUESTPROBE3_TYPE && Flag[5] > 0)
+    if (Version != QUESTPROBE3_TYPE && Flag[5] > 0)
         Flag[5]--;
 }
 
 static void Put(unsigned char obj, unsigned char loc)
 {
     /* Will need refresh logics somewhere, maybe here ? */
-    if(ObjectLoc[obj] == MyLoc || loc == MyLoc)
+    if (ObjectLoc[obj] == MyLoc || loc == MyLoc)
         Redraw = 1;
     ObjectLoc[obj] = loc;
 }
@@ -835,7 +834,7 @@ static int Present(unsigned char obj)
     if (obj >= NumObjects())
         return 0;
     unsigned char v = ObjectLoc[obj];
-    if(v == MyLoc|| v == Worn() || v == Carried() || (Version == QUESTPROBE3_TYPE && v == OtherGuyInv && OtherGuyLoc == MyLoc))
+    if (v == MyLoc || v == Worn() || v == Carried() || (Version == QUESTPROBE3_TYPE && v == OtherGuyInv && OtherGuyLoc == MyLoc))
         return 1;
     return 0;
 }
@@ -843,8 +842,8 @@ static int Present(unsigned char obj)
 static int Chance(int n)
 {
     unsigned long v = rand() >> 12;
-    v%=100;
-    if(v > n)
+    v %= 100;
+    if (v > n)
         return 0;
     return 1;
 }
@@ -873,23 +872,24 @@ static void NewGame(void)
     PrintedOK = 1;
 }
 
-static int GetFileLength(strid_t stream) {
+static int GetFileLength(strid_t stream)
+{
     glk_stream_set_position(stream, 0, seekmode_End);
     return glk_stream_get_position(stream);
 }
 
 int YesOrNo(void)
 {
-    while(1) {
+    while (1) {
         uint8_t c = WaitCharacter();
         if (c == 250)
             c = 0;
         OutChar(c);
         OutChar('\n');
         OutFlush();
-        if(c == 'n' || c == 'N')
+        if (c == 'n' || c == 'N')
             return 0;
-        if(c == 'y' || c == 'Y')
+        if (c == 'y' || c == 'Y')
             return 1;
         OutString("Please answer Y or N.\n");
         OutFlush();
@@ -898,49 +898,46 @@ int YesOrNo(void)
 
 int LoadGame(void)
 {
-        frefid_t fileref = glk_fileref_create_by_prompt (fileusage_SavedGame,
-                                                         filemode_Read, 0);
-        if (!fileref)
-        {
-            OutFlush();
-            return 0;
-        }
+    frefid_t fileref = glk_fileref_create_by_prompt(fileusage_SavedGame,
+        filemode_Read, 0);
+    if (!fileref) {
+        OutFlush();
+        return 0;
+    }
 
-        /*
+    /*
          * Reject the file reference if we're expecting to read from it, and the
          * referenced file doesn't exist.
          */
-        if (!glk_fileref_does_file_exist (fileref))
-        {
-            OutString("Unable to open file.\n");
-            glk_fileref_destroy (fileref);
-            OutFlush();
-            return 0;
-        }
+    if (!glk_fileref_does_file_exist(fileref)) {
+        OutString("Unable to open file.\n");
+        glk_fileref_destroy(fileref);
+        OutFlush();
+        return 0;
+    }
 
-        strid_t stream = glk_stream_open_file(fileref, filemode_Read, 0);
-        if (!stream)
-        {
-            OutString("Unable to open file.\n");
-            glk_fileref_destroy (fileref);
-            OutFlush();
-            return 0;
-        }
+    strid_t stream = glk_stream_open_file(fileref, filemode_Read, 0);
+    if (!stream) {
+        OutString("Unable to open file.\n");
+        glk_fileref_destroy(fileref);
+        OutFlush();
+        return 0;
+    }
 
-        struct SavedState *state = SaveCurrentState();
+    struct SavedState *state = SaveCurrentState();
 
-        /* Restore saved game data. */
+    /* Restore saved game data. */
 
-        if (glk_get_buffer_stream(stream, (char *)Flag, 128) != 128 || glk_get_buffer_stream(stream, (char *)ObjectLoc, 256) != 256 || GetFileLength(stream) != 384) {
-            RecoverFromBadRestore(state);
-        } else {
-            glk_window_clear(Bottom);
-            Look();
-            free(state);
-        }
-        glk_stream_close (stream, NULL);
-        glk_fileref_destroy (fileref);
-        return 1;
+    if (glk_get_buffer_stream(stream, (char *)Flag, 128) != 128 || glk_get_buffer_stream(stream, (char *)ObjectLoc, 256) != 256 || GetFileLength(stream) != 384) {
+        RecoverFromBadRestore(state);
+    } else {
+        glk_window_clear(Bottom);
+        Look();
+        free(state);
+    }
+    glk_stream_close(stream, NULL);
+    glk_fileref_destroy(fileref);
+    return 1;
 }
 
 static int LoadPrompt(void)
@@ -990,11 +987,11 @@ static void Inventory(void)
     if (BaseGame != REBEL_PLANET)
         OutCaps();
     SysMessage(INVENTORY);
-    for(i = 0; i < NumObjects(); i++) {
-        if(ObjectLoc[i] == Carried() || ObjectLoc[i] == Worn()) {
+    for (i = 0; i < NumObjects(); i++) {
+        if (ObjectLoc[i] == Carried() || ObjectLoc[i] == Worn()) {
             f = 1;
             PrintObject(i);
-            if(ObjectLoc[i] == Worn()) {
+            if (ObjectLoc[i] == Worn()) {
                 OutReplace(0);
                 SysMessage(NOWWORN);
                 if (CurrentGame == REBEL_PLANET) {
@@ -1002,11 +999,10 @@ static void Inventory(void)
                     OutFlush();
                     OutChar(',');
                 }
-
             }
         }
     }
-    if(f == 0)
+    if (f == 0)
         SysMessage(NOTHING);
     else {
         OutReplace('.');
@@ -1015,26 +1011,29 @@ static void Inventory(void)
     }
 }
 
-static void AnyKey(void) {
+static void AnyKey(void)
+{
     SysMessage(HIT_ENTER);
     OutFlush();
     WaitCharacter();
 }
 
-static void Okay(void) {
+static void Okay(void)
+{
     SysMessage(OKAY);
     OutChar(' ');
     OutCaps();
     PrintedOK = 1;
 }
 
-void SaveGame(void) {
+void SaveGame(void)
+{
 
     strid_t file;
     frefid_t ref;
 
     ref = glk_fileref_create_by_prompt(fileusage_TextMode | fileusage_SavedGame,
-                                       filemode_Write, 0);
+        filemode_Write, 0);
     if (ref == NULL) {
         OutString("Save failed.\n");
         OutFlush();
@@ -1050,8 +1049,8 @@ void SaveGame(void) {
     }
 
     /* Write game state. */
-    glk_put_buffer_stream (file, (char *)Flag, 128);
-    glk_put_buffer_stream (file, (char *)ObjectLoc, 256);
+    glk_put_buffer_stream(file, (char *)Flag, 128);
+    glk_put_buffer_stream(file, (char *)ObjectLoc, 256);
     glk_stream_close(file, NULL);
     OutString("Saved.\n");
     OutFlush();
@@ -1072,7 +1071,7 @@ static void TakeAll(int start)
             PrintObject(i);
             OutReplace(0);
             OutString("......");
-            if(CarryItem() == 0) {
+            if (CarryItem() == 0) {
                 SysMessage(YOURE_CARRYING_TOO_MUCH);
                 return;
             }
@@ -1087,11 +1086,12 @@ static void TakeAll(int start)
     }
 }
 
-static void DropAll(int loud) {
+static void DropAll(int loud)
+{
     int i;
     int found = 0;
-    for(i = 0; i < NumObjects(); i++) {
-        if(ObjectLoc[i] == Carried() && ObjectLoc[i] != Worn()) {
+    for (i = 0; i < NumObjects(); i++) {
+        if (ObjectLoc[i] == Carried() && ObjectLoc[i] != Worn()) {
             if (loud) {
                 if (found)
                     OutChar('\n');
@@ -1112,18 +1112,19 @@ static void DropAll(int loud) {
     Flag[5] = 0;
 }
 
-static int GetObject(unsigned char obj) {
-    if(ObjectLoc[obj] == Carried() || ObjectLoc[obj] == Worn()) {
+static int GetObject(unsigned char obj)
+{
+    if (ObjectLoc[obj] == Carried() || ObjectLoc[obj] == Worn()) {
         SysMessage(YOU_HAVE_IT);
         return 0;
     }
     if (!(Version == QUESTPROBE3_TYPE && Flag[1] == MyLoc && ObjectLoc[obj] == Flag[3])) {
-        if(ObjectLoc[obj] != MyLoc) {
+        if (ObjectLoc[obj] != MyLoc) {
             SysMessage(YOU_DONT_SEE_IT);
             return 0;
         }
     }
-    if(CarryItem() == 0) {
+    if (CarryItem() == 0) {
         SysMessage(YOURE_CARRYING_TOO_MUCH);
         return 0;
     }
@@ -1132,13 +1133,14 @@ static int GetObject(unsigned char obj) {
     return 1;
 }
 
-static int DropObject(unsigned char obj) {
+static int DropObject(unsigned char obj)
+{
     /* FIXME: check if this is how the real game behaves */
-    if(ObjectLoc[obj] == Worn()) {
+    if (ObjectLoc[obj] == Worn()) {
         SysMessage(YOU_ARE_WEARING_IT);
         return 0;
     }
-    if(ObjectLoc[obj] != Carried()) {
+    if (ObjectLoc[obj] != Carried()) {
         SysMessage(YOU_HAVENT_GOT_IT);
         return 0;
     }
@@ -1155,12 +1157,12 @@ static void ListExits(int caps)
     int f = 0;
     p = FileImage + ExitBase;
 
-    while(*p != locw)
+    while (*p != locw)
         p++;
     p++;
-    while(*p < 0x80) {
-        if(f == 0) {
-            if(CurrentGame == BLIZZARD_PASS && LastChar == ',')
+    while (*p < 0x80) {
+        if (f == 0) {
+            if (CurrentGame == BLIZZARD_PASS && LastChar == ',')
                 LastChar = 0;
             OutCaps();
             SysMessage(EXITS);
@@ -1171,7 +1173,7 @@ static void ListExits(int caps)
         SysMessage(*p);
         p += 2;
     }
-    if(f == 1) {
+    if (f == 1) {
         OutReplace('.');
         OutChar('\n');
     }
@@ -1181,7 +1183,8 @@ static void RunStatusTable(void);
 static void DrawExtraQP3Images(void);
 extern uint8_t buffer[768][9];
 
-void Look(void) {
+void Look(void)
+{
     if (MyLoc == 0 || (BaseGame == KAYLETH && MyLoc == 91) || NoGraphics)
         CloseGraphicsWindow();
     else
@@ -1200,7 +1203,7 @@ void Look(void) {
 
     OutCaps();
 
-    if(Flag[DarkFlag()]) {
+    if (Flag[DarkFlag()]) {
         SysMessage(TOO_DARK_TO_SEE);
         OutString("\n\n");
         DrawBlack();
@@ -1211,9 +1214,9 @@ void Look(void) {
         OutString("You are ");
     PrintRoom(MyLoc);
 
-    for(i = 0; i < NumLowObjects; i++) {
-        if(ObjectLoc[i] == MyLoc) {
-            if(f == 0) {
+    for (i = 0; i < NumLowObjects; i++) {
+        if (ObjectLoc[i] == MyLoc) {
+            if (f == 0) {
                 if (Version == QUESTPROBE3_TYPE) {
                     OutReplace(0);
                     SysMessage(0);
@@ -1226,16 +1229,16 @@ void Look(void) {
             PrintObject(i);
         }
     }
-    if(f == 1 && !isalpha(LastChar))
+    if (f == 1 && !isalpha(LastChar))
         OutReplace('.');
 
     if (Version == QUESTPROBE3_TYPE) {
         ListExits(1);
     } else {
         f = 0;
-        for(; i < NumObjects(); i++) {
-            if(ObjectLoc[i] == MyLoc) {
-                if(f == 0) {
+        for (; i < NumObjects(); i++) {
+            if (ObjectLoc[i] == MyLoc) {
+                if (f == 0) {
                     /* Only the text-only and hybrid games */
                     if (BaseGame == TEMPLE_OF_TERROR
                         && CurrentGame != TEMPLE_OF_TERROR
@@ -1254,7 +1257,7 @@ void Look(void) {
                 PrintObject(i);
             }
         }
-        if(f == 1)
+        if (f == 1)
             OutReplace('.');
         else
             OutChar('.');
@@ -1293,8 +1296,8 @@ void Look(void) {
     }
 }
 
-
-static void Goto(unsigned char loc) {
+static void Goto(unsigned char loc)
+{
     if (BaseGame == QUESTPROBE3 && !PrintedOK)
         Okay();
     if (BaseGame == HEMAN && Location == 0 && loc == 1) {
@@ -1305,7 +1308,8 @@ static void Goto(unsigned char loc) {
     }
 }
 
-static void Delay(unsigned char seconds) {
+static void Delay(unsigned char seconds)
+{
     OutChar(' ');
     OutFlush();
 
@@ -1327,12 +1331,13 @@ static void Delay(unsigned char seconds) {
     glk_request_timer_events(AnimationRunning);
 }
 
-static void Wear(unsigned char obj) {
-    if(ObjectLoc[obj] == Worn()) {
+static void Wear(unsigned char obj)
+{
+    if (ObjectLoc[obj] == Worn()) {
         SysMessage(YOU_ARE_WEARING_IT);
         return;
     }
-    if(ObjectLoc[obj] != Carried()) {
+    if (ObjectLoc[obj] != Carried()) {
         SysMessage(YOU_HAVENT_GOT_IT);
         return;
     }
@@ -1340,31 +1345,35 @@ static void Wear(unsigned char obj) {
     Put(obj, Worn());
 }
 
-static void Remove(unsigned char obj) {
-    if(ObjectLoc[obj] != Worn()) {
+static void Remove(unsigned char obj)
+{
+    if (ObjectLoc[obj] != Worn()) {
         SysMessage(YOU_ARE_NOT_WEARING_IT);
         return;
     }
-    if(CarryItem() == 0) {
+    if (CarryItem() == 0) {
         SysMessage(YOURE_CARRYING_TOO_MUCH);
         return;
     }
     Put(obj, Carried());
 }
 
-static void Means(unsigned char vb, unsigned char no) {
+static void Means(unsigned char vb, unsigned char no)
+{
     Word[0] = vb;
     Word[1] = no;
 }
 
-static void Q3SwitchInvFlags(unsigned char a, unsigned char b) {
+static void Q3SwitchInvFlags(unsigned char a, unsigned char b)
+{
     if (Flag[2] == a) {
         Flag[2] = b;
         Flag[3] = a;
     }
 }
 
-static void Q3UpdateFlags(void) {
+static void Q3UpdateFlags(void)
+{
     if (ObjectLoc[7] == 253)
         ObjectLoc[7] = 254;
     if (IsThing) {
@@ -1429,49 +1438,51 @@ static void Q3UpdateFlags(void) {
 static void Q3AdjustConditions(unsigned char op, unsigned char *arg1)
 {
     switch (op) {
-        case ZERO:
-        case NOTZERO:
-        case LT:
-        case GT:
-        case EQ:
-        case NE:
-            *arg1 += 4;
-            break;
-        default:
-            break;
+    case ZERO:
+    case NOTZERO:
+    case LT:
+    case GT:
+    case EQ:
+    case NE:
+        *arg1 += 4;
+        break;
+    default:
+        break;
     }
 }
 
 static void Q3AdjustActions(unsigned char op, unsigned char *arg1, unsigned char *arg2)
 {
     switch (op) {
-        case SET:
-        case CLEAR:
-        case LET:
-        case ADD:
-        case SUB:
-            if (arg1 != NULL)
-                *arg1 += 4;
-            break;
-        case SWAPF:
-            if (arg1 != NULL)
-                *arg1 += 4;
-            if (arg2 != NULL)
-                *arg2 += 4;
-            break;
-        default:
-            break;
+    case SET:
+    case CLEAR:
+    case LET:
+    case ADD:
+    case SUB:
+        if (arg1 != NULL)
+            *arg1 += 4;
+        break;
+    case SWAPF:
+        if (arg1 != NULL)
+            *arg1 += 4;
+        if (arg2 != NULL)
+            *arg2 += 4;
+        break;
+    default:
+        break;
     }
 }
 
-static int TwoConditionParameters() {
+static int TwoConditionParameters()
+{
     if (Version == QUESTPROBE3_TYPE)
         return 16;
     else
         return 21;
 }
 
-static int TwoActionParameters() {
+static int TwoActionParameters()
+{
     if (Version == QUESTPROBE3_TYPE)
         return 18;
     else
@@ -1485,7 +1496,7 @@ static void ExecuteLineCode(unsigned char *p, int *done)
     do {
         unsigned char op = *p;
 
-        if(op & 0x80)
+        if (op & 0x80)
             break;
         p++;
         arg1 = *p++;
@@ -1499,8 +1510,7 @@ static void ExecuteLineCode(unsigned char *p, int *done)
             fprintf(stderr, "%s %d ", Condition[op], arg1);
         }
 #endif
-        if (op >= TwoConditionParameters())
-        {
+        if (op >= TwoConditionParameters()) {
             arg2 = *p++;
 #ifdef DEBUG
             fprintf(stderr, "%d ", arg2);
@@ -1512,151 +1522,151 @@ static void ExecuteLineCode(unsigned char *p, int *done)
             Q3AdjustConditions(op, &arg1);
         }
 
-        switch(op) {
-            case AT:
-                if(MyLoc == arg1)
-                    continue;
-                break;
-            case NOTAT:
-                if(MyLoc != arg1)
-                    continue;
-                break;
-            case ATGT:
-                if(MyLoc > arg1)
-                    continue;
-                break;
-            case ATLT:
-                if(MyLoc < arg1)
-                    continue;
-                break;
-            case PRESENT:
-                if(Present(arg1))
-                    continue;
-                break;
-            case HERE:
-                if(ObjectLoc[arg1] == MyLoc)
-                    continue;
-                break;
-            case ABSENT:
-                if(!Present(arg1))
-                    continue;
-                break;
-            case NOTHERE:
-                if(ObjectLoc[arg1] != MyLoc)
-                    continue;
-                break;
-            case CARRIED:
-                if(ObjectLoc[arg1] == Carried() || ObjectLoc[arg1] == Worn())
-                    continue;
-                break;
-            case NOTCARRIED:
-                if(ObjectLoc[arg1] != Carried() && ObjectLoc[arg1] != Worn())
-                    continue;
-                break;
-            case WORN:
-                if(ObjectLoc[arg1] == Worn())
-                    continue;
-                break;
-            case NOTWORN:
-                if(ObjectLoc[arg1] != Worn())
-                    continue;
-                break;
-            case NODESTROYED:
-                if(ObjectLoc[arg1] != Destroyed())
-                    continue;
-                break;
-            case DESTROYED:
-                if(ObjectLoc[arg1] == Destroyed())
-                    continue;
-                break;
-            case ZERO:
-                if (BaseGame == TEMPLE_OF_TERROR) {
-                    /* Unless we have kicked sand in the eyes of the guard, tracked by flag 63, make sure he kills us if we try to pass, by setting flag 28 to zero */
-                    if (arg1 == 28 && Flag[63] == 0 && Word[0] == 20 && Word[1] == 162)
-                        Flag[28] = 0;
-                }
-                if(Flag[arg1] == 0)
-                    continue;
-                break;
-            case NOTZERO:
-                if(Flag[arg1] != 0)
-                    continue;
-                break;
-            case WORD1:
-                if(Word[2] == arg1)
-                    continue;
-                break;
-            case WORD2:
-                if(Word[3] == arg1)
-                    continue;
-                break;
-            case WORD3:
-                if(Word[4] == arg1)
-                    continue;
-                break;
-            case CHANCE:
-                if(Chance(arg1))
-                    continue;
-                break;
-            case LT:
-                if(Flag[arg1] < arg2)
-                    continue;
-                break;
-            case GT:
-                if(Flag[arg1] > arg2)
-                    continue;
-                break;
-            case EQ:
-                /* Fix final puzzle (Flag 12 conflict) */
-                if (BaseGame == TEMPLE_OF_TERROR) {
-                    if (arg1 == 12 && arg2 == 4)
-                        arg1 = 60;
-                }
-                if(Flag[arg1] == arg2) {
-                    continue;
-                }
-                break;
-            case NE:
-                if(Flag[arg1] != arg2)
-                    continue;
-                break;
-            case OBJECTAT:
-                if(ObjectLoc[arg1] == arg2)
-                    continue;
-                break;
-            default:
-                fprintf(stderr, "Unknown condition %d.\n",
-                        op);
-                break;
+        switch (op) {
+        case AT:
+            if (MyLoc == arg1)
+                continue;
+            break;
+        case NOTAT:
+            if (MyLoc != arg1)
+                continue;
+            break;
+        case ATGT:
+            if (MyLoc > arg1)
+                continue;
+            break;
+        case ATLT:
+            if (MyLoc < arg1)
+                continue;
+            break;
+        case PRESENT:
+            if (Present(arg1))
+                continue;
+            break;
+        case HERE:
+            if (ObjectLoc[arg1] == MyLoc)
+                continue;
+            break;
+        case ABSENT:
+            if (!Present(arg1))
+                continue;
+            break;
+        case NOTHERE:
+            if (ObjectLoc[arg1] != MyLoc)
+                continue;
+            break;
+        case CARRIED:
+            if (ObjectLoc[arg1] == Carried() || ObjectLoc[arg1] == Worn())
+                continue;
+            break;
+        case NOTCARRIED:
+            if (ObjectLoc[arg1] != Carried() && ObjectLoc[arg1] != Worn())
+                continue;
+            break;
+        case WORN:
+            if (ObjectLoc[arg1] == Worn())
+                continue;
+            break;
+        case NOTWORN:
+            if (ObjectLoc[arg1] != Worn())
+                continue;
+            break;
+        case NODESTROYED:
+            if (ObjectLoc[arg1] != Destroyed())
+                continue;
+            break;
+        case DESTROYED:
+            if (ObjectLoc[arg1] == Destroyed())
+                continue;
+            break;
+        case ZERO:
+            if (BaseGame == TEMPLE_OF_TERROR) {
+                /* Unless we have kicked sand in the eyes of the guard, tracked by flag 63, make sure he kills us if we try to pass, by setting flag 28 to zero */
+                if (arg1 == 28 && Flag[63] == 0 && Word[0] == 20 && Word[1] == 162)
+                    Flag[28] = 0;
+            }
+            if (Flag[arg1] == 0)
+                continue;
+            break;
+        case NOTZERO:
+            if (Flag[arg1] != 0)
+                continue;
+            break;
+        case WORD1:
+            if (Word[2] == arg1)
+                continue;
+            break;
+        case WORD2:
+            if (Word[3] == arg1)
+                continue;
+            break;
+        case WORD3:
+            if (Word[4] == arg1)
+                continue;
+            break;
+        case CHANCE:
+            if (Chance(arg1))
+                continue;
+            break;
+        case LT:
+            if (Flag[arg1] < arg2)
+                continue;
+            break;
+        case GT:
+            if (Flag[arg1] > arg2)
+                continue;
+            break;
+        case EQ:
+            /* Fix final puzzle (Flag 12 conflict) */
+            if (BaseGame == TEMPLE_OF_TERROR) {
+                if (arg1 == 12 && arg2 == 4)
+                    arg1 = 60;
+            }
+            if (Flag[arg1] == arg2) {
+                continue;
+            }
+            break;
+        case NE:
+            if (Flag[arg1] != arg2)
+                continue;
+            break;
+        case OBJECTAT:
+            if (ObjectLoc[arg1] == arg2)
+                continue;
+            break;
+        default:
+            fprintf(stderr, "Unknown condition %d.\n",
+                op);
+            break;
         }
 #ifdef DEBUG
         fprintf(stderr, "\n");
 #endif
         return;
-    } while(1);
+    } while (1);
 
     ActionsExecuted = 1;
 
     do {
         unsigned char op = *p;
-        if(!(op & 0x80))
+        if (!(op & 0x80))
             break;
 
 #ifdef DEBUG
-        if(op & 0x40)
+        if (op & 0x40)
             fprintf(stderr, "DONE:");
         if (Version == QUESTPROBE3_TYPE)
-            fprintf(stderr,"%s(%d) ", Action[Q3Action[op & 0x3F]], op & 0x3F);
+            fprintf(stderr, "%s(%d) ", Action[Q3Action[op & 0x3F]], op & 0x3F);
         else
-            fprintf(stderr,"%s(%d) ", Action[op & 0x3F], op & 0x3F);
+            fprintf(stderr, "%s(%d) ", Action[op & 0x3F], op & 0x3F);
 #endif
 
         p++;
-        if(op & 0x40)
+        if (op & 0x40)
             *done = 1;
         op &= 0x3F;
 
-        if(op > 8) {
+        if (op > 8) {
             arg1 = *p++;
 #ifdef DEBUG
             unsigned char debugarg1 = arg1;
@@ -1665,7 +1675,7 @@ static void ExecuteLineCode(unsigned char *p, int *done)
             fprintf(stderr, "%d ", debugarg1);
 #endif
         }
-        if(op >= TwoActionParameters()) {
+        if (op >= TwoActionParameters()) {
             arg2 = *p++;
 #ifdef DEBUG
             unsigned char debugarg2 = arg2;
@@ -1685,245 +1695,242 @@ static void ExecuteLineCode(unsigned char *p, int *done)
 
         int WasDark = Flag[DarkFlag()];
 
-        switch(op) {
-            case LOADPROMPT:
-                if (LoadPrompt()) {
-                    *done = 1;
-                    return;
-                }
-                break;
-            case QUIT:
-                if (!RecursionGuard) {
-                    RecursionGuard = 1;
-                    QuitGame();
-                }
+        switch (op) {
+        case LOADPROMPT:
+            if (LoadPrompt()) {
                 *done = 1;
                 return;
-            case SHOWINVENTORY:
-                Inventory();
-                break;
-            case ANYKEY:
-                AnyKey();
-                break;
-            case SAVE:
-                StopTime = 1;
-                SaveGame();
-                break;
-            case DROPALL:
-                if ((BaseGame == REBEL_PLANET && (Word[0] != 20 || Word[1] != 141)) ||
-                    (BaseGame == KAYLETH && (Word[0] != 20 || Word[1] != 254)))
-                    DropAll(0);
-                else
-                    DropAll(1);
-                break;
-            case LOOK:
-                Look();
-                break;
-            case PRINTOK:
-                /* Guess */
-                Okay();
-                break;
-            case GET:
-                if (GetObject(arg1) == 0 && Version == QUESTPROBE3_TYPE)
-                    *done = 1;
-                break;
-            case DROP:
-                if (DropObject(arg1) == 0 && BaseGame == REBEL_PLANET) {
-                    *done = 1;
-                    return;
-                }
-                break;
-            case GOTO:
-                /*
+            }
+            break;
+        case QUIT:
+            if (!RecursionGuard) {
+                RecursionGuard = 1;
+                QuitGame();
+            }
+            *done = 1;
+            return;
+        case SHOWINVENTORY:
+            Inventory();
+            break;
+        case ANYKEY:
+            AnyKey();
+            break;
+        case SAVE:
+            StopTime = 1;
+            SaveGame();
+            break;
+        case DROPALL:
+            if ((BaseGame == REBEL_PLANET && (Word[0] != 20 || Word[1] != 141)) || (BaseGame == KAYLETH && (Word[0] != 20 || Word[1] != 254)))
+                DropAll(0);
+            else
+                DropAll(1);
+            break;
+        case LOOK:
+            Look();
+            break;
+        case PRINTOK:
+            /* Guess */
+            Okay();
+            break;
+        case GET:
+            if (GetObject(arg1) == 0 && Version == QUESTPROBE3_TYPE)
+                *done = 1;
+            break;
+        case DROP:
+            if (DropObject(arg1) == 0 && BaseGame == REBEL_PLANET) {
+                *done = 1;
+                return;
+            }
+            break;
+        case GOTO:
+            /*
                  He-Man moves the the player to a special "By the power of Grayskull" room
                  and then issues an undo to return to the previous room
                  */
-                if (BaseGame == HEMAN && arg1 == 83)
-                    SaveUndo();
-                Goto(arg1);
-                break;
-            case GOBY:
-                /* Blizzard pass era */
-                if(Version == BLIZZARD_PASS_TYPE)
-                    Goto(ObjectLoc[arg1]);
-                else
-                    Message2(arg1);
-                break;
-            case SET:
-                Flag[arg1] = 255;
-                break;
-            case CLEAR:
-                Flag[arg1] = 0;
-                break;
-            case MESSAGE:
-                /* Prevent repeated "Blob returns to his post" messages */
-                if (CurrentGame == QUESTPROBE3_64 && arg1 == 44)
-                    Flag[59] = 0;
-                Message(arg1);
-                if (CurrentGame == BLIZZARD_PASS && arg1 != 160)
-                    OutChar('\n');
-                break;
-            case CREATE:
-                Put(arg1, MyLoc);
-                break;
-            case DESTROY:
-                Put(arg1, Destroyed());
-                break;
-            case PRINT:
-                PrintNumber(Flag[arg1]);
-                break;
-            case DELAY:
-                Delay(arg1);
-                break;
-            case WEAR:
-                Wear(arg1);
-                break;
-            case REMOVE:
-                Remove(arg1);
-                break;
-            case LET:
-                if (BaseGame == TEMPLE_OF_TERROR) {
-                    if (arg1 == 28 && arg2 == 2) {
-                        /* If the serpent guard is present, we have just kicked sand in his eyes. Set flag 63 to track this */
-                        Flag[63] = (ObjectLoc[48] == MyLoc);
-                    }
+            if (BaseGame == HEMAN && arg1 == 83)
+                SaveUndo();
+            Goto(arg1);
+            break;
+        case GOBY:
+            /* Blizzard pass era */
+            if (Version == BLIZZARD_PASS_TYPE)
+                Goto(ObjectLoc[arg1]);
+            else
+                Message2(arg1);
+            break;
+        case SET:
+            Flag[arg1] = 255;
+            break;
+        case CLEAR:
+            Flag[arg1] = 0;
+            break;
+        case MESSAGE:
+            /* Prevent repeated "Blob returns to his post" messages */
+            if (CurrentGame == QUESTPROBE3_64 && arg1 == 44)
+                Flag[59] = 0;
+            Message(arg1);
+            if (CurrentGame == BLIZZARD_PASS && arg1 != 160)
+                OutChar('\n');
+            break;
+        case CREATE:
+            Put(arg1, MyLoc);
+            break;
+        case DESTROY:
+            Put(arg1, Destroyed());
+            break;
+        case PRINT:
+            PrintNumber(Flag[arg1]);
+            break;
+        case DELAY:
+            Delay(arg1);
+            break;
+        case WEAR:
+            Wear(arg1);
+            break;
+        case REMOVE:
+            Remove(arg1);
+            break;
+        case LET:
+            if (BaseGame == TEMPLE_OF_TERROR) {
+                if (arg1 == 28 && arg2 == 2) {
+                    /* If the serpent guard is present, we have just kicked sand in his eyes. Set flag 63 to track this */
+                    Flag[63] = (ObjectLoc[48] == MyLoc);
                 }
-                Flag[arg1] = arg2;
-                break;
-            case ADD:
-                /* Fix final puzzle (Flag 12 conflict) */
-                if (BaseGame == TEMPLE_OF_TERROR) {
-                    if (arg1 == 12 && arg2 == 1)
-                        arg1 = 60;
-                }
-                n = Flag[arg1] + arg2;
-                if(n > 255)
-                    n = 255;
-                Flag[arg1] = n;
-                break;
-            case SUB:
-                n = Flag[arg1] - arg2;
-                if(n < 0)
-                    n = 0;
-                Flag[arg1] = n;
-                break;
-            case PUT:
-                Put(arg1, arg2);
-                break;
-            case SWAP:
-                n = ObjectLoc[arg1];
-                Put(arg1, ObjectLoc[arg2]);
-                Put(arg2, n);
-                break;
-            case SWAPF:
-                n = Flag[arg1];
-                Flag[arg1] = Flag[arg2];
-                Flag[arg2] = n;
-                break;
-            case MEANS:
-                Means(arg1, arg2);
-                break;
-            case PUTWITH:
-                Put(arg1, ObjectLoc[arg2]);
-                break;
-            case BEEP:
+            }
+            Flag[arg1] = arg2;
+            break;
+        case ADD:
+            /* Fix final puzzle (Flag 12 conflict) */
+            if (BaseGame == TEMPLE_OF_TERROR) {
+                if (arg1 == 12 && arg2 == 1)
+                    arg1 = 60;
+            }
+            n = Flag[arg1] + arg2;
+            if (n > 255)
+                n = 255;
+            Flag[arg1] = n;
+            break;
+        case SUB:
+            n = Flag[arg1] - arg2;
+            if (n < 0)
+                n = 0;
+            Flag[arg1] = n;
+            break;
+        case PUT:
+            Put(arg1, arg2);
+            break;
+        case SWAP:
+            n = ObjectLoc[arg1];
+            Put(arg1, ObjectLoc[arg2]);
+            Put(arg2, n);
+            break;
+        case SWAPF:
+            n = Flag[arg1];
+            Flag[arg1] = Flag[arg2];
+            Flag[arg2] = n;
+            break;
+        case MEANS:
+            Means(arg1, arg2);
+            break;
+        case PUTWITH:
+            Put(arg1, ObjectLoc[arg2]);
+            break;
+        case BEEP:
 #if defined(GLK_MODULE_GARGLKBLEEP)
-                garglk_zbleep(1 + (arg1 == 250));
+            garglk_zbleep(1 + (arg1 == 250));
 #elif defined(SPATTERLIGHT)
-                fprintf(stderr, "BEEP: arg1: %d arg2: %d\n", arg1, arg2);
-                win_beep(1 + (arg1 == 250));
+            fprintf(stderr, "BEEP: arg1: %d arg2: %d\n", arg1, arg2);
+            win_beep(1 + (arg1 == 250));
 #else
-                putchar('\007');
-                fflush(stdout);
+            putchar('\007');
+            fflush(stdout);
 #endif
-                break;
-            case REFRESH:
-                if (BaseGame == KAYLETH)
-                    TakeAll(78);
-                if (BaseGame == HEMAN)
-                    TakeAll(45);
-                Redraw = 1;
-                break;
-            case RAMSAVE:
-                RamSave(1);
-                break;
-            case RAMLOAD:
-                RamLoad();
-                break;
-            case CLSLOW:
-                OutFlush();
-                glk_window_clear(Bottom);
-                break;
-            case OOPS:
-                RestoreUndo(0);
-                Redraw = 1;
-                break;
-            case DIAGNOSE:
-                Message(223);
-                char buf[5];
-                char *q = buf;
-                /* TurnsLow = turns % 100, TurnsHigh == turns / 100 */
-                snprintf(buf, sizeof buf, "%04d", TurnsLow + TurnsHigh * 100);
-                while(*q)
-                    OutChar(*q++);
-                SysMessage(14);
-                if (IsThing)
+            break;
+        case REFRESH:
+            if (BaseGame == KAYLETH)
+                TakeAll(78);
+            if (BaseGame == HEMAN)
+                TakeAll(45);
+            Redraw = 1;
+            break;
+        case RAMSAVE:
+            RamSave(1);
+            break;
+        case RAMLOAD:
+            RamLoad();
+            break;
+        case CLSLOW:
+            OutFlush();
+            glk_window_clear(Bottom);
+            break;
+        case OOPS:
+            RestoreUndo(0);
+            Redraw = 1;
+            break;
+        case DIAGNOSE:
+            Message(223);
+            char buf[5];
+            char *q = buf;
+            /* TurnsLow = turns % 100, TurnsHigh == turns / 100 */
+            snprintf(buf, sizeof buf, "%04d", TurnsLow + TurnsHigh * 100);
+            while (*q)
+                OutChar(*q++);
+            SysMessage(14);
+            if (IsThing)
                 /* THING is always 100 percent rested */
-                    OutString("100");
-                else {
-                    /* Calculate "restedness" percentage */
-                    /* Flag[7] == 80 means 100 percent rested */
-                    q = buf;
-                    snprintf(buf, sizeof buf, "%d", (Flag[7] >> 2) + Flag[7]);
-                    while(*q)
-                        OutChar(*q++);
-                }
-                SysMessage(15);
-                break;
-            case SWITCHINVENTORY:
-            {
-                uint8_t temp = Flag[2]; /* Switch inventory */
-                Flag[2] = OtherGuyInv;
-                OtherGuyInv = temp;
-                temp = Flag[42]; /* Switch dark flag */
-                Flag[42] = Flag[43];
-                Flag[43] = temp;
-                Redraw = 1;
+                OutString("100");
+            else {
+                /* Calculate "restedness" percentage */
+                /* Flag[7] == 80 means 100 percent rested */
+                q = buf;
+                snprintf(buf, sizeof buf, "%d", (Flag[7] >> 2) + Flag[7]);
+                while (*q)
+                    OutChar(*q++);
+            }
+            SysMessage(15);
+            break;
+        case SWITCHINVENTORY: {
+            uint8_t temp = Flag[2]; /* Switch inventory */
+            Flag[2] = OtherGuyInv;
+            OtherGuyInv = temp;
+            temp = Flag[42]; /* Switch dark flag */
+            Flag[42] = Flag[43];
+            Flag[43] = temp;
+            Redraw = 1;
+            break;
+        }
+        case SWITCHCHARACTER:
+            /* Go to the location of the other guy */
+            Location = ObjectLoc[arg1];
+            /* Pick him up, so that you don't see yourself */
+            GetObject(arg1);
+            Redraw = 1;
+            break;
+        case DONE:
+            *done = 1;
+            break;
+        case IMAGE:
+            if (MyLoc == 3 || Flag[DarkFlag()]) {
+                DrawBlack();
                 break;
             }
-            case SWITCHCHARACTER:
-                /* Go to the location of the other guy */
-                Location = ObjectLoc[arg1];
-                /* Pick him up, so that you don't see yourself */
-                GetObject(arg1);
-                Redraw = 1;
+            if (arg1 == 0) {
+                ClearGraphMem();
+                DrawSagaPictureNumber(MyLoc - 1);
+            } else if (arg1 == 45 && ObjectLoc[48] != MyLoc) {
                 break;
-            case DONE:
-                *done = 1;
-                break;
-            case IMAGE:
-                if (MyLoc == 3 || Flag[DarkFlag()]) {
-                    DrawBlack();
-                    break;
-                }
-                if (arg1 == 0) {
-                    ClearGraphMem();
-                    DrawSagaPictureNumber(MyLoc - 1);
-                } else if (arg1 == 45 && ObjectLoc[48] != MyLoc) {
-                    break;
-                } else {
-                    DrawSagaPictureNumber(arg1 - 1);
-                }
-                DrawSagaPictureFromBuffer();
-                break;
-            default:
-                fprintf(stderr, "Unknown command %d.\n", op);
-                break;
+            } else {
+                DrawSagaPictureNumber(arg1 - 1);
+            }
+            DrawSagaPictureFromBuffer();
+            break;
+        default:
+            fprintf(stderr, "Unknown command %d.\n", op);
+            break;
         }
         if (WasDark != Flag[DarkFlag()])
             Redraw = 1;
-    }
-    while(1);
+    } while (1);
 #ifdef DEBUG
     fprintf(stderr, "\n");
 #endif
@@ -1932,23 +1939,24 @@ static void ExecuteLineCode(unsigned char *p, int *done)
 static unsigned char *NextLine(unsigned char *p)
 {
     unsigned char op;
-    while(!((op = *p) & 0x80)) {
-        p+=2;
-        if(op >= TwoConditionParameters())
+    while (!((op = *p) & 0x80)) {
+        p += 2;
+        if (op >= TwoConditionParameters())
             p++;
     }
-    while(((op = *p) & 0x80)) {
+    while (((op = *p) & 0x80)) {
         op &= 0x3F;
         p++;
         if (op > 8)
             p++;
-        if(op >= TwoActionParameters())
+        if (op >= TwoActionParameters())
             p++;
     }
     return p;
 }
 
-static void DrawExtraQP3Images(void) {
+static void DrawExtraQP3Images(void)
+{
     if (MyLoc == 34 && ObjectLoc[29] == 34) {
         DrawSagaPictureNumber(46);
         buffer[32 * 8 + 25][8] &= 191;
@@ -1977,12 +1985,12 @@ static void RunStatusTable(void)
         Q3UpdateFlags();
     }
 
-    while(*p != 0x7F) {
+    while (*p != 0x7F) {
         while (Version == QUESTPROBE3_TYPE && *p == 0x7e) {
             p++;
         }
         ExecuteLineCode(p, &done);
-        if(done) {
+        if (done) {
             return;
         }
         p = NextLine(p);
@@ -1999,15 +2007,10 @@ static void RunCommandTable(void)
     ActionsExecuted = 0;
     FoundMatch = 0;
 
-    while(*p != 0x7F) {
+    while (*p != 0x7F) {
         /* Match input to table entry as VERB NOUN or NOUN VERB */
         /* 126 is wildcard that matches any word */
-        if(((*p == 126 || *p == Word[0]) &&
-           (p[1] == 126 || p[1] == Word[1])) ||
-           (*p == Word[1] && p[1] == Word[0]) ||
-           (BaseGame != QUESTPROBE3 && (*p == 126 || *p == Word[1]) &&
-           (p[1] == 126 || p[1] == Word[0]))
-           ) {
+        if (((*p == 126 || *p == Word[0]) && (p[1] == 126 || p[1] == Word[1])) || (*p == Word[1] && p[1] == Word[0]) || (BaseGame != QUESTPROBE3 && (*p == 126 || *p == Word[1]) && (p[1] == 126 || p[1] == Word[0]))) {
 #ifdef DEBUG
             PrintWord(p[0]);
             PrintWord(p[1]);
@@ -2027,7 +2030,7 @@ static void RunCommandTable(void)
                 }
             }
             ExecuteLineCode(p + 2, &done);
-            if(done)
+            if (done)
                 return;
         }
         p = NextLine(p + 2);
@@ -2038,18 +2041,18 @@ static int AutoExit(unsigned char v)
 {
     unsigned char *p = FileImage + ExitBase;
     unsigned char want = MyLoc | 0x80;
-    while(*p != want) {
-        if(*p == 0xFE)
+    while (*p != want) {
+        if (*p == 0xFE)
             return 0;
         p++;
     }
     p++;
-    while(*p < 0x80) {
-        if(*p == v) {
+    while (*p < 0x80) {
+        if (*p == v) {
             Goto(p[1]);
             return 1;
         }
-        p+=2;
+        p += 2;
     }
     return 0;
 }
@@ -2060,14 +2063,14 @@ static int IsDir(unsigned char word)
         return 0;
     if (Version == QUESTPROBE3_TYPE) {
         return (word <= 4 || word == 57 || word == 60);
-    }
-    else return (word <= 10);
+    } else
+        return (word <= 10);
 }
 
 static void RunOneInput(void)
 {
     PrintedOK = 0;
-    if(Word[0] == 0 && Word[1] == 0) {
+    if (Word[0] == 0 && Word[1] == 0) {
         if (TryExtraCommand() == 0) {
             OutCaps();
             SysMessage(I_DONT_UNDERSTAND);
@@ -2079,10 +2082,10 @@ static void RunOneInput(void)
         return;
     }
     if (IsDir(Word[0]) || (Word[0] == GoVerb && IsDir(Word[1]))) {
-        if(AutoExit(Word[0]) || AutoExit(Word[1])) {
+        if (AutoExit(Word[0]) || AutoExit(Word[1])) {
             StopTime = 0;
             RunStatusTable();
-            if(Redraw)
+            if (Redraw)
                 Look();
             return;
         }
@@ -2097,7 +2100,7 @@ static void RunOneInput(void)
     OutCaps();
     RunCommandTable();
 
-    if(ActionsExecuted == 0) {
+    if (ActionsExecuted == 0) {
         int OriginalVerb = Word[0];
         if (TryExtraCommand() == 0) {
             if (LastVerb) {
@@ -2109,7 +2112,7 @@ static void RunOneInput(void)
                 RunCommandTable();
             }
             if (ActionsExecuted == 0) {
-                if(IsDir(OriginalVerb) || (Word[0] == GoVerb && IsDir(Word[1])))
+                if (IsDir(OriginalVerb) || (Word[0] == GoVerb && IsDir(Word[1])))
                     SysMessage(YOU_CANT_GO_THAT_WAY);
                 else if (FoundMatch)
                     SysMessage(THATS_BEYOND_MY_POWER);
@@ -2119,13 +2122,14 @@ static void RunOneInput(void)
                 StopTime = 1;
                 return;
             }
-        } else return;
+        } else
+            return;
     }
 
     if (Word[0] != 0)
         LastVerb = Word[0];
 
-    if(Redraw && !(BaseGame == REBEL_PLANET && MyLoc == 250)) {
+    if (Redraw && !(BaseGame == REBEL_PLANET && MyLoc == 250)) {
         Look();
     }
 
@@ -2148,7 +2152,7 @@ static void RunOneInput(void)
             RunStatusTable();
         }
 
-        if(Redraw) {
+        if (Redraw) {
             Look();
         }
         Redraw = 0;
@@ -2164,13 +2168,13 @@ static void RunOneInput(void)
         Flag[WaitFlag()] = 0;
 }
 
-void PrintFirstTenBytes(size_t offset) {
+void PrintFirstTenBytes(size_t offset)
+{
     fprintf(stderr, "\nFirst 10 bytes at 0x%04zx: ", offset);
     for (int i = 0; i < 10; i++)
         fprintf(stderr, "0x%02x ", FileImage[offset + i]);
     fprintf(stderr, "\n");
 }
-
 
 static void FindTables(void)
 {
@@ -2181,7 +2185,7 @@ static void FindTables(void)
     ActionBase = Game->start_of_actions + FileBaselineOffset;
     ExitBase = Game->start_of_room_connections + FileBaselineOffset;
     FlagBase = FindFlags();
-    ObjLocBase = Game->start_of_item_locations  + FileBaselineOffset;
+    ObjLocBase = Game->start_of_item_locations + FileBaselineOffset;
     MessageBase = Game->start_of_messages + FileBaselineOffset;
     Message2Base = Game->start_of_messages_2 + FileBaselineOffset;
 
@@ -2203,22 +2207,21 @@ static int GuessLowObjectEnd0(void)
     unsigned char c = 0, lc;
     int n = 0;
 
-    while(p < EndOfData) {
-        if(t == NULL)
+    while (p < EndOfData) {
+        if (t == NULL)
             t = TokenText(*p++);
         lc = c;
         c = *t & 0x7F;
-        if(c == 0x5E || c == 0x7E) {
-            if(lc == ',' && n > 20)
+        if (c == 0x5E || c == 0x7E) {
+            if (lc == ',' && n > 20)
                 return n;
             n++;
         }
-        if(*t++ & 0x80)
+        if (*t++ & 0x80)
             t = NULL;
     }
     return -1;
 }
-
 
 static int GuessLowObjectEnd(void)
 {
@@ -2235,15 +2238,15 @@ static int GuessLowObjectEnd(void)
     if (Version == REBEL_PLANET_TYPE)
         return GuessLowObjectEnd0();
 
-    while(n < NumObjects()) {
-        while(*p != 0x7E && *p != 0x5E) {
+    while (n < NumObjects()) {
+        while (*p != 0x7E && *p != 0x5E) {
             p++;
         }
         x = TokenText(p[-1]);
-        while(!(*x & 0x80)) {
+        while (!(*x & 0x80)) {
             x++;
         }
-        if((*x & 0x7F) == ',')
+        if ((*x & 0x7F) == ',')
             return n;
         n++;
         p++;
@@ -2279,16 +2282,15 @@ int glkunix_startup_code(glkunix_startup_t *data)
             if (*argv[1] != '-')
                 break;
             switch (argv[1][1]) {
-                case 'n':
-                    Options |= NO_DELAYS;
-                    break;
+            case 'n':
+                Options |= NO_DELAYS;
+                break;
             }
             argv++;
             argc--;
         }
 
-    if(argv[1] == NULL)
-    {
+    if (argv[1] == NULL) {
         fprintf(stderr, "%s: <file>.\n", argv[0]);
         glk_exit();
     }
@@ -2299,8 +2301,7 @@ int glkunix_startup_code(glkunix_startup_t *data)
     Filename[namelen] = '\0';
 
     FILE *f = fopen(Filename, "r");
-    if(f == NULL)
-    {
+    if (f == NULL) {
         perror(Filename);
         glk_exit();
     }
@@ -2342,7 +2343,8 @@ int glkunix_startup_code(glkunix_startup_t *data)
 
 #ifdef DEBUG
 
-void PrintConditionAddresses(void) {
+void PrintConditionAddresses(void)
+{
     fprintf(stderr, "Memory adresses of conditions\n\n");
     uint16_t conditionsOffsets = 0x56A8 + FileBaselineOffset;
     uint8_t *conditions;
@@ -2356,7 +2358,8 @@ void PrintConditionAddresses(void) {
     fprintf(stderr, "\n");
 }
 
-void PrintActionAddresses(void) {
+void PrintActionAddresses(void)
+{
     fprintf(stderr, "Memory adresses of actions\n\n");
     uint16_t actionOffsets = 0x591C + FileBaselineOffset;
     uint8_t *actions;
@@ -2458,14 +2461,13 @@ static void LookForSecondTOTGame(void)
 
     struct GameInfo *AltGame = DetectGame(AltVerbBase);
 
-    if ((CurrentGame == TOT_TEXT_ONLY && AltGame->gameID != TEMPLE_OF_TERROR) ||
-        (CurrentGame == TEMPLE_OF_TERROR && AltGame->gameID != TOT_TEXT_ONLY)) {
+    if ((CurrentGame == TOT_TEXT_ONLY && AltGame->gameID != TEMPLE_OF_TERROR) || (CurrentGame == TEMPLE_OF_TERROR && AltGame->gameID != TOT_TEXT_ONLY)) {
         UnparkFileImage(ParkedFile, ParkedLength, ParkedOffset, 1);
         return;
     }
 
     Display(Bottom, "Found files for both the text-only version and the graphics version of Temple of Terror.\n"
-            "Would you like to use the longer texts from the text-only version along with the graphics from the other file? (Y/N) ");
+                    "Would you like to use the longer texts from the text-only version along with the graphics from the other file? (Y/N) ");
     if (!YesOrNo()) {
         UnparkFileImage(ParkedFile, ParkedLength, ParkedOffset, 1);
         return;
@@ -2499,14 +2501,14 @@ void glk_main(void)
         EndOfData = FileImage + FileImageLen;
     } else {
         fprintf(stderr, "DetectC64 did not recognize the game\n");
-	}
+    }
 
 #ifdef DEBUG
     fprintf(stderr, "Loaded %zu bytes.\n", FileImageLen);
 #endif
 
     VerbBase = FindCode("NORT\001N", 0, 6);
-    if(VerbBase == -1) {
+    if (VerbBase == -1) {
         fprintf(stderr, "No verb table!\n");
         glk_exit();
     }
@@ -2554,11 +2556,11 @@ void glk_main(void)
     InitialState = SaveCurrentState();
 
     RunStatusTable();
-    if(Redraw) {
+    if (Redraw) {
         OutFlush();
         Look();
     }
-    while(1) {
+    while (1) {
         if (ShouldRestart) {
             RestartGame();
         } else if (!StopTime)

--- a/terps/taylor/player.c
+++ b/terps/taylor/player.c
@@ -584,7 +584,7 @@ static unsigned char *TokenText(unsigned char n)
 
 void Q3PrintChar(uint8_t c)
 { // Print character
-    if (c == 0x0d)
+    if (c < 0x20 && c != 0x0a)
         return;
 
     if (FirstAfterInput)

--- a/terps/taylor/sagadraw.c
+++ b/terps/taylor/sagadraw.c
@@ -8,12 +8,12 @@
 //  Original code at https://github.com/tautology0/textadventuregraphics
 //
 
-#include "glk.h"
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
 
+#include "glk.h"
 #include "taylor.h"
 #include "utility.h"
 
@@ -441,8 +441,8 @@ static void transform(int32_t character, int32_t flip_mode, int32_t ptr)
 
 #ifdef DRAWDEBUG
     fprintf(stderr, "Plotting char: %d with flip: %02x (%s) at %d: %d,%d\n",
-            character, flip_mode, flipdescription[(flip_mode & 48) >> 4], ptr,
-            ptr % 0x20, ptr / 0x20);
+        character, flip_mode, flipdescription[(flip_mode & 48) >> 4], ptr,
+        ptr % 0x20, ptr / 0x20);
 #endif
 
     // first copy the character into work
@@ -488,11 +488,11 @@ void PutPixel(glsi32 x, glsi32 y, int32_t color)
     glui32 glk_color = ((pal[color][0] << 16)) | ((pal[color][1] << 8)) | (pal[color][2]);
 
     glk_window_fill_rect(Graphics, glk_color, x * pixel_size + x_offset,
-                         y * pixel_size + y_offset, pixel_size, pixel_size);
+        y * pixel_size + y_offset, pixel_size, pixel_size);
 }
 
 void RectFill(int32_t x, int32_t y, int32_t width, int32_t height,
-              int32_t color, int usebuffer)
+    int32_t color, int usebuffer)
 {
     glui32 y_offset = 0;
 
@@ -506,8 +506,8 @@ void RectFill(int32_t x, int32_t y, int32_t width, int32_t height,
     glui32 glk_color = ((pal[color][0] << 16)) | ((pal[color][1] << 8)) | (pal[color][2]);
 
     glk_window_fill_rect(Graphics, glk_color, x * pixel_size + x_offset,
-                         y * pixel_size + y_offset, width * pixel_size,
-                         height * pixel_size);
+        y * pixel_size + y_offset, width * pixel_size,
+        height * pixel_size);
 }
 
 void background(int32_t x, int32_t y, int32_t color)
@@ -517,7 +517,7 @@ void background(int32_t x, int32_t y, int32_t color)
 }
 
 void plotsprite(int32_t character, int32_t x, int32_t y, int32_t fg,
-                int32_t bg)
+    int32_t bg)
 {
     if (fg > 15)
         fg = 0;
@@ -539,7 +539,7 @@ static int isNthBitSet(unsigned const char c, int n)
 }
 
 uint8_t *DrawSagaPictureFromData(uint8_t *dataptr, int xsize, int ysize,
-                                 int xoff, int yoff, size_t datasize);
+    int xoff, int yoff, size_t datasize);
 
 struct image_patch {
     GameIDType id;
@@ -553,8 +553,8 @@ static const struct image_patch image_patches[] = {
     { UNKNOWN_GAME, 0, 0, 0, "" },
     { QUESTPROBE3, 55, 604, 3, "\xff\xff\x82" },
     { QUESTPROBE3, 56, 357, 46, "\x79\x81\x78\x79\x7b\x83\x47\x79\x82\x78\x79\x7b\x83\x47\x79\x83"
-        "\x78\x79\x7b\x81\x79\x47\x79\x84\x7b\x83\x47\x79\x84\x58\x83\x47\x7a\x84\x5f\x18\x81\x5f"
-        "\x47\x50\x84\x5f\x18\x81\x5f\x47" },
+                                "\x78\x79\x7b\x81\x79\x47\x79\x84\x7b\x83\x47\x79\x84\x58\x83\x47\x7a\x84\x5f\x18\x81\x5f"
+                                "\x47\x50\x84\x5f\x18\x81\x5f\x47" },
     { NUMGAMES, 0, 0, 0, "" },
 };
 
@@ -579,13 +579,15 @@ static void Patch(uint8_t *offset, int patch_number)
 
 void DrawTaylor(int loc);
 
-static void Q3Init(size_t *base, size_t *offsets, size_t *imgdata) {
+static void Q3Init(size_t *base, size_t *offsets, size_t *imgdata)
+{
     *base = FindCode("\x00\x01\x01\x02\x03\x04\x05\x06\x02\x02", 0, 10);
     *offsets = FindCode("\x00\x00\xa7\x02\xa7\x03\xb9\x08\xd7\x0b", 0, 10);
-    *imgdata =  FindCode("\x20\x0c\x00\x00\x8a\x01\x44\xa0\x17\x8a", *offsets, 10);
+    *imgdata = FindCode("\x20\x0c\x00\x00\x8a\x01\x44\xa0\x17\x8a", *offsets, 10);
 }
 
-static uint8_t *Q3Image(int imgnum, size_t base, size_t offsets, size_t imgdata) {
+static uint8_t *Q3Image(int imgnum, size_t base, size_t offsets, size_t imgdata)
+{
     uint16_t offset_addr = (FileImage[base + imgnum] & 0x7f) * 2 + offsets;
     uint16_t image_addr = imgdata + FileImage[offset_addr] + FileImage[offset_addr + 1] * 256;
     return &FileImage[image_addr];
@@ -593,7 +595,7 @@ static uint8_t *Q3Image(int imgnum, size_t base, size_t offsets, size_t imgdata)
 
 static void RepeatOpcode(int *number, uint8_t *instructions, uint8_t repeatcount)
 {
-	int i = *number - 1;
+    int i = *number - 1;
     instructions[i++] = 0x82;
     instructions[i++] = repeatcount;
     instructions[i++] = 0;
@@ -604,7 +606,7 @@ static size_t FindCharacterStart(void)
 {
     /* Look for the character data */
     size_t pos = FindCode("\x00\x00\x00\x00\x00\x00\x00\x00\x80\x80\x80\x80\x80\x80\x80\x80\x40\x40\x40\x40\x40\x40\x40\x40", 0, 24);
-    if(pos == -1) {
+    if (pos == -1) {
         fprintf(stderr, "Cannot find character data.\n");
         return 0;
     }
@@ -619,7 +621,7 @@ void SagaSetup(void)
     if (images != NULL)
         return;
 
-    if (Game->number_of_pictures == 0 ) {
+    if (Game->number_of_pictures == 0) {
         NoGraphics = 1;
         return;
     }
@@ -652,7 +654,7 @@ void SagaSetup(void)
 #ifdef DRAWDEBUG
     fprintf(stderr, "Grabbing Character details\n");
     fprintf(stderr, "Character Offset: %04lx\n",
-            CHAR_START - FileBaselineOffset);
+        CHAR_START - FileBaselineOffset);
 #endif
     for (i = 0; i < 246; i++) {
         for (y = 0; y < 8 && pos < EndOfGraphicsData; y++) {
@@ -717,11 +719,16 @@ void SagaSetup(void)
         img->height = (widthheight & 0x0f) + 1;
         if (CurrentGame == BLIZZARD_PASS) {
             switch (picture_number) {
-                case 13: case 15: case 17: case 34: case 85: case 111:
-                    img->width += 16;
-                    break;
-                default:
-                    break;
+            case 13:
+            case 15:
+            case 17:
+            case 34:
+            case 85:
+            case 111:
+                img->width += 16;
+                break;
+            default:
+                break;
             }
         }
         uint8_t instructions[2048];
@@ -733,44 +740,44 @@ void SagaSetup(void)
             uint8_t opcode = *pos;
             if (Version != HEMAN_TYPE) {
                 switch (opcode) {
-                    case 0xfb:
-                        number--;
-                        if (!copied_bytes || copied_bytes[0] == 0) {
-                            pos = stored_pointer;
-                            if (copied_bytes != NULL)
-                                free(copied_bytes);
-                            copied_bytes = NULL;
-                        } else {
-                            copied_bytes[0]--;
-                            pos = copied_bytes;
-                        }
-                        break;
-                     case 0xef:
-                         RepeatOpcode(&number, instructions, 1);
-                         break;
-                     case 0xee:
-                         RepeatOpcode(&number, instructions, 2);
-                         break;
-                     case 0xeb:
-                         RepeatOpcode(&number, instructions, 3);
-                         break;
-                     case 0xf3:
-                         pos++;
-                         RepeatOpcode(&number, instructions, *pos);
-                         break;
-                    case 0xfa:
-                        number--;
-                        pos++;
-                        int numbytes = *pos++;
-                        stored_pointer = pos;
+                case 0xfb:
+                    number--;
+                    if (!copied_bytes || copied_bytes[0] == 0) {
+                        pos = stored_pointer;
                         if (copied_bytes != NULL)
                             free(copied_bytes);
-                        copied_bytes = MemAlloc(numbytes + 1);
-                        memcpy(copied_bytes, pos, numbytes);
+                        copied_bytes = NULL;
+                    } else {
                         copied_bytes[0]--;
-                        copied_bytes[numbytes] = 0xfb;
                         pos = copied_bytes;
-                        break;
+                    }
+                    break;
+                case 0xef:
+                    RepeatOpcode(&number, instructions, 1);
+                    break;
+                case 0xee:
+                    RepeatOpcode(&number, instructions, 2);
+                    break;
+                case 0xeb:
+                    RepeatOpcode(&number, instructions, 3);
+                    break;
+                case 0xf3:
+                    pos++;
+                    RepeatOpcode(&number, instructions, *pos);
+                    break;
+                case 0xfa:
+                    number--;
+                    pos++;
+                    int numbytes = *pos++;
+                    stored_pointer = pos;
+                    if (copied_bytes != NULL)
+                        free(copied_bytes);
+                    copied_bytes = MemAlloc(numbytes + 1);
+                    memcpy(copied_bytes, pos, numbytes);
+                    copied_bytes[0]--;
+                    copied_bytes[numbytes] = 0xfb;
+                    pos = copied_bytes;
+                    break;
                 }
             } else if (Game->number_of_patterns) {
                 for (i = 0; i < Game->number_of_patterns; i++) {
@@ -805,9 +812,9 @@ void PrintImageContents(int index, uint8_t *data, size_t size)
 {
     fprintf(stderr, "/* image %d ", index);
     fprintf(stderr,
-            "width: %d height: %d xoff: %d yoff: %d size: %zu bytes*/\n{ ",
-            images[index].width, images[index].height, images[index].xoff,
-            images[index].yoff, size);
+        "width: %d height: %d xoff: %d yoff: %d size: %zu bytes*/\n{ ",
+        images[index].width, images[index].height, images[index].xoff,
+        images[index].yoff, size);
     for (int i = 0; i < size; i++) {
         fprintf(stderr, "0x%02x, ", data[i]);
         if (i % 8 == 7)
@@ -909,8 +916,9 @@ static void flip_image_vertically(void)
     memcpy(buffer, mirror, 384 * 9);
 }
 
-static void flip_area_vertically(uint8_t x1, uint8_t y1, uint8_t width, uint8_t y2) {
-//    fprintf(stderr, "flip_area_vertically x1: %d: y1: %d width: %d y2 %d\n", x1, y1, width, y2);
+static void flip_area_vertically(uint8_t x1, uint8_t y1, uint8_t width, uint8_t y2)
+{
+    //    fprintf(stderr, "flip_area_vertically x1: %d: y1: %d width: %d y2 %d\n", x1, y1, width, y2);
     uint8_t mirror[384][9];
 
     for (int line = 0; line <= y2; line++) {
@@ -929,7 +937,8 @@ static void flip_area_vertically(uint8_t x1, uint8_t y1, uint8_t width, uint8_t 
     }
 }
 
-static void mirror_area_vertically(uint8_t x1, uint8_t y1, uint8_t width, uint8_t y2) {
+static void mirror_area_vertically(uint8_t x1, uint8_t y1, uint8_t width, uint8_t y2)
+{
     for (int line = 0; line <= y2 / 2; line++) {
         for (int col = x1; col < x1 + width; col++) {
             buffer[(y2 - line) * 32 + col][8] = buffer[(y1 + line) * 32 + col][8];
@@ -939,8 +948,9 @@ static void mirror_area_vertically(uint8_t x1, uint8_t y1, uint8_t width, uint8_
     }
 }
 
-static void flip_area_horizontally(uint8_t x1, uint8_t y1, uint8_t width, uint8_t y2) {
-//    fprintf(stderr, "flip_area_horizontally x1: %d: y1: %d width: %d y2 %d\n", x1, y1, width, y2);
+static void flip_area_horizontally(uint8_t x1, uint8_t y1, uint8_t width, uint8_t y2)
+{
+    //    fprintf(stderr, "flip_area_horizontally x1: %d: y1: %d width: %d y2 %d\n", x1, y1, width, y2);
     uint8_t mirror[384][9];
 
     for (int line = y1; line < y2; line++) {
@@ -967,8 +977,7 @@ static void draw_colour_old(uint8_t x, uint8_t y, uint8_t colour, uint8_t length
     }
 }
 
-
-static void draw_colour( uint8_t colour, uint8_t x, uint8_t y, uint8_t width, uint8_t height)
+static void draw_colour(uint8_t colour, uint8_t x, uint8_t y, uint8_t width, uint8_t height)
 {
     for (int h = 0; h < height; h++) {
         for (int w = 0; w < width; w++) {
@@ -983,7 +992,6 @@ static void make_light(void)
         buffer[i][8] = buffer[i][8] | 0x40;
     }
 }
-
 
 static void replace_colour(uint8_t before, uint8_t after)
 {
@@ -1006,13 +1014,15 @@ static void replace_colour(uint8_t before, uint8_t after)
     }
 }
 
-static uint8_t ink2paper(uint8_t ink) {
+static uint8_t ink2paper(uint8_t ink)
+{
     uint8_t paper = (ink & 0x07) << 3; // 0000 0111 mask ink
     paper = paper & 0x38; // 0011 1000 mask paper
     return (ink & 0x40) | paper; // 0x40 = 0100 0000 preserve brightness bit from ink
 }
 
-static void replace(uint8_t before, uint8_t after, uint8_t mask) {
+static void replace(uint8_t before, uint8_t after, uint8_t mask)
+{
     for (int j = 0; j < 384; j++) {
         uint8_t col = buffer[j][8] & mask;
         if (col == before) {
@@ -1023,7 +1033,8 @@ static void replace(uint8_t before, uint8_t after, uint8_t mask) {
     }
 }
 
-static void replace_paper_and_ink(uint8_t before, uint8_t after) {
+static void replace_paper_and_ink(uint8_t before, uint8_t after)
+{
     uint8_t beforeink = before & 0x47; // 0100 0111 ink and brightness
     replace(beforeink, after, 0x47);
     uint8_t beforepaper = ink2paper(before);
@@ -1048,117 +1059,117 @@ void DrawTaylor(int loc)
     while (ptr < EndOfGraphicsData) {
         //        fprintf(stderr, "DrawTaylorRoomImage: Instruction %d: 0x%02x\n", instruction++, *ptr);
         switch (*ptr) {
-            case 0xff:
-                //                fprintf(stderr, "End of picture\n");
+        case 0xff:
+            //                fprintf(stderr, "End of picture\n");
+            return;
+        case 0xfe:
+            //                fprintf(stderr, "0xfe mirror_left_half\n");
+            mirror_area(0, 0, 32, 12);
+            break;
+        case 0xfd:
+            //                fprintf(stderr, "0xfd Replace colour %x with %x\n", *(ptr + 1), *(ptr + 2));
+            replace_colour(*(ptr + 1), *(ptr + 2));
+            ptr += 2;
+            break;
+        case 0xfc: // Draw colour: x, y, attribute, length 7808
+            if (Version != HEMAN_TYPE) {
+                // fprintf(stderr, "0xfc (7808) Draw attribute %x at %d,%d length %d\n", *(ptr + 3), *(ptr + 1), *(ptr + 2), *(ptr + 4));
+                draw_colour_old(*(ptr + 1), *(ptr + 2), *(ptr + 3), *(ptr + 4));
+                ptr = ptr + 4;
+            } else {
+                // fprintf(stderr, "0xfc (7808) Draw attribute %x at %d,%d height %d width %d\n", *(ptr + 4), *(ptr + 2), *(ptr + 1), *(ptr + 3), *(ptr + 5));
+                draw_colour(*(ptr + 4), *(ptr + 2), *(ptr + 1), *(ptr + 5), *(ptr + 3));
+                ptr = ptr + 5;
+            }
+            break;
+        case 0xfb: // Make all screen colours bright 713e
+            // fprintf(stderr, "Make colours in picture area bright\n");
+            make_light();
+            break;
+        case 0xfa: // Flip entire image horizontally 7646
+            // fprintf(stderr, "0xfa Flip entire image horizontally\n");
+            flip_image_horizontally();
+            break;
+        case 0xf9: //0xf9 Draw picture n recursively;
+            // fprintf(stderr, "Draw Room Image %d recursively\n", *(ptr + 1));
+            DrawTaylor(*(ptr + 1));
+            ptr++;
+            break;
+        case 0xf8:
+            // fprintf(stderr, "0xf8: Skip rest of picture if object %d is not present\n", *(ptr + 1));
+            ptr++;
+            if (CurrentGame == BLIZZARD_PASS || BaseGame == REBEL_PLANET) {
+                if (ObjectLoc[*ptr] == MyLoc) {
+                    DrawSagaPictureAtPos(*(ptr + 1), *(ptr + 2), *(ptr + 3));
+                }
+                ptr += 3;
+            } else {
+                if (ObjectLoc[*ptr] != MyLoc)
+                    return;
+            }
+            break;
+        case 0xf4: // End if object arg1 is present
+            // fprintf(stderr, "0xf4: Skip rest of picture if object %d IS present\n", *(ptr + 1));
+            if (ObjectLoc[*(ptr + 1)] == MyLoc)
                 return;
-            case 0xfe:
-                //                fprintf(stderr, "0xfe mirror_left_half\n");
-                mirror_area(0, 0, 32, 12);
-                break;
-            case 0xfd:
-                //                fprintf(stderr, "0xfd Replace colour %x with %x\n", *(ptr + 1), *(ptr + 2));
-                    replace_colour(*(ptr + 1), *(ptr + 2));
-                ptr += 2;
-                break;
-            case 0xfc: // Draw colour: x, y, attribute, length 7808
-                if (Version != HEMAN_TYPE) {
-                    // fprintf(stderr, "0xfc (7808) Draw attribute %x at %d,%d length %d\n", *(ptr + 3), *(ptr + 1), *(ptr + 2), *(ptr + 4));
-                    draw_colour_old(*(ptr + 1), *(ptr + 2), *(ptr + 3), *(ptr + 4));
-                    ptr = ptr + 4;
-                } else {
-                    // fprintf(stderr, "0xfc (7808) Draw attribute %x at %d,%d height %d width %d\n", *(ptr + 4), *(ptr + 2), *(ptr + 1), *(ptr + 3), *(ptr + 5));
-                    draw_colour(*(ptr + 4), *(ptr + 2), *(ptr + 1), *(ptr + 5), *(ptr + 3));
-                    ptr = ptr + 5;
-                }
-                break;
-            case 0xfb: // Make all screen colours bright 713e
-                // fprintf(stderr, "Make colours in picture area bright\n");
-                make_light();
-                break;
-            case 0xfa: // Flip entire image horizontally 7646
-                // fprintf(stderr, "0xfa Flip entire image horizontally\n");
-                flip_image_horizontally();
-                break;
-            case 0xf9: //0xf9 Draw picture n recursively;
-                // fprintf(stderr, "Draw Room Image %d recursively\n", *(ptr + 1));
-                DrawTaylor(*(ptr + 1));
-                ptr++;
-                break;
-            case 0xf8:
-                // fprintf(stderr, "0xf8: Skip rest of picture if object %d is not present\n", *(ptr + 1));
-                ptr++;
-                if (CurrentGame == BLIZZARD_PASS || BaseGame == REBEL_PLANET) {
-                    if (ObjectLoc[*ptr] == MyLoc) {
-                        DrawSagaPictureAtPos(*(ptr + 1), *(ptr + 2), *(ptr + 3));
-                    }
-                    ptr += 3;
-                } else {
-                    if (ObjectLoc[*ptr] != MyLoc)
-                        return;
-                }
-                break;
-            case 0xf4: // End if object arg1 is present
-                // fprintf(stderr, "0xf4: Skip rest of picture if object %d IS present\n", *(ptr + 1));
-                if (ObjectLoc[*(ptr + 1)] == MyLoc)
-                    return;
-                ptr++;
-                break;
-            case 0xf3:
-                // fprintf(stderr, "0xf3: goto 753d Mirror top half vertically\n");
-                mirror_top_half();
-                break;
-            case 0xf2: // arg1 arg2 arg3 arg4 Mirror horizontally
-                // fprintf(stderr, "0xf2: Mirror area x: %d y: %d width:%d y2:%d horizontally\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
-                mirror_area(*(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
-                ptr = ptr + 4;
-                break;
-            case 0xf1: // arg1 arg2 arg3 arg4 Mirror vertically
-                // fprintf(stderr, "0xf1: Mirror area x: %d y: %d width:%d y2:%d vertically\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
-                mirror_area_vertically(*(ptr + 1), *(ptr + 2), *(ptr + 4),  *(ptr + 3));
-                ptr = ptr + 4;
-                break;
-            case 0xee: // arg1 arg2 arg3 arg4  Flip area horizontally
-                // fprintf(stderr, "0xf1: Flip area x: %d y: %d width:%d y2:%d horizontally\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
-                flip_area_horizontally(*(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
-                ptr = ptr + 4;
-                break;
-            case 0xed:
-                // fprintf(stderr, "0xed: Flip entire image vertically\n");
-                flip_image_vertically();
-                break;
-            case 0xec: // Flip area vertically
-                // fprintf(stderr, "0xf1: Flip area x: %d y: %d width:%d y2:%d vertically\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
-                flip_area_vertically(*(ptr + 1), *(ptr + 2), *(ptr + 4), *(ptr + 3));
-                ptr = ptr + 4;
-                break;
-            case 0xe9:
-                // fprintf(stderr, "0xe9: (77ac) replace paper and ink %d for colour %d?\n",  *(ptr + 1), *(ptr + 2));
-                replace_paper_and_ink(*(ptr + 1), *(ptr + 2));
-                ptr = ptr + 2;
-                break;
-            case 0xe8:
-                // fprintf(stderr, "Clear graphics memory\n");
-                ClearGraphMem();
-                break;
-            case 0xf7: // set A to 0c and call 70b7, but A seems to not be used. Vestigial code?
-                if (BaseGame == REBEL_PLANET && MyLoc == 43 && ObjectLoc[131] == 252)
-                    return;
-            case 0xf6: // set A to 04 and call 70b7. See 0xf7 above.
-            case 0xf5: // set A to 08 and call 70b7. See 0xf7 above.
-                // fprintf(stderr, "0x%02x: set A to unused value and draw image block %d at %d, %d\n",  *ptr, *(ptr + 1), *(ptr + 2), *(ptr + 3));
-                ptr++; // Deliberate fallthrough
-            default: // else draw image *ptr at x, y
-                // fprintf(stderr, "Default: Draw image block %d at %d,%d\n", *ptr, *(ptr + 1), *(ptr + 2));
-                DrawSagaPictureAtPos(*ptr, *(ptr + 1), *(ptr + 2));
-                ptr = ptr + 2;
-                break;
+            ptr++;
+            break;
+        case 0xf3:
+            // fprintf(stderr, "0xf3: goto 753d Mirror top half vertically\n");
+            mirror_top_half();
+            break;
+        case 0xf2: // arg1 arg2 arg3 arg4 Mirror horizontally
+            // fprintf(stderr, "0xf2: Mirror area x: %d y: %d width:%d y2:%d horizontally\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
+            mirror_area(*(ptr + 2), *(ptr + 1), *(ptr + 4), *(ptr + 3));
+            ptr = ptr + 4;
+            break;
+        case 0xf1: // arg1 arg2 arg3 arg4 Mirror vertically
+            // fprintf(stderr, "0xf1: Mirror area x: %d y: %d width:%d y2:%d vertically\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
+            mirror_area_vertically(*(ptr + 1), *(ptr + 2), *(ptr + 4), *(ptr + 3));
+            ptr = ptr + 4;
+            break;
+        case 0xee: // arg1 arg2 arg3 arg4  Flip area horizontally
+            // fprintf(stderr, "0xf1: Flip area x: %d y: %d width:%d y2:%d horizontally\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
+            flip_area_horizontally(*(ptr + 2), *(ptr + 1), *(ptr + 4), *(ptr + 3));
+            ptr = ptr + 4;
+            break;
+        case 0xed:
+            // fprintf(stderr, "0xed: Flip entire image vertically\n");
+            flip_image_vertically();
+            break;
+        case 0xec: // Flip area vertically
+            // fprintf(stderr, "0xf1: Flip area x: %d y: %d width:%d y2:%d vertically\n", *(ptr + 2), *(ptr + 1), *(ptr + 4),  *(ptr + 3));
+            flip_area_vertically(*(ptr + 1), *(ptr + 2), *(ptr + 4), *(ptr + 3));
+            ptr = ptr + 4;
+            break;
+        case 0xe9:
+            // fprintf(stderr, "0xe9: (77ac) replace paper and ink %d for colour %d?\n",  *(ptr + 1), *(ptr + 2));
+            replace_paper_and_ink(*(ptr + 1), *(ptr + 2));
+            ptr = ptr + 2;
+            break;
+        case 0xe8:
+            // fprintf(stderr, "Clear graphics memory\n");
+            ClearGraphMem();
+            break;
+        case 0xf7: // set A to 0c and call 70b7, but A seems to not be used. Vestigial code?
+            if (BaseGame == REBEL_PLANET && MyLoc == 43 && ObjectLoc[131] == 252)
+                return;
+        case 0xf6: // set A to 04 and call 70b7. See 0xf7 above.
+        case 0xf5: // set A to 08 and call 70b7. See 0xf7 above.
+            // fprintf(stderr, "0x%02x: set A to unused value and draw image block %d at %d, %d\n",  *ptr, *(ptr + 1), *(ptr + 2), *(ptr + 3));
+            ptr++; // Deliberate fallthrough
+        default: // else draw image *ptr at x, y
+            // fprintf(stderr, "Default: Draw image block %d at %d,%d\n", *ptr, *(ptr + 1), *(ptr + 2));
+            DrawSagaPictureAtPos(*ptr, *(ptr + 1), *(ptr + 2));
+            ptr = ptr + 2;
+            break;
         }
         ptr++;
     }
 }
 
 uint8_t *DrawSagaPictureFromData(uint8_t *dataptr, int xsize, int ysize,
-                                 int xoff, int yoff, size_t datasize)
+    int xoff, int yoff, size_t datasize)
 {
     if (dataptr == NULL)
         return NULL;
@@ -1227,7 +1238,7 @@ uint8_t *DrawSagaPictureFromData(uint8_t *dataptr, int xsize, int ysize,
                             data2 += 128;
 #ifdef DRAWDEBUG
                         fprintf(stderr, "Plotting %d directly (overlay) at %d\n", data2,
-                                offset);
+                            offset);
 #endif
                         for (i = 0; i < count; i++)
                             transform(data2, old & 0x0c, offset + i);
@@ -1237,9 +1248,9 @@ uint8_t *DrawSagaPictureFromData(uint8_t *dataptr, int xsize, int ysize,
                             character += 128;
 #ifdef DRAWDEBUG
                         fprintf(stderr, "Plotting %d with flip %02x (%s) at %d %d\n",
-                                character, (data2 | mask_mode),
-                                flipdescription[((data2 | mask_mode) & 48) >> 4], offset,
-                                count);
+                            character, (data2 | mask_mode),
+                            flipdescription[((data2 | mask_mode) & 48) >> 4], offset,
+                            count);
 #endif
                         for (i = 0; i < count; i++)
                             transform(character, (data2 & 0xf3) | mask_mode, offset + i);
@@ -1270,11 +1281,11 @@ draw_attributes:
     while (y < ysize) {
         if (dataptr - origptr > datasize) {
             fprintf(stderr, "DrawSagaPictureFromData: data offset %zu out of range! Image size %zu. Bailing!\n", dataptr - origptr, datasize);
-                return dataptr;
+            return dataptr;
         }
         data = *dataptr++;
-//        fprintf(stderr, "%03ld: read attribute data byte %02x\n", dataptr -
-//                origptr - 1, data);
+        //        fprintf(stderr, "%03ld: read attribute data byte %02x\n", dataptr -
+        //                origptr - 1, data);
         if ((data & 0x80)) {
             count = (data & 0x7f) + 1;
             if (version >= 3) {
@@ -1341,7 +1352,7 @@ draw_attributes:
                     buffer[(y + yoff) * 32 + x + xoff2][i] = screenchars[offset][i];
             } else {
                 plotsprite(offset, x + xoff2, y + yoff, Remap(ink[x][y]),
-                           Remap(paper[x][y]));
+                    Remap(paper[x][y]));
             }
 
 #ifdef DRAWDEBUG
@@ -1355,8 +1366,8 @@ draw_attributes:
             ink = Remap(ink);
 
             fprintf(stderr, "(gfx#:plotting %d,%d:paper=%s,ink=%s)\n", x + xoff2,
-                    y + yoff, colortext(paper),
-                    colortext(ink));
+                y + yoff, colortext(paper),
+                colortext(ink));
 #endif
             offset++;
             if (offset > offsetlimit)
@@ -1369,12 +1380,12 @@ void DrawSagaPictureNumber(int picture_number)
 {
     if (Game->number_of_pictures == 0)
         return;
-//    int numgraphics = Game->number_of_pictures;
-//    if (picture_number >= numgraphics) {
-//        fprintf(stderr, "Invalid image number %d! Last image:%d\n", picture_number,
-//                numgraphics - 1);
-//        return;
-//    }
+    //    int numgraphics = Game->number_of_pictures;
+    //    if (picture_number >= numgraphics) {
+    //        fprintf(stderr, "Invalid image number %d! Last image:%d\n", picture_number,
+    //                numgraphics - 1);
+    //        return;
+    //    }
 
     Image img = images[picture_number];
 
@@ -1382,7 +1393,7 @@ void DrawSagaPictureNumber(int picture_number)
         return;
 
     DrawSagaPictureFromData(img.imagedata, img.width, img.height, img.xoff,
-                            img.yoff, img.datasize);
+        img.yoff, img.datasize);
 }
 
 void DrawSagaPictureAtPos(int picture_number, int x, int y)
@@ -1415,8 +1426,8 @@ void DrawSagaPictureFromBuffer(void)
                     glui32 glk_color = (glui32)((pal[ink][0] << 16) | (pal[ink][1] << 8) | pal[ink][2]);
 
                     glk_window_fill_rect(
-                                         Graphics, glk_color, (glsi32)(col * 8 * pixel_size + x_offset),
-                                         (glsi32)(line * 8 + i) * pixel_size, 8 * pixel_size, pixel_size);
+                        Graphics, glk_color, (glsi32)(col * 8 * pixel_size + x_offset),
+                        (glsi32)(line * 8 + i) * pixel_size, 8 * pixel_size, pixel_size);
                     continue;
                 }
                 for (int j = 0; j < 8; j++)

--- a/terps/taylor/sagadraw.h
+++ b/terps/taylor/sagadraw.h
@@ -21,7 +21,7 @@ typedef struct {
 } Image;
 
 uint8_t *DrawSagaPictureFromData(uint8_t *dataptr, int xsize, int ysize,
-                                     int xoff, int yoff, size_t datasize);
+    int xoff, int yoff, size_t datasize);
 
 void DrawSagaPictureNumber(int picture_number);
 void DrawSagaPictureFromBuffer(void);

--- a/terps/taylor/taylor.h
+++ b/terps/taylor/taylor.h
@@ -9,6 +9,7 @@
 #define taylor_h
 
 #include <stdlib.h>
+
 #include "glk.h"
 
 unsigned char WaitCharacter(void);
@@ -22,9 +23,9 @@ void Updates(event_t ev);
 void DrawBlack(void);
 void WriteToRoomDescriptionStream(const char *fmt, ...)
 #ifdef __GNUC__
-__attribute__((__format__(__printf__, 1, 2)))
+    __attribute__((__format__(__printf__, 1, 2)))
 #endif
-;
+    ;
 void CloseGraphicsWindow(void);
 void OpenGraphicsWindow(void);
 void OpenTopWindow(void);
@@ -40,15 +41,17 @@ void PrintFirstTenBytes(size_t offset);
 
 #define IsThing (Flag[31])
 
-#define debug_print(fmt, ...) \
-do { if (DEBUG_ACTIONS) fprintf(stderr, fmt, ##__VA_ARGS__); } while (0)
+#define debug_print(fmt, ...)                    \
+    do {                                         \
+        if (DEBUG_ACTIONS)                       \
+            fprintf(stderr, fmt, ##__VA_ARGS__); \
+    } while (0)
 
 #define MyLoc (Flag[0])
 
 #define CurrentGame (Game->gameID)
 #define Version (Game->type)
 #define BaseGame (Game->base_game)
-
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
@@ -224,15 +227,20 @@ typedef enum {
 } ActionType;
 
 typedef enum {
-    DEBUGGING = 1,    /* Info from database load */
-    NO_DELAYS = 2,     /* Skip all pauses */
-    FORCE_PALETTE_ZX = 4,     /* Force ZX Spectrum image palette */
-    FORCE_PALETTE_C64 = 8,     /* Force CBM 64 image palette */
-    FORCE_INVENTORY = 16,     /* Inventory in upper window always on */
-    FORCE_INVENTORY_OFF = 32     /* Inventory in upper window always off */
+    DEBUGGING = 1, /* Info from database load */
+    NO_DELAYS = 2, /* Skip all pauses */
+    FORCE_PALETTE_ZX = 4, /* Force ZX Spectrum image palette */
+    FORCE_PALETTE_C64 = 8, /* Force CBM 64 image palette */
+    FORCE_INVENTORY = 16, /* Inventory in upper window always on */
+    FORCE_INVENTORY_OFF = 32 /* Inventory in upper window always off */
 } OptionsType;
 
-typedef enum { NO_PALETTE, ZX, ZXOPT, C64A, C64B, VGA } palette_type;
+typedef enum { NO_PALETTE,
+    ZX,
+    ZXOPT,
+    C64A,
+    C64B,
+    VGA } palette_type;
 
 typedef enum {
     NO_TYPE,

--- a/terps/taylor/ui.c
+++ b/terps/taylor/ui.c
@@ -3,11 +3,10 @@
 //  Part of TaylorMade, an interpreter for Adventure Soft UK games
 //
 
-#include <stdlib.h>
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <ctype.h>
-
+#include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 
@@ -17,11 +16,11 @@
 #endif
 #include "glkstart.h"
 
+#include "animations.h"
+#include "layouttext.h"
+#include "sagadraw.h"
 #include "taylor.h"
 #include "utility.h"
-#include "sagadraw.h"
-#include "layouttext.h"
-#include "animations.h"
 
 #define GLK_BUFFER_ROCK 1
 #define GLK_STATUS_ROCK 1010
@@ -92,7 +91,7 @@ static int JustWroteNewline = 0;
 
 void PrintCharacter(unsigned char c)
 {
-    if(OutC == 0 &&  c == '\0')
+    if (OutC == 0 && c == '\0')
         return;
 
     if (c == '.' || c == '!') {
@@ -103,8 +102,8 @@ void PrintCharacter(unsigned char c)
         JustWrotePeriod = 0;
     }
 
-    if(CurrentWindow == Bottom) {
-        if(isspace(c)) {
+    if (CurrentWindow == Bottom) {
+        if (isspace(c)) {
             WordFlush(Bottom);
             if ((c == 10 || c == 13) && !JustWroteNewline) {
                 Display(Bottom, "\n");
@@ -117,21 +116,21 @@ void PrintCharacter(unsigned char c)
         JustWroteNewline = 0;
         OutWord[OutC] = c;
         OutC++;
-        if(OutC > 127)
+        if (OutC > 127)
             WordFlush(Bottom);
         return;
     } else {
-        if(isspace(c)) {
+        if (isspace(c)) {
             WordFlush(Top);
             WriteToRoomDescriptionStream(" ");
-            if(c == '\n') {
+            if (c == '\n') {
                 WriteToRoomDescriptionStream("\n");
             }
             return;
         }
         OutWord[OutC] = c;
         OutC++;
-        if(OutC == TopWidth)
+        if (OutC == TopWidth)
             WordFlush(Top);
     }
     return;
@@ -153,7 +152,7 @@ unsigned char WaitCharacter(void)
 static void WordFlush(winid_t win)
 {
     int i;
-    for(i = 0; i < OutC; i++) {
+    for (i = 0; i < OutC; i++) {
         if (win == Top)
             WriteToRoomDescriptionStream("%c", OutWord[i]);
         else
@@ -164,7 +163,6 @@ static void WordFlush(winid_t win)
 
 extern strid_t room_description_stream;
 extern char *roomdescbuf;
-
 
 void TopWindow(void)
 {
@@ -216,7 +214,7 @@ static void FlushRoomDescription(void)
     if (!(bottomheight < 3 && TopHeight < rows)) {
         glk_window_get_size(Top, &TopWidth, &TopHeight);
         glk_window_set_arrangement(o2, winmethod_Above | winmethod_Fixed, rows,
-                                   Top);
+            Top);
     } else {
         print_delimiter = 0;
     }
@@ -253,7 +251,7 @@ static void FlushRoomDescription(void)
     if (line < rows - 1) {
         glk_window_get_size(Top, &TopWidth, &TopHeight);
         glk_window_set_arrangement(o2, winmethod_Above | winmethod_Fixed,
-                                   MIN(rows - 1, TopHeight - 1), Top);
+            MIN(rows - 1, TopHeight - 1), Top);
     }
 
     free(text_with_breaks);
@@ -286,36 +284,36 @@ void Look(void);
 void OpenGraphicsWindow(void);
 void CloseGraphicsWindow(void);
 
-
-void UpdateSettings(void) {
+void UpdateSettings(void)
+{
 #ifdef SPATTERLIGHT
     if (gli_sa_delays)
         Options &= ~NO_DELAYS;
     else
         Options |= NO_DELAYS;
 
-    switch(gli_sa_inventory) {
-        case 0:
-            Options &= ~(FORCE_INVENTORY | FORCE_INVENTORY_OFF);
-            break;
-        case 1:
-            Options = (Options | FORCE_INVENTORY) & ~FORCE_INVENTORY_OFF;
-            break;
-        case 2:
-            Options = (Options | FORCE_INVENTORY_OFF) & ~FORCE_INVENTORY;
-            break;
+    switch (gli_sa_inventory) {
+    case 0:
+        Options &= ~(FORCE_INVENTORY | FORCE_INVENTORY_OFF);
+        break;
+    case 1:
+        Options = (Options | FORCE_INVENTORY) & ~FORCE_INVENTORY_OFF;
+        break;
+    case 2:
+        Options = (Options | FORCE_INVENTORY_OFF) & ~FORCE_INVENTORY;
+        break;
     }
 
-    switch(gli_sa_palette) {
-        case 0:
-            Options &= ~(FORCE_PALETTE_ZX | FORCE_PALETTE_C64);
-            break;
-        case 1:
-            Options = (Options | FORCE_PALETTE_ZX) & ~FORCE_PALETTE_C64;
-            break;
-        case 2:
-            Options = (Options | FORCE_PALETTE_C64) & ~FORCE_PALETTE_ZX;
-            break;
+    switch (gli_sa_palette) {
+    case 0:
+        Options &= ~(FORCE_PALETTE_ZX | FORCE_PALETTE_C64);
+        break;
+    case 1:
+        Options = (Options | FORCE_PALETTE_ZX) & ~FORCE_PALETTE_C64;
+        break;
+    case 2:
+        Options = (Options | FORCE_PALETTE_C64) & ~FORCE_PALETTE_ZX;
+        break;
     }
 #endif
     palette_type previous_pal = palchosen;
@@ -346,14 +344,14 @@ void Updates(event_t ev)
         Resizing = 0;
     } else if (ev.type == evtype_Timer) {
         switch (BaseGame) {
-            case REBEL_PLANET:
-                UpdateRebelAnimations();
-                break;
-            case KAYLETH:
-                UpdateKaylethAnimations();
-                break;
-            default:
-                break;
+        case REBEL_PLANET:
+            UpdateRebelAnimations();
+            break;
+        case KAYLETH:
+            UpdateKaylethAnimations();
+            break;
+        default:
+            break;
         }
     }
 }
@@ -405,7 +403,7 @@ void OpenGraphicsWindow(void)
         glk_window_get_size(Top, &TopWidth, &TopHeight);
         glk_window_close(Top, NULL);
         Graphics = glk_window_open(Bottom, winmethod_Above | winmethod_Proportional,
-                                   60, wintype_Graphics, GLK_GRAPHICS_ROCK);
+            60, wintype_Graphics, GLK_GRAPHICS_ROCK);
         glk_window_get_size(Graphics, &graphwidth, &graphheight);
         pixel_size = OptimalPictureSize(&optimal_width, &optimal_height);
         x_offset = ((int)graphwidth - (int)optimal_width) / 2;
@@ -413,7 +411,7 @@ void OpenGraphicsWindow(void)
         if (graphheight > optimal_height) {
             winid_t parent = glk_window_get_parent(Graphics);
             glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                       optimal_height, NULL);
+                optimal_height, NULL);
         }
 
         /* Set the graphics window background to match
@@ -422,24 +420,24 @@ void OpenGraphicsWindow(void)
          */
         glui32 background_color;
         if (glk_style_measure(Bottom, style_Normal, stylehint_BackColor,
-                              &background_color)) {
+                &background_color)) {
             glk_window_set_background_color(Graphics, background_color);
             glk_window_clear(Graphics);
         }
 
         Top = glk_window_open(Bottom, winmethod_Above | winmethod_Fixed, TopHeight,
-                              wintype_TextGrid, GLK_STATUS_ROCK);
+            wintype_TextGrid, GLK_STATUS_ROCK);
         glk_window_get_size(Top, &TopWidth, &TopHeight);
     } else {
         if (!Graphics)
             Graphics = glk_window_open(Bottom, winmethod_Above | winmethod_Proportional, 60,
-                                       wintype_Graphics, GLK_GRAPHICS_ROCK);
+                wintype_Graphics, GLK_GRAPHICS_ROCK);
         glk_window_get_size(Graphics, &graphwidth, &graphheight);
         pixel_size = OptimalPictureSize(&optimal_width, &optimal_height);
         x_offset = (graphwidth - optimal_width) / 2;
         winid_t parent = glk_window_get_parent(Graphics);
         glk_window_set_arrangement(parent, winmethod_Above | winmethod_Fixed,
-                                   optimal_height, NULL);
+            optimal_height, NULL);
     }
 }
 
@@ -448,7 +446,7 @@ void OpenTopWindow(void)
     Top = FindGlkWindowWithRock(GLK_STATUS_ROCK);
     if (Top == NULL) {
         Top = glk_window_open(Bottom, winmethod_Above | winmethod_Fixed,
-                              TopHeight, wintype_TextGrid, GLK_STATUS_ROCK);
+            TopHeight, wintype_TextGrid, GLK_STATUS_ROCK);
         if (Top == NULL) {
             Top = Bottom;
         } else {
@@ -460,10 +458,11 @@ void OpenTopWindow(void)
 void DrawBlack(void)
 {
     glk_window_fill_rect(Graphics, 0, x_offset, 0, 32 * 8 * pixel_size,
-                         12 * 8 * pixel_size);
+        12 * 8 * pixel_size);
 }
 
-void DrawRoomImage(void) {
+void DrawRoomImage(void)
+{
     if (MyLoc == 0 || (BaseGame == KAYLETH && MyLoc == 91) || NoGraphics) {
         return;
     }
@@ -473,7 +472,8 @@ void DrawRoomImage(void) {
     DrawSagaPictureFromBuffer();
 }
 
-void OpenBottomWindow(void) {
+void OpenBottomWindow(void)
+{
     Bottom = glk_window_open(0, 0, 0, wintype_TextBuffer, GLK_BUFFER_ROCK);
 }
 

--- a/terps/taylor/utility.c
+++ b/terps/taylor/utility.c
@@ -9,6 +9,7 @@
 
 #include "glk.h"
 #include "taylor.h"
+
 #include "utility.h"
 
 strid_t Transcript = NULL;
@@ -48,9 +49,9 @@ uint8_t *SeekToPos(uint8_t *buf, size_t offset)
 void print_memory(int address, int length)
 {
     unsigned char *p = FileImage + address;
-    for (int i = address; i <= address + length ; i += 16){
+    for (int i = address; i <= address + length; i += 16) {
         fprintf(stderr, "\n%04X:  ", i);
-        for (int j = 0; j < 16; j++){
+        for (int j = 0; j < 16; j++) {
             fprintf(stderr, "%02X ", *p++);
         }
     }
@@ -59,7 +60,7 @@ void print_memory(int address, int length)
 uint8_t *readFile(const char *name, size_t *size)
 {
     FILE *f = fopen(name, "r");
-    if(f == NULL)
+    if (f == NULL)
         return NULL;
 
     fseek(f, 0, SEEK_END);

--- a/terps/taylor/utility.h
+++ b/terps/taylor/utility.h
@@ -9,6 +9,7 @@
 #define utility_h
 
 #include <stdio.h>
+
 #include "glk.h"
 
 void Display(winid_t w, const char *fmt, ...);


### PR DESCRIPTION
This PR depends on #769.

The TaylorMade version of *Questprobe 3* uses ASCII 31 (unit separator) as string separators, which are included in the output of Gargoyle as a symbol. We fix this by filtering out all control characters except newline (ASCII 10).

<img width="796" alt="Skärmavbild 2023-03-19 kl  12 34 31" src="https://user-images.githubusercontent.com/5066755/226172580-b9278fa2-ffa0-459a-8704-e14de2be20f8.png">
