### PR TITLE
Provide warnings for invalid config file entries

### DIFF
--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -117,7 +117,7 @@ static FT_Matrix ftmat;
 static bool use_freetype_preset_filter = false;
 static FT_LcdFilter freetype_preset_filter = FT_LCD_FILTER_DEFAULT;
 
-void garglk::set_lcdfilter(const std::string &filter)
+bool garglk::set_lcdfilter(const std::string &filter)
 {
     use_freetype_preset_filter = true;
 
@@ -129,9 +129,14 @@ void garglk::set_lcdfilter(const std::string &filter)
         freetype_preset_filter = FT_LCD_FILTER_LIGHT;
     } else if (filter == "legacy") {
         freetype_preset_filter = FT_LCD_FILTER_LEGACY;
+    } else if (filter == "custom") {
+        use_freetype_preset_filter = false;
     } else {
         use_freetype_preset_filter = false;
+        return false;
     }
+
+    return true;
 }
 
 //
@@ -358,7 +363,7 @@ Font::Font(FontFace fontface, FT_Face face, const std::string &fontpath) :
     m_face(face)
 {
     int err = 0;
-    float aspect, size;
+    double aspect, size;
 
     if (m_fontface.monospace) {
         aspect = gli_conf_monoaspect;
@@ -405,7 +410,7 @@ void gli_initialize_fonts()
     }
 
     for (int i = 0; i <= GAMMA_MAX; i++) {
-        gammainv[i] = std::round(std::pow(i / static_cast<float>(GAMMA_MAX), 1.0 / gli_conf_gamma) * 255.0);
+        gammainv[i] = std::round(std::pow(i / static_cast<double>(GAMMA_MAX), 1.0 / gli_conf_gamma) * 255.0);
     }
 
     err = FT_Init_FreeType(&ftlib);

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -159,16 +159,16 @@ void winabort(const std::string &msg);
 std::string downcase(const std::string &string);
 void fontreplace(const std::string &font, FontType type);
 std::vector<ConfigFile> configs(const nonstd::optional<std::string> &gamepath);
-void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, const std::function<void(const std::string &cmd, const std::string &arg)> &callback);
+void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, const std::function<void(const std::string &cmd, const std::string &arg, int lineno)> &callback);
 std::string user_config();
-void set_lcdfilter(const std::string &filter);
+bool set_lcdfilter(const std::string &filter);
 nonstd::optional<std::string> winfontpath(const std::string &filename);
 std::vector<std::string> winappdata();
 nonstd::optional<std::string> winappdir();
 
 namespace theme {
 void init();
-void set(std::string name);
+bool set(std::string name);
 std::vector<std::string> paths();
 std::vector<std::string> names();
 }
@@ -557,8 +557,8 @@ extern int gli_wpaddingy;
 extern int gli_tmarginx;
 extern int gli_tmarginy;
 
-extern float gli_backingscalefactor;
-extern float gli_zoom;
+extern double gli_backingscalefactor;
+extern double gli_zoom;
 
 extern bool gli_conf_lcd;
 extern std::array<unsigned char, 5> gli_conf_lcd_weights;
@@ -606,11 +606,11 @@ extern FontFiles gli_conf_prop, gli_conf_prop_override;
 extern std::string gli_conf_monofont;
 extern FontFiles gli_conf_mono, gli_conf_mono_override;
 
-extern float gli_conf_gamma;
-extern float gli_conf_propsize;
-extern float gli_conf_monosize;
-extern float gli_conf_propaspect;
-extern float gli_conf_monoaspect;
+extern double gli_conf_gamma;
+extern double gli_conf_propsize;
+extern double gli_conf_monosize;
+extern double gli_conf_propaspect;
+extern double gli_conf_monoaspect;
 
 extern std::vector<glui32> gli_more_prompt;
 extern glui32 gli_more_prompt_len;

--- a/garglk/imgscale.cpp
+++ b/garglk/imgscale.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<picture_t> gli_picture_scale(const picture_t *src, int newcols, 
     int cols = src->w;
     int rows = src->h;
 
-    float xscale, yscale;
+    double xscale, yscale;
     long sxscale, syscale;
 
     long fracrowtofill, fracrowleft;
@@ -73,8 +73,8 @@ std::shared_ptr<picture_t> gli_picture_scale(const picture_t *src, int newcols, 
 
     // Compute all sizes and scales.
 
-    xscale = static_cast<float>(newcols) / static_cast<float>(cols);
-    yscale = static_cast<float>(newrows) / static_cast<float>(rows);
+    xscale = static_cast<double>(newcols) / static_cast<double>(cols);
+    yscale = static_cast<double>(newrows) / static_cast<double>(rows);
     sxscale = xscale * SCALE;
     syscale = yscale * SCALE;
 

--- a/garglk/launcher.cpp
+++ b/garglk/launcher.cpp
@@ -320,7 +320,7 @@ static nonstd::optional<Interpreter> findterp(const std::string &file, const std
 
     nonstd::optional<Interpreter> interpreter;
 
-    garglk::config_entries(file, false, matches, [&interpreter](const std::string &cmd, const std::string &arg) {
+    garglk::config_entries(file, false, matches, [&interpreter](const std::string &cmd, const std::string &arg, int) {
         if (cmd == "terp") {
             std::istringstream argstream(arg);
             std::string terp, opt;

--- a/garglk/theme.cpp
+++ b/garglk/theme.cpp
@@ -342,7 +342,7 @@ static std::string system_theme_name()
     return windark() ? "dark" : "light";
 }
 
-void garglk::theme::set(std::string name)
+bool garglk::theme::set(std::string name)
 {
     if (name == "system") {
         name = system_theme_name();
@@ -350,8 +350,9 @@ void garglk::theme::set(std::string name)
 
     try {
         themes.at(name).apply();
+        return true;
     } catch (const std::out_of_range &) {
-        std::cerr << "garglk: unknown theme: " << name << std::endl;
+        return false;
     }
 }
 


### PR DESCRIPTION
Prior to this Gargoyle would either ignore or pull into range invalid values in the config file, and the only real way to know you got it wrong was if your config change didn't do anything. Now it dumps errors to stderr, which isn't particularly helpful for anybody using a GUI to launch, but it's a start. The framework can be used to provide better error messages in the future, e.g. in a dialog box or similar.

At the same time, all "float" values have been converted to "double". Some config values were float, others double, so moving them all to double just simplifies things.