### PR TITLE
Full screen improvements

### DIFF
--- a/garglk/cheapglk/cgmisc.cpp
+++ b/garglk/cheapglk/cgmisc.cpp
@@ -96,6 +96,24 @@ void glk_exit()
 
     garglk_set_story_title("[ press any key to exit ]");
 
+    /* After a game exits, Gargoyle waits for a keypress, since
+       otherwise text might get lost. It signals this by changing the
+       titlebar (as above). However, in full screen mode, the titlebar
+       isn't visible, so after quitting a game, Gargoyle looks like it's
+       sitting there doing nothing. On exit, in full screen mode, add a
+       "press any key to exit" message to all text buffer windows in the
+       hopes that one is visible. In weird cases this won't work (e.g.
+       if there is no text buffer window), but the vast majority of the
+       time this should work fine. */
+    if (garglk::winisfullscreen()) {
+        for (auto *win = glk_window_iterate(nullptr, 0); win != nullptr; win = glk_window_iterate(win, 0)) {
+            if (win->type == wintype_TextBuffer) {
+                glk_set_style_stream(glk_window_get_stream(win), style_Subheader);
+                glk_put_string_stream(glk_window_get_stream(win), const_cast<char *>("\n[Press any key to exit]"));
+            }
+        }
+    }
+
     gli_terminated = true;
 
     /* wait for gli_handle_input_key to exit() */

--- a/garglk/cheapglk/cgmisc.cpp
+++ b/garglk/cheapglk/cgmisc.cpp
@@ -94,6 +94,10 @@ void glk_exit()
 #ifdef GARGLK
     event_t event;
 
+    if (!gli_wait_on_quit) {
+        winexit();
+    }
+
     garglk_set_story_title("[ press any key to exit ]");
 
     /* After a game exits, Gargoyle waits for a keypress, since

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -221,6 +221,8 @@ std::string gli_conf_speak_language;
 
 bool gli_conf_fullscreen = false;
 
+bool gli_wait_on_quit = true;
+
 bool gli_conf_stylehint = true;
 bool gli_conf_safeclicks = false;
 
@@ -741,6 +743,8 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 gli_conf_fullscreen = asbool(arg);
             } else if (cmd == "zoom") {
                 gli_zoom = config_atleast(parse_double(arg), 0.1);
+            } else if (cmd == "wait_on_quit") {
+                gli_wait_on_quit = asbool(arg);
             } else if (cmd == "speak") {
                 gli_conf_speak = asbool(arg);
             } else if (cmd == "speak_input") {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -165,6 +165,7 @@ bool set_lcdfilter(const std::string &filter);
 nonstd::optional<std::string> winfontpath(const std::string &filename);
 std::vector<std::string> winappdata();
 nonstd::optional<std::string> winappdir();
+bool winisfullscreen();
 
 namespace theme {
 void init();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -569,6 +569,8 @@ extern bool gli_conf_sound;
 
 extern bool gli_conf_fullscreen;
 
+extern bool gli_wait_on_quit;
+
 extern bool gli_conf_speak;
 extern bool gli_conf_speak_input;
 

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -104,6 +104,11 @@ zbleep        2 0.1 440
 fullscreen    0               # set to 1 for fullscreen
 zoom          1.0             # set display zoom
 
+# If set to 1, Gargoyle will wait for a keypress when a game quits, to
+# allow text printed just before quitting to be seen. If you would
+# rather that Gargoyle quit immediately, set this to 0.
+wait_on_quit  1
+
 #===============================================================================
 # Fonts, sizes and spaces
 # (Tweak this if you choose other fonts, or want bigger text)

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -853,6 +853,12 @@ static BOOL isTextbufferEvent(NSEvent *evt)
     NSRunAlertPanel(@"Fatal error", @"%@", nil, nil, nil, prompt);
 }
 
+- (BOOL) isFullScreen: (pid_t) processID
+{
+    GargoyleWindow *window = [windows objectForKey: [NSNumber numberWithInt: processID]];
+    return (window.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen;
+}
+
 #define kArrowCursor        1
 #define kIBeamCursor        2
 #define kPointingHandCursor 3

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -123,6 +123,8 @@
 
 - (void) setCursor: (unsigned int) cursor;
 
+- (BOOL) isFullScreen: (pid_t) processID;
+
 @end
 
 NSString *get_qt_plist_path();

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -860,6 +860,11 @@ nonstd::optional<std::string> garglk::winappdir()
     return nonstd::nullopt;
 }
 
+bool garglk::winisfullscreen()
+{
+    return [gargoyle isFullScreen: processID];
+}
+
 void gli_select(event_t *event, bool polled)
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -731,6 +731,11 @@ nonstd::optional<std::string> garglk::winappdir()
     return QCoreApplication::applicationDirPath().toStdString();
 }
 
+bool garglk::winisfullscreen()
+{
+    return window->isFullScreen();
+}
+
 void gli_tick()
 {
 #ifdef GARGLK_CONFIG_TICK


### PR DESCRIPTION
This makes two changes:

1. When in full screen mode, "[Press any key to exit]" is displayed in the window (hopefully: that string is written to all text buffer windows, so it's possible it won't appear, but practically speaking it will).
2. There is a new config setting `wait_on_quit`; if it's disabled (set to false), then Gargoyle will no longer wait for a keypress after `glk_exit()` is called.

See #197; this now implements suggestions "a" and "c" from that issue.