### PR TITLE
Handle newlines properly when pasting

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1026,6 +1026,7 @@ extern void gli_window_click(window_t *win, int x, int y);
 void gli_redraw_rect(int x0, int y0, int x1, int y1);
 
 void gli_input_handle_key(glui32 key);
+void gli_input_handle_key_paste(glui32 key);
 void gli_input_handle_click(int x, int y);
 void gli_event_store(glui32 type, window_t *win, glui32 val1, glui32 val2);
 

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -257,14 +257,17 @@ void winclipreceive()
                     case '\0':
                         return;
 
-                    case '\r':
-                    case '\n':
                     case '\b':
                     case '\t':
                         break;
 
+                    case '\r':
+                    case '\n':
+                        gli_input_handle_key_paste(keycode_Return);
+                        break;
+
                     default:
-                        gli_input_handle_key(ch);
+                        gli_input_handle_key_paste(ch);
                     }
                 }
             }

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -121,13 +121,16 @@ static constexpr int TICK_PERIOD_MILLIS = 10;
 static std::atomic<bool> process_events(false);
 #endif
 
-static void handle_input(const QString &input)
+static void handle_input(const QString &input, bool from_paste)
 {
+    auto fn = from_paste ? gli_input_handle_key_paste :
+                           gli_input_handle_key;
+
     for (const uint &c : input.toUcs4()) {
         if (c == '\r' || c == '\n') {
-            gli_input_handle_key(keycode_Return);
+            fn(keycode_Return);
         } else if (QChar::isPrint(c)) {
-            gli_input_handle_key(c);
+            fn(c);
         }
     }
 }
@@ -218,7 +221,7 @@ static void winclipreceive(QClipboard::Mode mode)
     QClipboard *clipboard = QGuiApplication::clipboard();
     QString text = clipboard->text(mode);
 
-    handle_input(text);
+    handle_input(text, true);
 }
 
 garglk::Window::Window() :
@@ -508,7 +511,7 @@ void garglk::View::keyPressEvent(QKeyEvent *event)
     } catch (const std::out_of_range &) {
     }
 
-    handle_input(event->text());
+    handle_input(event->text(), false);
 }
 
 void garglk::View::mouseMoveEvent(QMouseEvent *event)


### PR DESCRIPTION
Prior to this, the Qt and Mac interfaces behaved different to each other when pasting in line input mode, and both in a manner that most people would consider wrong.

The Mac code would strip out newlines, pasting multiple lines all at once.

The Qt code would send newlines appropriately as a Glk "return" keycode, but after that keycode, the window was no longer in "accept input" mode, which meant that all incoming keys were discarded. All the rest of the keys arrive too early, before the next line input is started, and are discarded as a result.

Char input is similar, but there _any_ characters is sufficient to stop the event and cause the rest of the paste to disappear.

Now, if a paste occurs when there's no input event, the pasted characters are buffered and injected when there _is_ an input event.