### PR TITLE
Remove unused DLLs in Qt sound

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -107,7 +107,7 @@ fi
 
 case ${GARGOYLE_SOUND} in
     QT)
-        SOUND_DLLS="Qt5Multimedia Qt5Network libFLAC-12 libmodplug-1 libmpg123-0 libogg-0 libopenmpt-0 libsndfile libvorbis-0 libvorbisenc-2 libvorbisfile-3"
+        SOUND_DLLS="Qt5Multimedia Qt5Network libmpg123-0 libogg-0 libopenmpt-0 libsndfile libvorbis-0 libvorbisenc-2 libvorbisfile-3"
         ;;
     SDL)
         SOUND_DLLS="SDL2 SDL2_mixer libmodplug-1 libmpg123-0 libogg-0 libopenmpt-0 libvorbis-0 libvorbisfile-3"


### PR DESCRIPTION
FLAC was required only because my libsndfile was built with FLAC support; Glk (or rather, Blorb) doesn't include FLAC. Now I build libsndfile without FLAC, so there's no need to ship an unused DLL.

Qt never needed modplug (just libopenmpt); I suspect this was a forgotten carryover from the SDL sound backend.