### PR TITLE
Truncate filenames at the first period, per Glk

### DIFF
--- a/garglk/cheapglk/cgfref.cpp
+++ b/garglk/cheapglk/cgfref.cpp
@@ -263,6 +263,11 @@ frefid_t glk_fileref_create_by_name(glui32 usage, char *name,
                            [&to_remove](const char &c) { return to_remove.find(c) != std::string::npos; }),
             buf.end());
 
+    auto dot = buf.find('.');
+    if (dot != std::string::npos) {
+        buf = buf.substr(0, dot);
+    }
+
     if (buf.empty()) {
         buf = "null";
     }


### PR DESCRIPTION
For some reason, when implementing the new Glk recommendations (§6.1), I neglected to take into account the "remove period and following" part, so that's done now. This changes the behavior of glk_fileref_create_by_name(), which is unfortunate, but should not have any real impact anywhere. Hopefully.