### PR TITLE
Allow toggling of fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ interpreter. However, there are a few shortcuts available (on Mac, use
   THEMES.md for more information on color themes).
 * `Ctrl`+`Shift`+`s`: Save the scrollback buffer to a file, effectively
   creating an ad hoc transcript.
+* `Alt`+`Enter` (or `Command`-`Ctrl`-`f` on Mac): Toggle fullscreen.
 
 In addition, Gargoyle supports many readline/Emacs-style line-editor bindings:
 

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -58,6 +58,9 @@ lockrows      0               # set to 1 to enforce row count
 #
 # The default is to save neither. If Gargoyle is able to restore a
 # saved window size, then the "cols" and "rows" settings are ignored.
+#
+# If either of these is true, then the fullscreen state will be stored
+# as well.
 
 justify       0               # 0=ragged-right 1=justified
 quotes        1               # Smart quotes           -- 0=off 1=normal 2=rabid

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -500,8 +500,13 @@ static BOOL isTextbufferEvent(NSEvent *evt)
 
             if (gli_conf_save_window_size) {
                 auto size = Format("@Size({} {})", self.frame.size.width, self.frame.size.height);
-                printf("Size: %s\n", size.c_str());
                 [config setObject: [NSString stringWithUTF8String: size.c_str()] forKey: @"window.size"];
+            }
+
+            if (gli_conf_save_window_location || gli_conf_save_window_size) {
+                auto is_fullscreen = (self.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen;
+                auto as_object = [NSNumber numberWithBool: is_fullscreen];
+                [config setObject: as_object forKey: @"window.fullscreen"];
             }
 
             [config writeToFile: path atomically: YES];
@@ -857,6 +862,12 @@ static BOOL isTextbufferEvent(NSEvent *evt)
 {
     GargoyleWindow *window = [windows objectForKey: [NSNumber numberWithInt: processID]];
     return (window.styleMask & NSWindowStyleMaskFullScreen) == NSWindowStyleMaskFullScreen;
+}
+
+- (void) toggleFullScreen: (pid_t) processID
+{
+    GargoyleWindow *window = [windows objectForKey: [NSNumber numberWithInt: processID]];
+    [window toggleFullScreen: self];
 }
 
 #define kArrowCursor        1

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -124,6 +124,7 @@
 - (void) setCursor: (unsigned int) cursor;
 
 - (BOOL) isFullScreen: (pid_t) processID;
+- (void) toggleFullScreen: (pid_t) processID;
 
 @end
 

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -411,6 +411,8 @@ void winopen()
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
+    auto do_fullscreen = gli_conf_fullscreen;
+
     bool move = false;
     int x = 0;
     int y = 0;
@@ -463,6 +465,13 @@ void winopen()
                 }
             }
         }
+
+        if (gli_conf_save_window_location || gli_conf_save_window_size) {
+            NSNumber *fsobj = config[@"window.fullscreen"];
+            if (fsobj) {
+                do_fullscreen = [fsobj boolValue];
+            }
+        }
     }
 
     [gargoyle initWindow: processID
@@ -471,7 +480,7 @@ void winopen()
                        y: y
                    width: width
                   height: height
-              fullscreen: gli_conf_fullscreen
+              fullscreen: do_fullscreen
          backgroundColor: windowColor];
 
     wintitle();
@@ -634,8 +643,7 @@ void winkey(NSEvent *evt)
         {{0, NSKEY_F12},  []{ gli_input_handle_key(keycode_Func12); }},
 
         // save transcript
-        {{NSEventModifierFlagShift | NSEventModifierFlagCommand, NSKEY_S},
-        []{
+        {{NSEventModifierFlagShift | NSEventModifierFlagCommand, NSKEY_S}, []{
             auto text = gli_get_scrollback();
             if (text.has_value()) {
                 NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -661,6 +669,11 @@ void winkey(NSEvent *evt)
             } else {
                 show_warning(@"Warning", "Could not find appropriate window for scrollback.");
             }
+        }},
+
+        // toggle fullscreen
+        {{NSEventModifierFlagControl | NSEventModifierFlagCommand, NSKEY_F}, []{
+            [gargoyle toggleFullScreen: processID];
         }},
     };
 

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -37,6 +37,9 @@ protected:
     void mousePressEvent(QMouseEvent *) override;
     void mouseReleaseEvent(QMouseEvent *) override;
     void wheelEvent(QWheelEvent *) override;
+
+private:
+    bool m_fullscreen_from_maximized = false;
 };
 
 class Window : public QMainWindow {


### PR DESCRIPTION
Alt-Enter on Qt, ⌘-Control-F on Mac.

F11 can't be used for fullscreen, since Glk gives access to all function keys (or at least 1-12). Use the traditional Alt-Enter instead.