### PR TITLE
Add a function to get the size of a window in pixels

### DIFF
--- a/garglk/cheapglk/glk.h
+++ b/garglk/cheapglk/glk.h
@@ -58,9 +58,11 @@ typedef int32_t glsi32;
 #define GLK_MODULE_DATETIME
 #define GLK_MODULE_RESOURCE_STREAM
 
+#define GLK_MODULE_FILEREF_GET_NAME
+
 #define GLK_MODULE_GARGLKTEXT
 #define GLK_MODULE_GARGLKBLEEP
-#define GLK_MODULE_FILEREF_GET_NAME
+#define GLK_MODULE_GARGLKWINSIZE
 
 /* Define a macro for a function attribute that indicates a function that
     never returns. (E.g., glk_exit().) We try to do this only in C compilers
@@ -522,6 +524,9 @@ extern void garglk_set_reversevideo_stream(strid_t str, glui32 reverse);
 extern void garglk_zbleep(glui32 number);
 
 extern int garglk_tads_os_banner_size(winid_t win);
+
+extern void garglk_window_get_size_pixels(winid_t win, glui32 *width, glui32 *height);
+
 
 /* non standard keycodes */
 #define keycode_Erase               (0xffffef7f)

--- a/garglk/garglk.cpp
+++ b/garglk/garglk.cpp
@@ -86,3 +86,32 @@ bool garglk::read_file(const std::string &filename, std::vector<unsigned char> &
 
     return !f.fail();
 }
+
+void garglk_window_get_size_pixels(window_t *win, glui32 *width, glui32 *height)
+{
+    glui32 wid;
+    glui32 hgt;
+
+    // glk_window_get_size() already does what we need for blank, pair,
+    // and graphics windows.
+    glk_window_get_size(win, &wid, &hgt);
+
+    // For text windows, the size should be reported in pixels, and
+    // since glk_window_get_size() does integer division, this can't
+    // just multiply by gli_cellw/gli_cellh; calculate directly.
+    if (win->type == wintype_TextGrid) {
+        wid = win->bbox.x1 - win->bbox.x0;
+        hgt = win->bbox.y1 - win->bbox.y0;
+    } else if (win->type == wintype_TextBuffer) {
+        wid = win->bbox.x1 - win->bbox.x0 - gli_tmarginx * 2;
+        hgt = win->bbox.y1 - win->bbox.y0 - gli_tmarginy * 2;
+    }
+
+    if (width != nullptr) {
+        *width = wid;
+    }
+
+    if (height != nullptr) {
+        *height = hgt;
+    }
+}


### PR DESCRIPTION
This is needed for Blorb resolution chunks (see Blorb §11.2), which are used by Z-machine interpreters to scale images.