### PR TITLE
Update the MP3 detection for SDL

### DIFF
--- a/garglk/sndsdl.cpp
+++ b/garglk/sndsdl.cpp
@@ -487,7 +487,13 @@ static int detect_format(const std::vector<unsigned char> &buf)
         {{0, {"OggS"}}, giblorb_ID_OGG},
 
         // mp3
-        {{0, {"\377\372"}}, giblorb_ID_MP3},
+        {{0, {"ID3"}}, giblorb_ID_MP3},
+        {{0, {"\xff\xe2"}}, giblorb_ID_MP3},
+        {{0, {"\xff\xe3"}}, giblorb_ID_MP3},
+        {{0, {"\xff\xf2"}}, giblorb_ID_MP3},
+        {{0, {"\xff\xf3"}}, giblorb_ID_MP3},
+        {{0, {"\xff\xfa"}}, giblorb_ID_MP3},
+        {{0, {"\xff\xfb"}}, giblorb_ID_MP3},
     };
 
     for (const auto &entry : formats) {


### PR DESCRIPTION
This is copied from the Qt backend, which has a more robust way of detecting MP3 files. Because of MP3's lack of structure, this isn't perfect, but there's not much you can do about that.