### PR TITLE
TaylorMade update

### DIFF
--- a/terps/taylor/FORMAT
+++ b/terps/taylor/FORMAT
@@ -88,28 +88,30 @@ rules.
 Drawing Codes:
 
 0xFF		End
-0xFE		733C
-0xFD		6FF5 arg 0-7, arg 0-7
-0xFC		76D4 arg1 arg2 arg3 arg4
+0xFE		733C mirror area x0 y0 width y1
+0xFD		6FF5 arg 0-7, arg 0-7 replace colour arg1 with arg2
+0xFC		76D4 arg1 arg2 arg3 arg4 draw color, args y, x, height, colour, width
+		(in early games x, y, colour, length)
 		Seems to be
-		setattributes (arg1,arg2, height, attribute, width)
+		set attributes (arg1, arg2, height, attribute, width)
 		where arg1=y arg2=x in chars 0,0 top left
 0xFB		700D
 		Make picture attribute area bright
-0xFA		7512
+0xFA		7512 Flip image horizontally
 0xF9		DrawPicture n	(following byte)
-0xF8		729D
-0xF7		743A arg1 }
+0xF8		729D Skip rest of picture if object arg1 is not present
+		Early games: Draw picture arg1 at x y
+0xF7		743A arg1 } Rebel Planet: Stop drawing if alcove is unlocked
 0xF6		744E arg1 } set A to 0 4 or 8 and call same method
 0xF5		7444 arg1 }
 0xF4		7458 arg1
-	End of object arg1 is not present
-0xF3		7409
-0xF2		7331 arg1 arg2 arg3 arg4
-0xF1		73FE
-0xEE		7507
-0xED		7654
-0xEC		7649
+	End if object arg1 is not present
+0xF3		7409 Mirror top half vertically
+0xF2		7331 arg1 arg2 arg3 arg4 Mirror area horizontally
+0xF1		73FE Mirror area vertically
+0xEE		7507 Flip area horizontally
+0xED		7654 Flip image vertically
+0xEC		7649 Flip area vertically
 0xEB		CRASH
 0xEA		CRASH
 0xE9		7678 arg1 arg2 ..

--- a/terps/taylor/README
+++ b/terps/taylor/README
@@ -1,3 +1,21 @@
+Forker's note
+
+This is a fork of the original TaylorMade interpreter by Alan Cox. I've
+ported it to the Glk api and added support for "Questprobe featuring The
+Human Torch and The Thing", graphics and animations, and a couple of beeps
+in "Rebel Planet".
+
+The following "extra commands" are added to all games, though some games
+already had some of them:
+
+#RESTART, #RESTORE, #TRANSCRIPT ON, #TRANSCRIPT OFF, #QUICKSAVE, #QUICKLOAD,
+and UNDO.
+
+-- Petter Sjölund, May 2023
+
+
+Original README:
+
 
 	TaylorMade v0.4		(c) 2004 - 2016 Alan Cox
 				All Rights Reserved

--- a/terps/taylor/animations.c
+++ b/terps/taylor/animations.c
@@ -35,7 +35,7 @@ static int KaylethAnimationIndex = 0;
 static int AnimationStage = 0;
 static int ClickShelfStage = 0;
 
-extern uint8_t buffer[384][9];
+extern uint8_t screenbuf[768][9];
 extern Image *images;
 extern int draw_to_buffer;
 
