### PR TITLE
Display a message to the user when there is a font lookup problem

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -87,7 +87,7 @@ std::string garglk::ConfigFile::format_type() const {
 double gli_backingscalefactor = 1.0;
 double gli_zoom = 1.0;
 
-FontFiles gli_conf_prop, gli_conf_mono, gli_conf_prop_override, gli_conf_mono_override;
+FontFiles gli_conf_prop, gli_conf_mono;
 
 std::string gli_conf_monofont = "Gargoyle Mono";
 std::string gli_conf_propfont = "Gargoyle Serif";
@@ -601,25 +601,25 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
             } else if (cmd == "monosize") {
                 gli_conf_monosize = parse_double(arg);
             } else if (cmd == "monor") {
-                gli_conf_mono_override.r = arg;
+                gli_conf_mono.r.override = arg;
             } else if (cmd == "monob") {
-                gli_conf_mono_override.b = arg;
+                gli_conf_mono.b.override = arg;
             } else if (cmd == "monoi") {
-                gli_conf_mono_override.i = arg;
+                gli_conf_mono.i.override = arg;
             } else if (cmd == "monoz") {
-                gli_conf_mono_override.z = arg;
+                gli_conf_mono.z.override = arg;
             } else if (cmd == "monofont") {
                 gli_conf_monofont = arg;
             } else if (cmd == "propsize") {
                 gli_conf_propsize = parse_double(arg);
             } else if (cmd == "propr") {
-                gli_conf_prop_override.r = arg;
+                gli_conf_prop.r.override = arg;
             } else if (cmd == "propb") {
-                gli_conf_prop_override.b = arg;
+                gli_conf_prop.b.override = arg;
             } else if (cmd == "propi") {
-                gli_conf_prop_override.i = arg;
+                gli_conf_prop.i.override = arg;
             } else if (cmd == "propz") {
-                gli_conf_prop_override.z = arg;
+                gli_conf_prop.z.override = arg;
             } else if (cmd == "propfont") {
                 gli_conf_propfont = arg;
             } else if (cmd == "leading") {

--- a/garglk/font.h
+++ b/garglk/font.h
@@ -26,36 +26,38 @@ public:
         m_fonts.insert({style, std::move(path)});
     }
 
-    void fill() {
+    bool fill() {
         const auto &regular = m_fonts[Style::Regular];
         if (!regular.has_value()) {
-            return;
+            return false;
         }
 
         FontFiles &files = m_type == FontType::Monospace ? gli_conf_mono
                                                          : gli_conf_prop;
 
-        files.r = *regular;
-        files.b = *regular;
-        files.i = *regular;
-        files.z = *regular;
+        files.r.base = *regular;
+        files.b.base = *regular;
+        files.i.base = *regular;
+        files.z.base = *regular;
 
         const auto &bold = m_fonts[Style::Bold];
         if (bold.has_value()) {
-            files.b = *bold;
-            files.z = *bold;
+            files.b.base = *bold;
+            files.z.base = *bold;
         };
 
         const auto &italic = m_fonts[Style::Italic];
         if (italic.has_value()) {
-            files.i = *italic;
-            files.z = *italic;
+            files.i.base = *italic;
+            files.z.base = *italic;
         }
 
         const auto &bolditalic = m_fonts[Style::BoldItalic];
         if (bolditalic.has_value()) {
-            files.z = *bolditalic;
+            files.z.base = *bolditalic;
         }
+
+        return true;
     }
 
 private:

--- a/garglk/fontfc.cpp
+++ b/garglk/fontfc.cpp
@@ -81,10 +81,10 @@ static nonstd::optional<std::string> find_font_by_styles(const std::string &base
     return nonstd::nullopt;
 }
 
-void garglk::fontreplace(const std::string &font, FontType type)
+bool garglk::fontreplace(const std::string &font, FontType type)
 {
     if (cfg == nullptr || font.empty()) {
-        return;
+        return false;
     }
 
     // Although there are 4 "main" types of font (Regular, Italic, Bold, Bold
@@ -135,7 +135,7 @@ void garglk::fontreplace(const std::string &font, FontType type)
     // italic variations can be created out of a regular font, so it's
     // OK if those don't exist.
     if (!sysfont.has_value()) {
-        return;
+        return false;
     }
 
     FontFiller filler(type);
@@ -151,7 +151,7 @@ void garglk::fontreplace(const std::string &font, FontType type)
     sysfont = find_font_by_styles(font, bold_italic_styles, bold_weights, italic_slants);
     filler.add(FontFiller::Style::BoldItalic, sysfont);
 
-    filler.fill();
+    return filler.fill();
 }
 
 void fontload()

--- a/garglk/fontmac.mm
+++ b/garglk/fontmac.mm
@@ -28,10 +28,10 @@
 static NSMutableArray *gli_registered_fonts = nil;
 static NSDistributedLock *gli_font_lock = nil;
 
-void garglk::fontreplace(const std::string &font, FontType type)
+bool garglk::fontreplace(const std::string &font, FontType type)
 {
     if (font.empty()) {
-        return;
+        return false;
     }
 
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -77,9 +77,9 @@ void garglk::fontreplace(const std::string &font, FontType type)
         CFRelease(urlRef);
     }
 
-    filler.fill();
-
     [pool drain];
+
+    return filler.fill();
 }
 
 void fontload()

