### PR TITLE
Don't allow Alan games to call system()

### DIFF
--- a/terps/alan2/exe.c
+++ b/terps/alan2/exe.c
@@ -125,7 +125,11 @@ void sys(fpos, len)
 
   getstr(fpos, len);            /* Returns address to string on stack */
   command = (char *)pop();
+  // Gargoyle will not allow games to run arbitrary programs.
+#ifndef GARGLK
   int tmp = system(command);
+#endif
+  printf("Command was %s\n", command);
   free(command);
 }
 

--- a/terps/alan3/exe.c
+++ b/terps/alan3/exe.c
@@ -148,8 +148,11 @@ void sys(Aword fpos, Aword len)
     char *command;
 
     command = getStringFromFile(fpos, len);
+    // Gargoyle will not allow games to run arbitrary programs.
+#ifndef GARGLK
     if (system(command) == -1)
         /* Ignore errors */;
+#endif
     deallocate(command);
 }
 


### PR DESCRIPTION
There is apparently an Alan statement called "system" which just passes a string through to the host's system() function. I can't find any documentation on this statement, but from the code it looks like completely arbitrary strings can be passed, which is incredibly dangerous. Ban these calls in Gargoyle.