### PR TITLE
Update Fedora build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -146,11 +146,11 @@ installer.
 
 # System-specific instructions
 
-## Building on Fedora GNU/Linux (29,30): (notes by Andreas Davour, December 2019)
+## Building on Fedora GNU/Linux (37, 38): (notes by Andreas Davour, December 2019; updated April 2023)
 
 To build cleanly with CMake, you first need to install the pre-requisite packages:
 
-    sudo dnf install cmake fontconfig-devel freetype-devel gcc-c++ libjpeg-turbo-devel qt5-qtbase-devel qt5-qtbase
+    sudo dnf install cmake fmt-devel fontconfig-devel freetype-devel gcc-c++ libpng-devel qt5-qtbase-devel qt5-qtbase turbojpeg-devel zlib-devel
 
 If you want to compile with SDL support, you also need to install the development packages for that:
 


### PR DESCRIPTION
Instructions to build Gargoyle on Fedora are slightly outdated. This commit includes a few missing dependencies and, more importantly, replaces `libjpeg-turbo-devel` with `turbojpeg-devel`. Both packages apparently provide the  same libjpeg-turbo library but the former identifies as libjpeg and the latter properly as libjpeg-turbo.

Because of Gargoyle’s recent changes to libjpeg requirements, it is currently impossible to build with `libjpeg-turbo-devel` despite it working in the past, but `turbojpeg-devel` allows it to build without problems.