### PR TITLE
Update ScottFree

### DIFF
--- a/terps/scott/ai_uk/game_specific.c
+++ b/terps/scott/ai_uk/game_specific.c
@@ -107,9 +107,9 @@ void SecretAction(int p)
 void AdventurelandDarkness(void)
 {
     if ((Rooms[MyLoc].Image & 128) == 128)
-        BitFlags |= 1 << DARKBIT;
+        SetDark();
     else
-        BitFlags &= ~(1 << DARKBIT);
+        SetLight();
 }
 
 void AdventurelandAction(int p)
@@ -135,6 +135,7 @@ void AdventurelandAction(int p)
     DrawImage(image);
     Output("\n");
     Output(sys[HIT_ENTER]);
+    showing_closeup = 1;
     HitEnter();
     return;
 }

--- a/terps/scott/parser.c
+++ b/terps/scott/parser.c
@@ -19,7 +19,6 @@
 #define MAX_WORDS 128
 #define MAX_BUFFER 128
 
-extern strid_t Transcript;
 extern struct Command *CurrentCommand;
 
 glui32 **UnicodeWords = NULL;
@@ -55,6 +54,7 @@ const char *ExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
     "load",
     "#restore",
     "transcript",
+    "#transcript",
     "script",
     "#script",
     "oops",
@@ -73,6 +73,7 @@ const char *ExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
     "#qsave",
     "except",
     "but",
+    "#flicker",
     "", "", "", "", ""
 };
 
@@ -86,6 +87,7 @@ const char *GermanExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
     "load",
     "#restore",
     "transcript",
+    "#transcript",
     "script",
     "#script",
     "oops",
@@ -104,6 +106,7 @@ const char *GermanExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
     "#qsave",
     "ausser",
     "bis",
+    "#flicker",
     "laden",
     "wiederherstellen",
     "transkript",
@@ -121,6 +124,7 @@ const char *SpanishExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
     "load",
     "#restore",
     "transcript",
+    "#transcript",
     "script",
     "#script",
     "oops",
@@ -139,6 +143,7 @@ const char *SpanishExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
     "#qsave",
     "excepto",
     "menos",
+    "#flicker",
     "reanuda",
     "cargar",
     "transcripcion",
@@ -148,9 +153,9 @@ const char *SpanishExtraCommands[NUMBER_OF_EXTRA_COMMANDS] = {
 
 extra_command ExtraCommandsKey[NUMBER_OF_EXTRA_COMMANDS] = {
     NO_COMMAND, RESTART, RESTART, SAVE, SAVE, RESTORE, RESTORE,
-    RESTORE, SCRIPT, SCRIPT, SCRIPT, UNDO, UNDO, UNDO, UNDO,
+    RESTORE, SCRIPT, SCRIPT, SCRIPT, SCRIPT, UNDO, UNDO, UNDO, UNDO,
     RAM, RAMLOAD, RAMLOAD, RAMLOAD, RAMLOAD, RAMLOAD, RAMSAVE,
-    RAMSAVE, RAMSAVE, RAMSAVE, EXCEPT, EXCEPT,
+    RAMSAVE, RAMSAVE, RAMSAVE, EXCEPT, EXCEPT, FLICKER,
     RESTORE, RESTORE, SCRIPT, UNDO, RESTART
 };
 
@@ -581,11 +586,6 @@ void LineInput(void)
         }
 
         unibuf[ev.val1] = 0;
-
-        if (Transcript) {
-            glk_put_string_stream_uni(Transcript, unibuf);
-            glk_put_char_stream_uni(Transcript, 10);
-        }
 
         lastwasnewline = 1;
 

--- a/terps/scott/parser.h
+++ b/terps/scott/parser.h
@@ -38,7 +38,8 @@ typedef enum {
     COMMAND,
     ALL,
     IT,
-    EXCEPT
+    EXCEPT,
+    FLICKER
 } extra_command;
 
 int GetInput(int *vb, int *no);
