### PR TITLE
a Hugo parser Engine fix

### DIFF
--- a/terps/hugo/source/heparse.c
+++ b/terps/hugo/source/heparse.c
@@ -1087,7 +1087,12 @@ int MatchObject(int *wordnum)
 
 				/* definitely not this object */
 				else
+				{
 					SubtractPossibleObject(i);
+					/* clear bestobj if i is the current best object */
+					if (i == bestobj)
+						bestobj = 0;
+				}
 			}
 
 


### PR DESCRIPTION
Added some lines in heparse.c that fix a bug that comes up if a player is trying to refer to a known out of scope object when there is another known out of scope object that shares an adjective.  Without this fix, the engine locks onto the first defined object, ignoring nouns, and always sending that first object to ParseError.

This is my first time doing a pull request so if I'm doing something wrong, someone probably has my e-mail somewhere and can contact me directly.