### PR TITLE
Set NOMINMAX for Windows builds

### DIFF
--- a/garglk/cheapglk/cgfref.cpp
+++ b/garglk/cheapglk/cgfref.cpp
@@ -40,6 +40,7 @@
 #ifdef _WIN32
 #define _CRT_INTERNAL_NONSTDC_NAMES 1
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)

--- a/garglk/fontwin.cpp
+++ b/garglk/fontwin.cpp
@@ -17,6 +17,7 @@
 // along with Gargoyle; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+#define NOMINMAX
 #include <windows.h>
 
 #include <cstdio>

--- a/garglk/ttswin.cpp
+++ b/garglk/ttswin.cpp
@@ -18,6 +18,7 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 
 #include <array>
 #include <cstddef>


### PR DESCRIPTION
Windows, by default, defines min and max macros which clash with std::min and std::max, so ensure these are not defined.