### PR TITLE
Allow FluidSynth reverb/chorus to be disabled

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -226,6 +226,9 @@ std::deque<std::string> gli_conf_soundfonts = {GARGLK_DEFAULT_SOUNDFONT};
 std::deque<std::string> gli_conf_soundfonts;
 #endif
 
+bool gli_conf_fluidsynth_chorus = true;
+bool gli_conf_fluidsynth_reverb = true;
+
 bool gli_conf_fullscreen = false;
 
 bool gli_wait_on_quit = true;
@@ -767,6 +770,10 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 while (argstream >> std::quoted(soundfont)) {
                     gli_conf_soundfonts.push_front(soundfont);
                 }
+            } else if (cmd == "fluidsynth_reverb") {
+                gli_conf_fluidsynth_reverb = asbool(arg);
+            } else if (cmd == "fluidsynth_chorus") {
+                gli_conf_fluidsynth_chorus = asbool(arg);
             } else if (cmd == "fullscreen") {
                 gli_conf_fullscreen = asbool(arg);
             } else if (cmd == "zoom") {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -566,6 +566,9 @@ extern bool gli_conf_graphics;
 extern bool gli_conf_sound;
 extern std::deque<std::string> gli_conf_soundfonts;
 
+extern bool gli_conf_fluidsynth_reverb;
+extern bool gli_conf_fluidsynth_chorus;
+
 extern bool gli_conf_fullscreen;
 
 extern bool gli_wait_on_quit;

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -83,6 +83,13 @@ sound         1               # enable sound
 #
 # soundfont "/soundfont1.sf2" "/soundfont2.sf2"
 
+# If FluidSynth is being used for MIDI playback (which is the case if the Qt
+# sound backend is enabled), its reverb and chorus effects can be disabled by
+# setting the corresponding option to 0 (false).
+#
+# fluidsynth_reverb 1
+# fluidsynth_chorus 1
+
 # Gargoyle provides support for the Z-Machine's sound effects 1 and 2.
 # The Z-Machine Standards Document 1.1 says this about so-called bleeps:
 #

--- a/garglk/sndqt.cpp
+++ b/garglk/sndqt.cpp
@@ -453,6 +453,8 @@ public:
         }
 
         fluid_settings_setnum(m_settings.get(), "synth.gain", 0.6);
+        fluid_settings_setint(m_settings.get(), "synth.reverb.active", gli_conf_fluidsynth_reverb);
+        fluid_settings_setint(m_settings.get(), "synth.chorus.active", gli_conf_fluidsynth_chorus);
 
         double samplerate;
         fluid_settings_setnum(m_settings.get(), "synth.sample-rate", 48000);


### PR DESCRIPTION
FluidSynth has a _lot_ of configuration options, and there's no reason to expose most of them to the user. But the chorus and reverb settings have a big impact on the resulting sound, so let them be set.