--- a/garglk/fontwin.cpp
+++ b/garglk/fontwin.cpp
@@ -123,10 +123,10 @@ static bool find_font_file(const std::string &facename, std::string &filepath)
     return find_font_file_with_key(HKEY_LOCAL_MACHINE, FONT_SUBKEY, facename, filepath);
 }
 
-void garglk::fontreplace(const std::string &font, FontType type)
+bool garglk::fontreplace(const std::string &font, FontType type)
 {
     if (font.empty()) {
-        return;
+        return false;
     }
 
     LOGFONTA logfont;
@@ -142,9 +142,9 @@ void garglk::fontreplace(const std::string &font, FontType type)
     std::snprintf(logfont.lfFaceName, LF_FACESIZE, "%s", font.c_str());
     EnumFontFamiliesExA(hdc, &logfont, reinterpret_cast<FONTENUMPROCA>(font_cb), reinterpret_cast<LPARAM>(&filler), 0);
 
-    filler.fill();
-
     ReleaseDC(0, hdc);
+
+    return filler.fill();
 }
 
 void fontload()

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -158,8 +159,9 @@ std::string winopenfile(const char *prompt, FileFilter filter);
 std::string winsavefile(const char *prompt, FileFilter filter);
 [[noreturn]]
 void winabort(const std::string &msg);
+void winwarning(const std::string &title, const std::string &msg);
 std::string downcase(const std::string &string);
-void fontreplace(const std::string &font, FontType type);
+bool fontreplace(const std::string &font, FontType type);
 std::vector<ConfigFile> configs(const nonstd::optional<std::string> &gamepath);
 void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, const std::function<void(const std::string &cmd, const std::string &arg, int lineno)> &callback);
 std::string user_config();
@@ -183,6 +185,24 @@ std::unique_ptr<T, Deleter> unique(T *p, Deleter deleter)
 }
 
 bool read_file(const std::string &filename, std::vector<unsigned char> &buf);
+
+template <typename Iterable, typename DType>
+std::string join(const Iterable &values, const DType &delim)
+{
+    auto it = std::begin(values);
+    std::ostringstream result;
+
+    if (it != std::end(values)) {
+        result << *it++;
+    }
+
+    for (; it != std::end(values); ++it) {
+        result << delim << *it;
+    }
+
+    return result.str();
+}
+
 }
 
 template <std::size_t N>
@@ -607,12 +627,20 @@ extern int gli_baseline;
 extern int gli_leading;
 
 struct FontFiles {
-    nonstd::optional<std::string> r, b, i, z;
+    struct {
+        nonstd::optional<std::string> base;
+        nonstd::optional<std::string> override;
+
+        const nonstd::optional<std::string> &fontpath() const {
+            return override.has_value() ? override : base;
+        }
+    } r, b, i, z;
 };
+
 extern std::string gli_conf_propfont;
-extern FontFiles gli_conf_prop, gli_conf_prop_override;
+extern FontFiles gli_conf_prop;
 extern std::string gli_conf_monofont;
-extern FontFiles gli_conf_mono, gli_conf_mono_override;
+extern FontFiles gli_conf_mono;
 
 extern double gli_conf_gamma;
 extern double gli_conf_propsize;

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -167,6 +167,13 @@ void garglk::winabort(const std::string &msg)
     std::exit(1);
 }
 
+void garglk::winwarning(const std::string &title, const std::string &msg)
+{
+    auto *nsTitle = [NSString stringWithCString: title.c_str() encoding: NSUTF8StringEncoding];
+    auto *nsMsg = [NSString stringWithCString: msg.c_str() encoding: NSUTF8StringEncoding];
+    NSRunAlertPanel(nsTitle, @"%@", nil, nil, nil, nsMsg);
+}
+
 void winexit()
 {
     [gargoyle closeWindow:processID];

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -147,6 +147,12 @@ void garglk::winabort(const std::string &msg)
     gli_exit(EXIT_FAILURE);
 }
 
+void garglk::winwarning(const std::string &title, const std::string &msg)
+{
+    std::cerr << "warning: " << msg << std::endl;
+    QMessageBox::warning(nullptr, title.c_str(), msg.c_str());
+}
+
 void winexit()
 {
     gli_exit(0);

--- a/garglk/theme.cpp
+++ b/garglk/theme.cpp
@@ -92,24 +92,6 @@ struct ColorPair {
 
 }
 
-template <typename Iterable, typename DType>
-std::string join(const Iterable &values, const DType &delim)
-{
-    auto it = std::begin(values);
-    std::ostringstream result;
-
-    if (it != std::end(values)) {
-        result << *it++;
-    }
-
-    for (; it != std::end(values); ++it) {
-        result << delim;
-        result << *it;
-    }
-
-    return result.str();
-}
-
 namespace {
 
 struct ThemeStyles {
@@ -244,7 +226,7 @@ private:
         }
 
         if (!missing.empty()) {
-            throw std::runtime_error(Format("{} is missing the following styles: {}", color, join(missing, ", ")));
+            throw std::runtime_error(Format("{} is missing the following styles: {}", color, garglk::join(missing, ", ")));
         }
 
         return {colors};


### PR DESCRIPTION
Gargoyle falls back to its default fonts if the user font can't be loaded, but it used to do so silently, meaning an invalid configuration might not be noticed (apart from the small issue of the font looking completely wrong...)

Now Gargoyle will alert the user when there are font problems.