### PR TITLE
Use the new garglk_add_resource_from_file function for Hugo/Scare

### DIFF
--- a/terps/hugo/source/heres.c
+++ b/terps/hugo/source/heres.c
@@ -483,6 +483,10 @@ NotinResourceFile:
 		}
 #else
 	/* Glk implementation */
+#ifdef GARGLK
+	snprintf(temp, sizeof temp, "%s/%s", hugo_path_to_game, resname);
+	resource_file = glkunix_stream_open_pathname(temp, 0, 0);
+#else
 	fref = glk_fileref_create_by_name(fileusage_Data | fileusage_BinaryMode,
 		resname, 0);
 	if (glk_fileref_does_file_exist(fref))
@@ -490,6 +494,7 @@ NotinResourceFile:
 	else
 		resource_file = NULL;
 	glk_fileref_destroy(fref);
+#endif
 	if (!resource_file)
 	{
 		if (!strcmp(filename, ""))


### PR DESCRIPTION
This is still not ideal: the official Adrift runner can display images in a separate window manager window or in a split window, and a lot of games expect this, clearing the main window after displaying an image. Since Gargoyle displays images inline, they'll never be seen. But at least some games' images will work.

I'll probably add an option at some point to split the window for images, but for the time being, they are all inline. Another possibility is to intercept "clear window" calls and just print several newlines, but that's a bit of an overstep into a game's intent, maybe.