@@ -53,35 +53,35 @@ static void AnimateStars(void)
             /* because the bytes are flipped in our implementation */
             /* for some reason */
             for (int col = 15; col > 5; col--) {
-                uint8_t attribute = buffer[col + line * 32][8];
+                uint8_t attribute = screenbuf[col + line * 32][8];
                 glui32 ink = attribute & 7;
                 ink += 8 * ((attribute & 64) == 64);
                 ink = Remap(ink);
                 for (int bit = 0; bit < 8; bit++) {
-                    if ((buffer[col + line * 32][pixrow] & (1 << bit)) != 0) {
+                    if ((screenbuf[col + line * 32][pixrow] & (1 << bit)) != 0) {
                         PutPixel(col * 8 + bit, line * 8 + pixrow, ink);
                     }
                 }
-                carry = rotate_right_with_carry(&(buffer[col + line * 32][pixrow]), carry);
+                carry = rotate_right_with_carry(&(screenbuf[col + line * 32][pixrow]), carry);
             }
             if (carry) {
-                buffer[line * 32 + 15][pixrow] = buffer[line * 32 + 15][pixrow] | 128;
+                screenbuf[line * 32 + 15][pixrow] = screenbuf[line * 32 + 15][pixrow] | 128;
             }
             carry = 0;
             /* Then the right half */
             for (int col = 16; col < 26; col++) {
-                uint8_t attribute = buffer[col + line * 32][8];
+                uint8_t attribute = screenbuf[col + line * 32][8];
                 glui32 ink = attribute & 7;
                 ink += 8 * ((attribute & 64) == 64);
                 ink = Remap(ink);
                 for (int pix = 0; pix < 8; pix++) {
-                    if ((buffer[col + line * 32][pixrow] & (1 << pix)) != 0) {
+                    if ((screenbuf[col + line * 32][pixrow] & (1 << pix)) != 0) {
                         PutPixel(col * 8 + pix, line * 8 + pixrow, ink);
                     }
                 }
-                carry = rotate_left_with_carry(&(buffer[col + line * 32][pixrow]), carry);
+                carry = rotate_left_with_carry(&(screenbuf[col + line * 32][pixrow]), carry);
             }
-            buffer[line * 32 + 16][pixrow] = buffer[line * 32 + 16][pixrow] | carry;
+            screenbuf[line * 32 + 16][pixrow] = screenbuf[line * 32 + 16][pixrow] | carry;
         }
     }
 }
@@ -93,7 +93,7 @@ static void AnimateForcefield(void)
     RectFill(104, 16, 48, 39, 0, 0);
     /* We go line by line and pixel row by pixel row */
 
-    uint8_t colour = buffer[2 * 32 + 13][8];
+    uint8_t colour = screenbuf[2 * 32 + 13][8];
     glui32 ink = Remap(colour & 0x7);
 
     for (int line = 2; line < 7; line++) {
@@ -101,7 +101,7 @@ static void AnimateForcefield(void)
             carry = 0;
             for (int col = 13; col < 19; col++) {
                 for (int pix = 0; pix < 8; pix++) {
-                    if ((buffer[col + line * 32][pixrow] & (1 << pix)) != 0) {
+                    if ((screenbuf[col + line * 32][pixrow] & (1 << pix)) != 0) {
                         PutPixel(col * 8 + pix, line * 8 + pixrow, ink);
                     }
                 }
@@ -109,9 +109,9 @@ static void AnimateForcefield(void)
                 /* byte by byte, but we actually rotate to the left */
                 /* because the bytes are flipped in our implementation */
                 /* for some reason */
-                carry = rotate_left_with_carry(&(buffer[col + line * 32][pixrow]), carry);
+                carry = rotate_left_with_carry(&(screenbuf[col + line * 32][pixrow]), carry);
             }
-            buffer[line * 32 + 13][pixrow] = buffer[line * 32 + 13][pixrow] | carry;
+            screenbuf[line * 32 + 13][pixrow] = screenbuf[line * 32 + 13][pixrow] | carry;
         }
     }
 }
