### PR TITLE
Allow picture scaling to be selected for Magnetic Scrolls

### DIFF
--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -375,3 +375,8 @@ minrows       26              # Winter Wonderland contains ASCII art
 # Override for specific game
 # [ Floatpoint.zblorb ]
 # terp glulxe
+
+# By default, the Magnetic Scrolls interpreter scales images by 2x. This can be
+# changed to any integer value from 1 to 8 here.
+# [ *.mag ]
+# terp magnetic -sc 3

--- a/garglk/launcher.cpp
+++ b/garglk/launcher.cpp
@@ -70,14 +70,14 @@
 namespace {
 
 struct Interpreter {
-    explicit Interpreter(std::string terp_, nonstd::optional<std::string> flags_ = nonstd::nullopt) :
+    explicit Interpreter(std::string terp_, std::vector<std::string> flags_ = {}) :
         terp(std::move(terp_)),
         flags(std::move(flags_))
     {
     }
 
     std::string terp;
-    nonstd::optional<std::string> flags;
+    std::vector<std::string> flags;
 };
 
 }
@@ -162,7 +162,7 @@ static const std::unordered_map<std::string, Format> extensions = {
 static const std::unordered_map<Format, Interpreter> interpreters = {
     {Format::Adrift, Interpreter(T_ADRIFT)},
     {Format::AdvSys, Interpreter(T_ADVSYS)},
-    {Format::AGT, Interpreter(T_AGT, "-gl")},
+    {Format::AGT, Interpreter(T_AGT, {"-gl"})},
     {Format::Alan2, Interpreter(T_ALAN2)},
     {Format::Alan3, Interpreter(T_ALAN3)},
     {Format::Glulx, Interpreter(T_GLULX)},
@@ -323,12 +323,12 @@ static nonstd::optional<Interpreter> findterp(const std::string &file, const std
     garglk::config_entries(file, false, matches, [&interpreter](const std::string &cmd, const std::string &arg, int) {
         if (cmd == "terp") {
             std::istringstream argstream(arg);
-            std::string terp, opt;
-            nonstd::optional<std::string> flags;
+            std::string terp, flag;
+            std::vector<std::string> flags;
 
             if (argstream >> terp) {
-                if (argstream >> opt && opt[0] == '-') {
-                    flags = opt;
+                while (argstream >> flag) {
+                    flags.push_back(flag);
                 }
 
                 interpreter.emplace(terp, flags);

--- a/garglk/launcher.h
+++ b/garglk/launcher.h
@@ -22,13 +22,14 @@
 #define GARGLK_LAUNCHER_H
 
 #include <string>
+#include <vector>
 
 #include "optional.hpp"
 
 namespace garglk {
 
 void winmsg(const std::string &msg);
-bool winterp(const std::string &exe, const nonstd::optional<std::string> &flags, const std::string &game);
+bool winterp(const std::string &exe, const std::vector<std::string> &flags, const std::string &game);
 bool rungame(const std::string &game);
 
 }

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -1038,21 +1038,16 @@ static int winexec(const std::string &cmd, const std::vector<std::string> &args)
     return [proc isRunning];
 }
 
-bool garglk::winterp(const std::string &exe, const nonstd::optional<std::string> &flags, const std::string &game)
+bool garglk::winterp(const std::string &exe, const std::vector<std::string> &flags, const std::string &game)
 {
     // get dir of executable
     auto interpreter_dir = winpath();
 
     auto cmd = Format("{}/{}", interpreter_dir, exe);
 
-    std::vector<std::string> args;
+    auto args = flags;
 
-    if (flags.has_value()) {
-        args.push_back(*flags);
-        args.push_back(game);
-    } else {
-        args.push_back(game);
-    }
+    args.push_back(game);
 
     if (!winexec(cmd, args)) {
         garglk::winmsg("Could not start 'terp.\nSorry.");

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -116,7 +116,7 @@ static QString winbrowsefile()
     return QFileDialog::getOpenFileName(nullptr, AppName, "", filter_string, nullptr, options);
 }
 
-bool garglk::winterp(const std::string &exe, const nonstd::optional<std::string> &flags, const std::string &game)
+bool garglk::winterp(const std::string &exe, const std::vector<std::string> &flags, const std::string &game)
 {
     // Find the directory that contains the interpreters. By default
     // this is GARGLK_CONFIG_INTERPRETER_DIR but if that is not set, it
@@ -141,12 +141,10 @@ bool garglk::winterp(const std::string &exe, const nonstd::optional<std::string>
     QString argv0 = QDir(interpreter_dir).absoluteFilePath(exe.c_str());
 
     QStringList args;
-
-    if (flags.has_value()) {
-        args = QStringList({flags->c_str(), game.c_str()});
-    } else {
-        args = QStringList({game.c_str()});
+    for (const auto &flag : flags) {
+        args.push_back(QString::fromStdString(flag));
     }
+    args.push_back(QString::fromStdString(game));
 
     QProcess proc;
     proc.setProcessChannelMode(QProcess::ForwardedChannels);

--- a/terps/magnetic/Glk/glk.c
+++ b/terps/magnetic/Glk/glk.c
@@ -640,7 +640,11 @@ static const int GMS_GRAPHICS_ANIMATION_WAIT = 2,
                  GMS_GRAPHICS_REPAINT_WAIT = 10;
 
 /* Pixel size multiplier for image size scaling. */
+#ifdef GARGLK
+static int GMS_GRAPHICS_PIXEL = 2;
+#else
 static const int GMS_GRAPHICS_PIXEL = 2;
+#endif
 
 /* Proportion of the display to use for graphics. */
 static const glui32 GMS_GRAPHICS_PROPORTION = 60;
@@ -5926,6 +5930,18 @@ gms_startup_code (int argc, char *argv[])
           gms_prompt_enabled = FALSE;
           continue;
         }
+#ifdef GARGLK
+      if (strcmp (argv[argv_index], "-sc") == 0)
+        {
+          char *endptr;
+          long scale = strtol(argv[++argv_index], &endptr, 10);
+          if (scale >= 1 && scale <= 8 && *endptr == 0)
+            {
+              GMS_GRAPHICS_PIXEL = scale;
+            }
+          continue;
+        }
+#endif
       return FALSE;
     }
 
@@ -6218,6 +6234,10 @@ glkunix_argumentlist_t glkunix_arguments[] = {
    (char *) "-nx        Turn off picture animations"},
   {(char *) "-ne", glkunix_arg_NoValue,
    (char *) "-ne        Turn off additional interpreter prompt"},
+#ifdef GARGLK
+  {(char *) "-sc", glkunix_arg_ValueFollows,
+   (char *) "-sc        Scale pictures by integer value (1-8)"},
+#endif
   {(char *) "", glkunix_arg_ValueCanFollow,
    (char *) "filename   game to run"},
   {NULL, glkunix_arg_End, NULL}


### PR DESCRIPTION
This is a bit hacky due to the way Gargoyle works. The Gargoyle config file doesn't directly affect games at all, so the choice is either to allow the setting in the Gargoyle config or to create a separate config for Magnetic Scrolls.

Because the upstream Magnetic Scrolls doesn't already have a config file, it's less invasive to just add a new command-line argument that allows scaling, since Gargoyle _does_ allow arguments to be passed to interpreters, although that support had to be expanded a bit since it originally was very limited, meant only to support one thing for AGT.

See #600