@@ -70,7 +71,7 @@ extern const char *EnglishDelimiterList[];
 extern const char *GermanDelimiterList[];
 extern const char *DelimiterList[];
 
-#define NUMBER_OF_EXTRA_COMMANDS 32
+#define NUMBER_OF_EXTRA_COMMANDS 34
 extern const char *GermanExtraCommands[];
 extern const char *SpanishExtraCommands[];
 extern const char *ExtraCommands[];

--- a/terps/scott/saga/woz2nib.c
+++ b/terps/scott/saga/woz2nib.c
@@ -141,7 +141,7 @@ static int rotate_left_with_carry(uint8_t *byte, int last_carry)
 }
 
 // This is a translation of $trk =~ s{^0*(1.{7})}{}o;
-// Extract first '1' + 7 characters ("bits").
+// Extract first set bit + 7 following bits.
 static uint8_t extract_nibble(uint8_t *bitstream, int bits, int *pos)
 {
     int bytes = bits / 8 + (bits % 8 != 0);
@@ -320,9 +320,9 @@ static SearchResultType find_syncbytes(uint8_t *bitstream, int bitcount, int *po
         // or the next byte has the leftmost bit unset
         if ((b & 0x01) != 0 && (bitstream[i + 1] & 0x80) != 0) {
             for (int j = 1; j < 8; j++) {
-                // Check if this bit and the next left shifted j places become 0xff
+                // Check if this bit and the next one left-shifted j places become 0xff
                 if (((bitstream[i] << j) | (bitstream[i + 1] >> (8 - j))) == 0xff) {
-                    // If so, copy the following 8 bytes to a buffer left shifted j positions,
+                    // If so, copy the following 8 bytes to a buffer left-shifted j positions,
                     // and compare them to the sync byte sequences.
                     for (int k = 8; k > 0; k--) {
                         temp[k] = ((bitstream[i + k] << j) | (bitstream[i + k + 1] >> (8 - j)));

--- a/terps/scott/scott.h
+++ b/terps/scott/scott.h
@@ -85,19 +85,20 @@ typedef struct {
 
 // clang-format off
 
-#define YOUARE                 1     /* You are not I am */
-#define SCOTTLIGHT             2     /* Authentic Scott Adams light messages */
-#define DEBUGGING              4     /* Info from database load */
-#define TRS80_STYLE            8     /* Display in style used on TRS-80 */
-#define PREHISTORIC_LAMP      16     /* Destroy the lamp (very old databases) */
-#define SPECTRUM_STYLE        32     /* Display in style used on ZX Spectrum */
-#define TI994A_STYLE          64     /* Display in style used on TI-99/4A */
-#define NO_DELAYS            128     /* Skip all pauses */
-#define FORCE_PALETTE_ZX     256     /* Force ZX Spectrum image palette */
-#define FORCE_PALETTE_C64    512     /* Force CBM 64 image palette */
-#define FORCE_INVENTORY     1024     /* Inventory in upper window always on */
-#define FORCE_INVENTORY_OFF 2048     /* Inventory in upper window always off */
-#define PC_STYLE            4096     /* Display in style used on IBM PC (MS-DOS) */
+#define YOUARE                 0x1     /* You are not I am */
+#define SCOTTLIGHT             0x2     /* Authentic Scott Adams light messages */
+#define DEBUGGING              0x4     /* Info from database load */
+#define TRS80_STYLE            0x8     /* Display in style used on TRS-80 */
+#define PREHISTORIC_LAMP      0x10     /* Destroy the lamp (very old databases) */
+#define SPECTRUM_STYLE        0x20     /* Display in style used on ZX Spectrum */
+#define TI994A_STYLE          0x40     /* Display in style used on TI-99/4A */
+#define NO_DELAYS             0x80     /* Skip all pauses */
+#define FORCE_PALETTE_ZX     0x100     /* Force ZX Spectrum image palette */
+#define FORCE_PALETTE_C64    0x200     /* Force CBM 64 image palette */
+#define FORCE_INVENTORY      0x400     /* Inventory in upper window always on */
+#define FORCE_INVENTORY_OFF  0x800     /* Inventory in upper window always off */
+#define PC_STYLE            0x1000     /* Display in style used on IBM PC (MS-DOS) */
+#define FLICKER_ON          0x2000     /* Flicker room description like some original games */
 
 // clang-format on
 
@@ -142,6 +143,7 @@ void SaveGame(void);
 void PrintNoun(void);
 int PrintScore(void);
 void MoveItemAToLocOfItemB(int itemA, int itemB);
+void GoTo(int loc);
 void GoToStoredLoc(void);
 void SwapLocAndRoomflag(int index);
 void SwapItemLocations(int itemA, int itemB);
@@ -152,6 +154,10 @@ void PlayerIsDead(void);
 void UpdateSettings(void);
 winid_t FindGlkWindowWithRock(glui32 rock);
 void OpenTopWindow(void);
+void SetDark(void);
+void SetLight(void);
+void SetBitFlag(int bit);
+void ClearBitFlag(int bit);
 
 extern struct GameInfo *Game;
 extern Header GameHeader;

--- a/terps/scott/ti994a/ti99_4a_terp.c
+++ b/terps/scott/ti994a/ti99_4a_terp.c
@@ -268,13 +268,7 @@ static ActionResultType PerformTI99Line(const uint8_t *action_line)
             break;
 
         case 221: /* go to room */
-#ifdef DEBUG_ACTIONS
-            debug_print("player location is now room %d (%s).\n", *ptr,
-                Rooms[*ptr].Text);
-#endif
-            MyLoc = *(ptr++);
-            should_look_in_transcript = 1;
-            Look();
+            GoTo(*(ptr++));
             break;
 
         case 222: /* move item p to room 0 */
@@ -287,39 +281,26 @@ static ActionResultType PerformTI99Line(const uint8_t *action_line)
             break;
 
         case 223: /* darkness */
-            BitFlags |= 1 << DARKBIT;
+            SetDark();
             break;
 
         case 224: /* light */
-            BitFlags &= ~(1 << DARKBIT);
+            SetLight();
             break;
 
         case 225: /* set flag p */
-#ifdef DEBUG_ACTIONS
-            debug_print("Bitflag %d is set\n", dv);
-#endif
-            BitFlags |= (1 << *(ptr++));
+            SetBitFlag(*(ptr++));
             break;
 
         case 226: /* clear flag p */
-#ifdef DEBUG_ACTIONS
-            debug_print("Bitflag %d is cleared\n", dv);
-#endif
-            BitFlags &= ~(1 << *(ptr++));
+            ClearBitFlag(*(ptr++));
             break;
-
         case 227: /* set flag 0 */
-#ifdef DEBUG_ACTIONS
-            debug_print("Bitflag 0 is set\n");
-#endif
-            BitFlags |= (1 << 0);
+            SetBitFlag(0);
             break;
 
         case 228: /* clear flag 0 */
-#ifdef DEBUG_ACTIONS
-            debug_print("Bitflag 0 is cleared\n");
-#endif
-            BitFlags &= ~(1 << 0);
+            ClearBitFlag(0);
             break;
 
         case 229: /* die */
@@ -354,7 +335,7 @@ static ActionResultType PerformTI99Line(const uint8_t *action_line)
         case 234: /* refill lightsource */
             GameHeader.LightTime = LightRefill;
             Items[LIGHT_SOURCE].Location = CARRIED;
-            BitFlags &= ~(1 << LIGHTOUTBIT);
+            ClearBitFlag(LIGHTOUTBIT);
             break;
 
         case 235: /* save */


### PR DESCRIPTION
The main new feature is authentic flicker in the room description window, as discussed here:
https://intfiction.org/t/scott-adams-games-screen-effects/62229
Basically it is a glitch in some of the original interpreters that certain players like very much.
Currently it is off by default and can only be activated in Gargoyle with the metacommand `#flicker` .

Other notable changes:
- More output is echoed to the transcript, such as the battles in _Seas of Blood_.
- Resizing the window when showing closeups in Adventureland won't erase the closeup image.