### PR TITLE
Add "save scrollback" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ interpreter. However, there are a few shortcuts available (on Mac, use
   on color themes).
 * `Ctrl`+`Shift`+`t`: Display a list of all available color themes (see
   THEMES.md for more information on color themes).
+* `Ctrl`+`Shift`+`s`: Save the scrollback buffer to a file, effectively
+  creating an ad hoc transcript.
 
 In addition, Gargoyle supports many readline/Emacs-style line-editor bindings:
 

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1111,6 +1111,7 @@ using gli_decomp_block_t = glui32[2];
 // If the count is zero, there is no decomposition.
 
 void gli_putchar_utf8(glui32 val, std::FILE *fl);
+extern int gli_encode_utf8(glui32 val, char *buf, int len);
 glui32 gli_getchar_utf8(std::FILE *fl);
 glui32 gli_parse_utf8(const unsigned char *buf, glui32 buflen, glui32 *out, glui32 outlen);
 
@@ -1128,6 +1129,9 @@ void gli_move_selection(int x, int y);
 void gli_notification_waiting();
 
 void gli_edit_config();
+
+nonstd::optional<std::vector<char>> gli_get_scrollback();
+std::vector<char> gli_get_text(window_textbuffer_t *dwin);
 
 // A macro which reads and decodes one character of UTF-8. Needs no
 // explanation, I'm sure.

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -44,6 +44,7 @@
 #define NSKEY_H         0x04
 #define NSKEY_N         0x2d
 #define NSKEY_P         0x23
+#define NSKEY_S         0x01
 #define NSKEY_T         0x11
 #define NSKEY_U         0x20
 #define NSKEY_V         0x09

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -477,6 +477,29 @@ void garglk::View::keyPressEvent(QKeyEvent *event)
         {{Qt::NoModifier, Qt::Key_F10},       []{ gli_input_handle_key(keycode_Func10); }},
         {{Qt::NoModifier, Qt::Key_F11},       []{ gli_input_handle_key(keycode_Func11); }},
         {{Qt::NoModifier, Qt::Key_F12},       []{ gli_input_handle_key(keycode_Func12); }},
+
+        {{Qt::ShiftModifier | Qt::ControlModifier, Qt::Key_S},
+            []{
+                auto text = gli_get_scrollback();
+                if (text.has_value()) {
+                    auto filename = QFileDialog::getSaveFileName(::window, "Save transcript", "transcript.txt", "Text files (*.txt)");
+                    if (!filename.isNull()) {
+                        QFile file(filename);
+                        if (file.open(QIODevice::WriteOnly)) {
+                            std::size_t n = file.write(text->data(), text->size());
+                            if (n != text->size()) {
+                                QMessageBox::critical(nullptr, "Error", "Error writing entire transcript.");
+                            }
+                        } else {
+                            QMessageBox::critical(nullptr, "Error", "Unable to open file for writing.");
+                        }
+                    }
+                } else {
+                    QMessageBox::warning(nullptr, "Warning", "Could not find appropriate window for scrollback.");
+                }
+            }
+        },
+
     };
 
     try {

--- a/garglk/window.cpp
+++ b/garglk/window.cpp
@@ -48,6 +48,29 @@ void gli_initialize_windows()
     gli_focuswin = nullptr;
 }
 
+// Return the scrollback buffer of the focused window, if that window is
+// a text buffer. If it's not, find the textbuffer with the longest
+// scrollback and assume that's the best scrollback buffer, returning
+// it. If there are no textbuffer windows at all, return nullopt.
+nonstd::optional<std::vector<char>> gli_get_scrollback() {
+    nonstd::optional<std::vector<char>> text;
+
+    if (gli_focuswin != nullptr && gli_focuswin->type == wintype_TextBuffer) {
+        return gli_get_text(gli_focuswin->window.textbuffer);
+    }
+
+    for (auto *win = glk_window_iterate(nullptr, nullptr); win != nullptr; win = glk_window_iterate(win, nullptr)) {
+        if (win->type == wintype_TextBuffer) {
+            auto new_text = gli_get_text(win->window.textbuffer);
+            if (!text.has_value() || new_text.size() > text->size()) {
+                text = new_text;
+            }
+        }
+    }
+
+    return text;
+}
+
 static void gli_windows_rearrange()
 {
     if (gli_rootwin != nullptr) {

--- a/garglk/wintext.cpp
+++ b/garglk/wintext.cpp
@@ -78,6 +78,26 @@ void win_textbuffer_destroy(window_textbuffer_t *dwin)
     delete dwin;
 }
 
+std::vector<char> gli_get_text(window_textbuffer_t *dwin)
+{
+    int s = dwin->scrollmax < SCROLLBACK ? dwin->scrollmax : SCROLLBACK - 1;
+
+    std::vector<char> text;
+    for (int lineidx = s; lineidx >= 0; lineidx--) {
+        auto line = dwin->lines[lineidx];
+        for (int charidx = 0; charidx < line.len; charidx++) {
+            std::array<char, 4> buf;
+            auto n = gli_encode_utf8(line.chars[charidx], buf.data(), 4);
+            for (int i = 0; i < n; i++) {
+                text.push_back(buf[i]);
+            }
+        }
+        text.push_back(0x0a); // Unicode linefeed
+    }
+
+    return text;
+}
+
 static void reflow(window_t *win)
 {
     window_textbuffer_t *dwin = win->window.textbuffer;


### PR DESCRIPTION
With control/command-shift-S, the current scrollback buffer can be written to a file. Because Glk supports an arbitrary number of windows, there is no "definite" scrollback to save. Gargoyle tries the focused window first; if that's not a textbuffer, it then searches through all texstbuffers and chooses the one with the largest scrollback buffer. Hopefully this covers the vast majority of cases.

See #145.