### PR TITLE
Add MIDI support to the Qt sound backend via fluidsynth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           cmake
           extra-cmake-modules
           git
+          libfluidsynth-dev
           libfmt-dev
           libfontconfig1-dev
           libfreetype-dev

--- a/.github/workflows/macos-qt.yml
+++ b/.github/workflows/macos-qt.yml
@@ -15,7 +15,7 @@ jobs:
         run: brew update
 
       - name: Install packages
-        run: brew install fmt libopenmpt libsndfile libvorbis mpg123 pkg-config qt6 libpng jpeg
+        run: brew install fluid-synth fmt libopenmpt libsndfile libvorbis mpg123 pkg-config qt6 libpng jpeg
 
       - name: Build (Qt)
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
           gcc-7
           git
           grep
+          libfluidsynth-dev
           libfmt-dev
           libfontconfig1-dev
           libfreetype-dev

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,6 +25,8 @@ option (see below).
 In addition, if you want sound support, there are two backends: SDL and
 Qt. For SDL, you will need SDL2 and SDL2\_mixer. For Qt, you will need
 QtMultimedia, libsndfile (with Vorbis support), mpg123, and libopenmpt.
+In addition, if fluidsynth is installed, it will be used for MIDI in the
+Qt backend, but it is optional.
 
 If you want text-to-speech support on Unix, you will need
 speech-dispatcher. Windows and macOS natively provide text-to-speech
@@ -114,6 +116,13 @@ In addition, Gargoyle supports the following options:
 
 - `WITH_BUNDLED_FMT`: If true, prefer Gargoyle's bundled fmt library to
   the system library. Defaults to false.
+
+- `DEFAULT_SOUNDFONT`: Some MIDI backends require the use of a SoundFont, and
+  due to size restrictions, Gargoyle does not ship one. As a result, if a
+  SoundFont is required, and the user hasn't configured one, MIDI support
+  might be disabled. If a full path to a SoundFont is given to this option, it
+  will be used in the absence of a user's specified SoundFont, allowing
+  distributions to create an out-of-the-box working MIDI experience.
 
 As with any standard CMake-based project, DESTDIR can be used to install to a
 staging area:

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -30,6 +30,10 @@ if(INTERFACE STREQUAL "QT")
     option(WITH_NATIVE_FILE_DIALOGS "Use native dialogs instead of Qt dialogs" ON)
 endif()
 
+if(SOUND STREQUAL "SDL" OR SOUND STREQUAL "QT")
+    set(DEFAULT_SOUNDFONT "" CACHE STRING "Path to a soundfont to use by default (defaults to empty, i.e. no default soundfont)")
+endif()
+
 if(MSVC)
     vtk_encode_string(
         INPUT garglk.ini
@@ -98,6 +102,10 @@ warnings(garglk)
 
 if(UNIX AND NOT APPLE)
     target_compile_definitions(garglk PRIVATE "GARGLKINI=\"${GARGLKINI}\"")
+endif()
+
+if(DEFAULT_SOUNDFONT)
+    target_compile_definitions(garglk PRIVATE "GARGLK_DEFAULT_SOUNDFONT=\"${DEFAULT_SOUNDFONT}\"")
 endif()
 
 if(APPIMAGE)
@@ -238,6 +246,12 @@ if("${SOUND}" STREQUAL "QT")
         find_package(PkgConfig REQUIRED)
         pkg_check_modules(SOUND REQUIRED IMPORTED_TARGET sndfile libmpg123 libopenmpt)
         target_link_libraries(garglk PRIVATE Qt${QT_VERSION}::Multimedia PkgConfig::SOUND)
+
+        pkg_check_modules(FLUIDSYNTH IMPORTED_TARGET fluidsynth2)
+        if(TARGET PkgConfig::FLUIDSYNTH)
+            target_compile_definitions(garglk PRIVATE GARGLK_HAS_FLUIDSYNTH)
+            target_link_libraries(garglk PRIVATE PkgConfig::FLUIDSYNTH)
+        endif()
     endif()
     target_sources(garglk PRIVATE sndqt.cpp)
 elseif("${SOUND}" STREQUAL "SDL")

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <deque>
 #include <fstream>
 #include <functional>
 #include <iomanip>
@@ -218,6 +219,12 @@ bool gli_conf_sound = true;
 bool gli_conf_speak = false;
 bool gli_conf_speak_input = false;
 std::string gli_conf_speak_language;
+
+#ifdef GARGLK_DEFAULT_SOUNDFONT
+std::deque<std::string> gli_conf_soundfonts = {GARGLK_DEFAULT_SOUNDFONT};
+#else
+std::deque<std::string> gli_conf_soundfonts;
+#endif
 
 bool gli_conf_fullscreen = false;
 
@@ -750,6 +757,15 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
 
                 if (argstream >> number >> path) {
                     gli_bleeps.update(config_range(parse_int(number), 1, 2), path);
+                }
+            } else if (cmd == "soundfont") {
+                gli_conf_soundfonts.clear();
+
+                std::istringstream argstream(arg);
+                std::string soundfont;
+
+                while (argstream >> std::quoted(soundfont)) {
+                    gli_conf_soundfonts.push_front(soundfont);
                 }
             } else if (cmd == "fullscreen") {
                 gli_conf_fullscreen = asbool(arg);

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -564,6 +564,7 @@ extern std::array<unsigned char, 5> gli_conf_lcd_weights;
 
 extern bool gli_conf_graphics;
 extern bool gli_conf_sound;
+extern std::deque<std::string> gli_conf_soundfonts;
 
 extern bool gli_conf_fullscreen;
 

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -71,6 +71,18 @@ caps          0               # Force uppercase input  -- 0=off 1=on
 graphics      1               # enable graphics
 sound         1               # enable sound
 
+# Gargoyle supports MIDI files, as used by some Adrift games. Unlike other
+# supported file formats, MIDI files require external instruments, so can
+# require a bit more effort to get working. If the SDL sound backend is
+# enabled, it's possible that native operating system routines are being used
+# on Windows, Mac, and Haiku. For the Qt backend, or the SDL backend on other
+# platforms, SoundFonts are used to provide the instruments. Here you can
+# specify which SoundFonts you want to use, with higher priority ones listed
+# first: if an instrument is not found in the first font, the second is
+# consulted, and so on.
+#
+# soundfont "/soundfont1.sf2" "/soundfont2.sf2"
+
 # Gargoyle provides support for the Z-Machine's sound effects 1 and 2.
 # The Z-Machine Standards Document 1.1 says this about so-called bleeps:
 #

--- a/garglk/sndsdl.cpp
+++ b/garglk/sndsdl.cpp
@@ -127,6 +127,17 @@ void gli_initialize_sound()
             return;
         }
 
+        std::string soundfonts;
+        for (const auto &soundfont : gli_conf_soundfonts) {
+            if (soundfont.find(';') == std::string::npos) {
+                soundfonts += soundfont + ';';
+            }
+        }
+
+        if (!soundfonts.empty()) {
+            Mix_SetSoundFonts(soundfonts.c_str());
+        }
+
         int channels = Mix_AllocateChannels(SDL_CHANNELS);
         Mix_GroupChannels(0, channels - 1, FREE);
         Mix_ChannelFinished(nullptr);


### PR DESCRIPTION
At the same time, since SoundFonts are now part of the config, do SoundFont loading for the SDL backend.