@@ -122,7 +122,7 @@ static void FillCell(int cell, glui32 ink)
     int starty = (cell / 32) * 8;
     for (int pixrow = 0; pixrow < 8; pixrow++) {
         for (int pix = 0; pix < 8; pix++) {
-            if ((buffer[cell][pixrow] & (1 << pix)) == 0) {
+            if ((screenbuf[cell][pixrow] & (1 << pix)) == 0) {
                 PutPixel(startx + pix, starty + pixrow, ink);
             }
         }
@@ -178,21 +178,21 @@ static void AnimateKaylethClickShelves(int stage)
                 int ypos = line * 8 + i + stage;
                 if (ypos > 79)
                     ypos = ypos - 80;
-                uint8_t attribute = buffer[col + (ypos / 8) * 32][8];
+                uint8_t attribute = screenbuf[col + (ypos / 8) * 32][8];
                 glui32 ink = attribute & 7;
                 ink += 8 * ((attribute & 64) == 64);
-                attribute = buffer[col + ((79 - ypos) / 8) * 32][8];
+                attribute = screenbuf[col + ((79 - ypos) / 8) * 32][8];
                 glui32 ink2 = attribute & 7;
                 ink2 += 8 * ((attribute & 64) == 64);
                 ink = Remap(ink);
                 ink2 = Remap(ink2);
                 for (int j = 0; j < 8; j++)
                     if (col > 15) {
-                        if ((buffer[col + line * 32][i] & (1 << j)) != 0) {
+                        if ((screenbuf[col + line * 32][i] & (1 << j)) != 0) {
                             PutPixel(col * 8 + j, ypos, ink);
                         }
                     } else {
-                        if ((buffer[col + (9 - line) * 32][7 - i] & (1 << j)) != 0) {
+                        if ((screenbuf[col + (9 - line) * 32][7 - i] & (1 << j)) != 0) {
                             PutPixel(col * 8 + j, 79 - ypos, ink2);
                         }
                     }
@@ -201,69 +201,118 @@ static void AnimateKaylethClickShelves(int stage)
     }
 }
 
+struct KaylethAnimationFrame {
+    int counter_to_draw_at;
+    int counter;
+    int image;
+};
+
+struct KaylethAnimation {
+    int start_frame;
+    int required_object;
+    int number_of_frames;
+    int current_frame;
+    struct KaylethAnimationFrame *frames;
+};
+
+struct KaylethAnimation **KaylethAnimations = NULL;
+
+// This is really the number of rooms. We use NULL for rooms without animation.
+#define NUMBER_OF_KAYLETH_ANIMATIONS 92
+
+void LoadKaylethAnimationData(void)
+{
+    KaylethAnimations = MemAlloc(sizeof(struct KaylethAnimation *) * NUMBER_OF_KAYLETH_ANIMATIONS);
+    KaylethAnimations[0] = NULL;
+    uint8_t *ptr = &FileImage[AnimationData];
+    int counter = 0;
+    while (counter < NUMBER_OF_KAYLETH_ANIMATIONS) {
+        while (*ptr == 0xff) {
+            // No animation for this room
+            KaylethAnimations[counter] = NULL;
+            counter++;
+            ptr++;
+        }
+        if (counter < NUMBER_OF_KAYLETH_ANIMATIONS) {
+            struct KaylethAnimation *anim = MemAlloc(sizeof(struct KaylethAnimation));
+            anim->start_frame = *ptr / 3;
+            ptr++;
+            anim->current_frame = 0;
+            anim->required_object = *ptr;
+            ptr += 2; // Skipping skip byte, always zero initially
+            anim->number_of_frames = 0;
+            for (int i = 0; ptr[i] != 0xff; i += 3) {
+                anim->number_of_frames++;
+            }
+            anim->frames = MemAlloc(anim->number_of_frames * sizeof(struct KaylethAnimationFrame));
+            for (int i = 0; i < anim->number_of_frames; i++) {
+                anim->frames[i].counter_to_draw_at = *ptr;
+                anim->frames[i].counter = 0;
+                ptr += 2; // Skipping counter byte, always zero initially
+                anim->frames[i].image = *ptr++;
+            }
+
+            // Hack Azap chamber animations to look more like the original
+            if (anim->frames[0].image == 118) {
+                anim->frames[1].counter_to_draw_at = 5;
+                anim->frames[3].counter_to_draw_at = 5;
+                anim->frames[4].counter_to_draw_at = 8;
+            }
+
+            KaylethAnimations[counter++] = anim;
+
+            ptr++;
+        }
+    }
+
+    // Hack assembly line animation 2 to look more like the original
+    KaylethAnimations[2]->frames[0].counter_to_draw_at = 10;
+    KaylethAnimations[2]->frames[1].counter_to_draw_at = 20;
+    KaylethAnimations[2]->frames[2].counter_to_draw_at = 20;
+}
+
 static int UpdateKaylethAnimationFrames(void) // Draw animation frame
 {
-    if (MyLoc == 0) {
+    if (KaylethAnimations[MyLoc] == NULL) {
         return 0;
     }
 
-    uint8_t *ptr = &FileImage[AnimationData];
-    int counter = 0;
-    // Jump to animation index equal to location index
-    // Animations are delimited by 0xff
-    do {
-        if (*ptr == 0xff)
-            counter++;
-        ptr++;
-    } while (counter < MyLoc);
+    // Temporarily set object 0 to this location
+    int obj0loc = ObjectLoc[0];
+    ObjectLoc[0] = MyLoc;
+    // And object 122 if the destroyer droid has caught us
+    if (Flag[10] > 1)
+        ObjectLoc[122] = MyLoc;
 
-    while (1) {
-        if (*ptr == 0xff) {
-            return 0;
-        }
-        int Stage = *ptr;
-        ptr++;
-        uint8_t *LastInstruction = ptr;
-        if (ObjectLoc[*ptr] != MyLoc && *ptr != 0 && *ptr != 122) {
-            //Returning because location of object *ptr is not current location
-            return 0;
-        }
-        ptr++;
-        // Reset animation if we are in a new room
-        if (KaylethAnimationIndex != MyLoc) {
-            KaylethAnimationIndex = MyLoc;
-            *ptr = 0;
-        }
+    struct KaylethAnimation *anim = KaylethAnimations[MyLoc];
 
-        ptr += *ptr + 1;
-        int AnimationRate = *ptr;
+    // Reset animation if we are in a new room
+    if (KaylethAnimationIndex != MyLoc) {
+        KaylethAnimationIndex = MyLoc;
+        anim->current_frame = 0;
+    }
 
-        // This is needed to make conveyor belt animation 2 smooth
-        // (the one you see after getting up)
-        // No idea why, this code is still largely a mystery
-        if (KaylethAnimationIndex == 2 && AnimationRate == 50)
-            AnimationRate = 10;
+    if (ObjectLoc[anim->required_object] == MyLoc) {
 
-        if (AnimationRate != 0xff) {
-            ptr++;
-            (*ptr)++;
-            if (AnimationRate == *ptr) {
-                *ptr = 0;
-                // Draw "room image" *(ptr + 1) (Actually an animation frame)
-                int result = *(ptr + 1);
-                DrawTaylor(result);
-                DrawSagaPictureFromBuffer();
-                ptr = LastInstruction + 1;
-                (*ptr) += 3;
-                return result;
+        struct KaylethAnimationFrame *frame = &anim->frames[anim->current_frame];
+
+        if (frame->counter >= frame->counter_to_draw_at) {
+            DrawTaylor(frame->image);
+            DrawSagaPictureFromBuffer();
+            anim->current_frame++;
+            frame->counter = 0;
+            if (anim->current_frame >= anim->number_of_frames) {
+                anim->current_frame = anim->start_frame;
             }
-            return 1;
         } else {
-            ptr = LastInstruction + 1;
-            *ptr = Stage;
-            ptr -= 2;
+            frame->counter++;
         }
     }
+
+    // Reset the temporarily moved objects
+    ObjectLoc[0] = obj0loc;
+    ObjectLoc[122] = DESTROYED;
+    return 1;
 }
 
 void UpdateKaylethAnimations(void)
@@ -370,11 +419,8 @@ void StartAnimations(void)
             speed = 20;
             KaylethAnimationIndex = 0;
         }
-        if (ObjectLoc[0] == MyLoc) { // Azap chamber
-            if (CurrentGame == KAYLETH_64)
-                speed = 30;
-            else
-                speed = 13;
+        if (ObjectLoc[0] == MyLoc && CurrentGame == KAYLETH_64) { // Azap chamber
+            speed = 30;
         }
         switch (MyLoc) {
         case 1:
@@ -389,14 +435,21 @@ void StartAnimations(void)
             else
                 speed = 40;
             break;
-        case 53: // Twin peril forest
-            speed = 350;
-            break;
-        case 56: // Citadel of Zenron
-            speed = 40;
+        case 32: // Videodrome
+            speed = 50;
             break;
         case 36: // Guard dome
             speed = 12;
+            break;
+        case 52:
+        case 53: // Twin peril forest
+            if (ObjectLoc[30] == MyLoc) {
+                speed = 150;
+                UpdateKaylethAnimationFrames();
+            }
+            break;
+        case 56: // Citadel of Zenron
+            speed = 40;
             break;
         default:
             break;

--- a/terps/taylor/extracommands.h
+++ b/terps/taylor/extracommands.h
@@ -11,5 +11,8 @@
 #include <stdio.h>
 
 int TryExtraCommand(void);
+int ParseExtraCommand(char *p);
+
+#define EXTRA_COMMAND 0xffff
 
 #endif /* extracommands_h */

--- a/terps/taylor/gameinfo.c
+++ b/terps/taylor/gameinfo.c
@@ -29,13 +29,13 @@ struct GameInfo games[NUMGAMES] = {
         0x2000, // start_of_messages
         0,      // second message bank
 
-        0x6100, // start_of_characters;
-        0x6916, // start_of_image_data;
-        0x381c, // image patterns lookup table;
+        0x6100, // start_of_characters
+        0x6916, // start_of_image_data
+        0x381c, // image patterns lookup table
         0x001c, // number of patterns
         0x009f, // patterns end marker
         0x878b, // start of room image instructions
-        57,     // number_of_image blocks;
+        57,     // number_of_image blocks
         ZXOPT   // palette
     },
 
@@ -57,13 +57,13 @@ struct GameInfo games[NUMGAMES] = {
         0x0142, // start_of_messages
         0,      // second message bank
 
-        0xbb02, // start_of_characters;
-        0x6058, // start_of_image_data;
-        0x381c, // image patterns lookup table;
+        0xbb02, // start_of_characters
+        0x6058, // start_of_image_data
+        0x381c, // image patterns lookup table
         0x001c, // number of patterns
         0x009f, // patterns end marker
         0x878b, // start of room image instructions
-        57,     // number_of_image blocks;
+        57,     // number_of_image blocks
         C64A    // palette
     },
 
@@ -147,7 +147,7 @@ struct GameInfo games[NUMGAMES] = {
         0,      // number of patterns
         0,      // patterns end marker
         0x7798, // start of room image instructions
-        114,    // number_of_image blocks;
+        114,    // number_of_image blocks
         ZXOPT   // palette
     },
 
@@ -197,13 +197,13 @@ struct GameInfo games[NUMGAMES] = {
         0x6737, // start_of_messages
         0x1923, // second message bank
 
-        0x8008, // start_of_characters;
-        0x8718, // start_of_image_data;
-        0,      // image patterns lookup table;
+        0x8008, // start_of_characters
+        0x8718, // start_of_image_data
+        0,      // image patterns lookup table
         0,      // number of patterns
         0,      // patterns end marker
         0x4808, // start of room image instructions
-        139,    // number_of_image blocks;
+        139,    // number_of_image blocks
         C64B    // palette
     },
 
@@ -225,13 +225,13 @@ struct GameInfo games[NUMGAMES] = {
         0x667d, // start_of_messages
         0x75d0, // second message bank
 
-        0x83cb, // start_of_characters;
-        0x8a33, // start_of_image_blocks;
-        0x3837, // image patterns lookup table;
+        0x83cb, // start_of_characters
+        0x8a33, // start_of_image_blocks
+        0x3837, // image patterns lookup table
         0x0012, // number of patterns
         0x00aa, // patterns end marker
         0x7b75, // start of room image instructions
-        143,    // number_of_image blocks;
+        143,    // number_of_image blocks
         ZXOPT   // palette
     },
 
@@ -253,13 +253,13 @@ struct GameInfo games[NUMGAMES] = {
         0x5fd9, // start_of_messages
         0x73b7, // second message bank
 
-        0,      // start_of_characters;
-        0,      // start_of_image_blocks;
-        0,      // image patterns lookup table;
+        0,      // start_of_characters
+        0,      // start_of_image_blocks
+        0,      // image patterns lookup table
         0,      // number of patterns
         0,      // patterns end marker
         0,      // start of room image instructions
-        0,      // number_of_image blocks;
+        0,      // number_of_image blocks
         0       // palette
     },
 
@@ -281,13 +281,13 @@ struct GameInfo games[NUMGAMES] = {
         0x5fd9, // start_of_messages
         0x73b7, // second message bank
 
-        0x83cb, // start_of_characters;
-        0x8a33, // start_of_image_blocks;
-        0x3837, // image patterns lookup table;
+        0x83cb, // start_of_characters
+        0x8a33, // start_of_image_blocks
+        0x3837, // image patterns lookup table
         0x0012, // number of patterns
         0x00aa, // patterns end marker
         0x7b75, // start of room image instructions
-        143,    // number_of_image blocks;
+        143,    // number_of_image blocks
         ZXOPT   // palette
     },
 
@@ -309,13 +309,13 @@ struct GameInfo games[NUMGAMES] = {
         0x6bba, // start_of_messages
         0x7b0d, // second message bank
 
-        0x8048, // start_of_characters;
-        0x86b0, // start_of_image_blocks;
-        0,      // image patterns lookup table;
+        0x8048, // start_of_characters
+        0x86b0, // start_of_image_blocks
+        0,      // image patterns lookup table
         0,      // number of patterns
         0,      // patterns end marker
         0x4708, // start of room image instructions
-        143,    // number_of_image blocks;
+        143,    // number_of_image blocks
         C64B    // palette
     },
 
@@ -337,13 +337,13 @@ struct GameInfo games[NUMGAMES] = {
         0x6438, // start_of_messages
         0x7816, // second message bank
 
-        0,      // start_of_characters;
-        0,      // start_of_image_blocks;
-        0,      // image patterns lookup table;
+        0,      // start_of_characters
+        0,      // start_of_image_blocks
+        0,      // image patterns lookup table
         0,      // number of patterns
         0,      // patterns end marker
         0,      // start of room image instructions
-        0,      // number_of_image blocks;
+        0,      // number_of_image blocks
         C64B    // palette
     },
 
@@ -365,13 +365,13 @@ struct GameInfo games[NUMGAMES] = {
         0x6438, // start_of_messages
         0x7816, // second message bank
 
-        0x8888, // start_of_characters;
-        0x8ef0, // start_of_image_blocks;
-        0,      // image patterns lookup table;
+        0x8888, // start_of_characters
+        0x8ef0, // start_of_image_blocks
+        0,      // image patterns lookup table
         0,      // number of patterns
         0,      // patterns end marker
         0x16ea, // start of room image instructions
-        143,    // number_of_image blocks;
+        143,    // number_of_image blocks
         C64B    // palette
     },
 
@@ -393,13 +393,13 @@ struct GameInfo games[NUMGAMES] = {
         0x5a99, // start_of_messages
         0x769d, // second message bank
 
-        0x95f0, // start_of_characters;
-        0x9ce0, // start_of_image_blocks;
-        0x38B6, // image patterns lookup table;
-        0x1f,   // number of patterns
-        0x8e,   // patterns end marker
+        0x95f0, // start_of_characters
+        0x9ce0, // start_of_image_blocks
+        0x38B6, // image patterns lookup table
+        0x001f, // number of patterns
+        0x008e, // patterns end marker
         0x8279, // start of room image instructions
-        210,    // number_of_image blocks;
+        210,    // number_of_image blocks
         ZXOPT   // palette
     },
 
@@ -421,13 +421,13 @@ struct GameInfo games[NUMGAMES] = {
         0x9579, // start_of_messages
         0xb17d, // second message bank
 
-        0xc028, // start_of_characters;
-        0x5b28, // start_of_image_blocks;
-        0,      // image patterns lookup table;
+        0xc028, // start_of_characters
+        0x5b28, // start_of_image_blocks
+        0,      // image patterns lookup table
         0,      // number of patterns
         0,      // patterns end marker
         0x0012, // start of room image instructions
-        210,    // number_of_image blocks;
+        210,    // number_of_image blocks
         C64B    // palette
     },
 // clang-format on

--- a/terps/taylor/parseinput.c
+++ b/terps/taylor/parseinput.c
@@ -27,6 +27,8 @@ int WordsInInput = 0;
 // The index in InputWordStrings of the next command
 int WordIndex = 0;
 
+int FoundExtraCommand = 0;
+
 void FreeInputWords(void)
 {
     WordIndex = 0;
@@ -139,11 +141,6 @@ void LineInput(void)
         int length = ev.val1;
         buf[length] = 0;
 
-        if (Transcript) {
-            glk_put_string_stream(Transcript, buf);
-            glk_put_string_stream(Transcript, "\n");
-        }
-
         SplitIntoWords(buf, length);
 
         if (WordsInInput >= MAX_WORDS) {
@@ -201,6 +198,10 @@ int ParseWord(char *p)
             }
         }
     }
+
+    if (ParseExtraCommand(p)) {
+        FoundExtraCommand = 1;
+    }
     return 0;
 }
 
@@ -248,6 +249,8 @@ static int FindNextCommandDelimiter(void)
 void Parser(void)
 {
     int i;
+
+    FoundExtraCommand = 0;
 
     /* Is there input remaining to be analyzed? */
     if (!FindNextCommandDelimiter()) {

--- a/terps/taylor/restorestate.c
+++ b/terps/taylor/restorestate.c
@@ -87,8 +87,10 @@ void SaveUndo(void)
     }
 }
 
-void RestoreUndo(int game)
+void RestoreUndo(int from_player)
 {
+    just_undid = 1;
+
     if (JustStarted) {
         Display(Bottom, "You can't undo on first turn\n");
         return;
@@ -102,11 +104,13 @@ void RestoreUndo(int game)
     if (last_undo->previousState == NULL)
         oldest_undo = last_undo;
     RestoreState(last_undo);
-    if (game)
+    if (from_player) {
         Display(Bottom, "Move undone.\n");
+    } else {
+        just_undid = 0;
+    }
     free(current);
     number_of_undos--;
-    just_undid = 1;
 }
 
 void RamSave(int game)

--- a/terps/taylor/sagadraw.h
+++ b/terps/taylor/sagadraw.h
@@ -39,6 +39,8 @@ void DrawTaylor(int loc);
 void ClearGraphMem(void);
 int32_t Remap(int32_t color);
 
+void PatchAndDrawQP3Cannon(void);
+
 extern palette_type palchosen;
 
 extern int white_colour;

--- a/terps/taylor/taylor.h
+++ b/terps/taylor/taylor.h
@@ -39,15 +39,11 @@ void PrintFirstTenBytes(size_t offset);
 
 #define DEBUG_ACTIONS 0
 
-#define IsThing (Flag[31])
-
 #define debug_print(fmt, ...)                    \
     do {                                         \
         if (DEBUG_ACTIONS)                       \
             fprintf(stderr, fmt, ##__VA_ARGS__); \
     } while (0)
-
-#define MyLoc (Flag[0])
 
 #define CurrentGame (Game->gameID)
 #define Version (Game->type)
@@ -55,6 +51,25 @@ void PrintFirstTenBytes(size_t offset);
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+
+#ifdef SPATTERLIGHT
+#define TAYLOR_GRAPHICS_ENABLED gli_enable_graphics
+#else
+#define TAYLOR_GRAPHICS_ENABLED glk_gestalt(gestalt_Graphics, 0)
+#endif
+
+#define MyLoc (Flag[0])
+#define OtherGuyLoc (Flag[1])
+#define OtherGuyInv (Flag[3])
+#define MaxCarried (Flag[4])
+#define ItemsCarried (Flag[5])
+#define TurnsLow (Flag[26])
+#define TurnsHigh (Flag[27])
+#define IsThing (Flag[31])
+#define ThingAsphyx (Flag[47])
+#define TorchAsphyx (Flag[48])
+#define DrawImages (Flag[52])
+#define Q3SwitchedWatch (Flag[126])
 
 typedef enum {
     QUESTPROBE3,

--- a/terps/taylor/ui.c
+++ b/terps/taylor/ui.c
@@ -61,8 +61,6 @@ void Display(winid_t w, const char *fmt, ...)
     va_end(ap);
 
     glk_put_string_stream(glk_window_get_stream(w), msg);
-    if (Transcript && w == Bottom)
-        glk_put_string_stream(Transcript, msg);
 }
 
 void HitEnter(void)
@@ -162,7 +160,7 @@ static void WordFlush(winid_t win)
 }
 
 extern strid_t room_description_stream;
-extern char *roomdescbuf;
+char *roomdescbuf = NULL;
 
 void TopWindow(void)
 {
@@ -266,10 +264,6 @@ static void FlushRoomDescription(void)
     }
 }
 
-char *roomdescbuf = NULL;
-
-extern int PendSpace;
-
 void BottomWindow(void)
 {
     WordFlush(Top);
@@ -342,7 +336,7 @@ void Updates(event_t ev)
         CloseGraphicsWindow();
         Look();
         Resizing = 0;
-    } else if (ev.type == evtype_Timer) {
+    } else if (ev.type == evtype_Timer && TAYLOR_GRAPHICS_ENABLED) {
         switch (BaseGame) {
         case REBEL_PLANET:
             UpdateRebelAnimations();


### PR DESCRIPTION
EDIT: Now it should work.

Improved formatting of gameinfo.c

Added some minimal documentation of the extra commands.

Extra commands like TRANSCRIPT OFF was broken in games that defined OFF in their internal dictionary (and TRANSCRIPT ON if they defined ON, and so on.)

Fixed some problems with undo. It would skip some turns and occasionally break. It is no longer possible to undo into the _Kayleth_ "intro location".

Renamed `buffer[]` array to not shadow local LibSpectrum variables.

One animation in _Kayleth_ (the firing android) would not show at all. Other animations are closer to how they looked on the original hardware, and the animation code is a little more readable.

Energy display in _Rebel Planet_ said 0 where it should say 00.

Multiple waiting now matches the originals. It actually waits one extra turn, but won't print a message for the last one.

Gives the same error messages as the originals: One of three depending on whether it understood none of the input words ("I can’t compute that... sorry!"), only understood a noun but no verb ("Please try varying that verb"), or found a verb but no matching command ("That’s not possible.")