### PR TITLE
typo that will creep in all the binaries

### DIFF
--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -320,7 +320,7 @@ gcolor 10     606060  ffffff  # User2
 # Gargoyle also comes with several other themes, and you can provide your own
 # themes as well. To see a list of available themes, use Shift-Control-T while
 # Gargoyle is running. To see a list of theme paths (where you can add your own
-# themes), use Control-period. MacOS users subtitute Command for Control.
+# themes), use Control-period. MacOS users substitute Command for Control.
 # This must come after all other color settings, or they will override the theme.
 # See THEMES.md for information on how themes are created.
 theme system


### PR DESCRIPTION
this typo was found by Debian's lintian.