### PR TITLE
Add and check a macro protecting garglk_tads_os_banner_size()

### DIFF
--- a/garglk/cheapglk/glk.h
+++ b/garglk/cheapglk/glk.h
@@ -64,6 +64,7 @@ typedef int32_t glsi32;
 #define GLK_MODULE_GARGLKBLEEP
 #define GLK_MODULE_GARGLKWINSIZE
 #define GLK_MODULE_GARGLK_FILE_RESOURCES
+#define GLK_MODULE_GARGLK_TADS_OS_BANNER_SIZE
 
 /* Define a macro for a function attribute that indicates a function that
     never returns. (E.g., glk_exit().) We try to do this only in C compilers

--- a/terps/tads/glk/osglkban.c
+++ b/terps/tads/glk/osglkban.c
@@ -28,6 +28,10 @@
 #include "os.h"
 #include "glk.h"
 
+#ifndef GLK_MODULE_GARGLK_TADS_OS_BANNER_SIZE
+#include "garglk.h"                 /* for-size to-contents hack */
+#endif
+
 typedef struct os_banner_s *osbanid_t;
 typedef struct banner_contents_s *contentid_t;
 
@@ -546,7 +550,15 @@ void os_banner_size_to_contents(void *banner_handle)
 #ifdef GARGLK
     if (banner->type == wintype_TextBuffer)
     {
+#ifdef GLK_MODULE_GARGLK_TADS_OS_BANNER_SIZE
         int size = garglk_tads_os_banner_size(banner->win);
+#else
+        winid_t win = banner->win;
+        window_textbuffer_t *dwin = win->data;
+        int size = dwin->scrollmax;
+        if (dwin->numchars)
+            size ++;
+#endif
         os_banner_set_size(banner, size, OS_BANNER_SIZE_ABS, 0);
     }
 #endif /* GARGLK */


### PR DESCRIPTION
This needs to be submitted to upstream, but upstream can't assume that Gargoyle is the current version; so restore the old invasive way, using the new TADS-specific API function only if its (new) associated macro exists.