### PR TITLE
Expand the dedicated directory to all game data

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -238,7 +238,7 @@ bool gli_conf_safeclicks = false;
 
 bool gli_conf_per_game_config = true;
 
-bool gli_conf_dedicated_save_directory = false;
+bool gli_conf_dedicated_gamedata_directory = false;
 
 Scaler gli_conf_scaler = Scaler::None;
 
@@ -850,8 +850,8 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 }
             } else if (cmd == "game_config") {
                 gli_conf_per_game_config = asbool(arg);
-            } else if (cmd == "dedicated_save_directory") {
-                gli_conf_dedicated_save_directory = asbool(arg);
+            } else if (cmd == "dedicated_gamedata_directory") {
+                gli_conf_dedicated_gamedata_directory = asbool(arg);
             } else if (cmd == "redraw_hack") {
                 gli_conf_redraw_hack = asbool(arg);
             } else if (cmd == "glyph_substitution_file") {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -667,7 +667,7 @@ extern bool gli_claimselect;
 
 extern bool gli_conf_per_game_config;
 
-extern bool gli_conf_dedicated_save_directory;
+extern bool gli_conf_dedicated_gamedata_directory;
 
 enum class Scaler {
     None,

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -151,15 +151,16 @@ scaler none
 wait_on_quit 1
 
 # By default, Gargoyle will allow the native file picker (Qt or MacOS)
-# to choose which directory to open in when saving and restoring. This
-# may not be the most desirable location for saves to go. Instead, if
-# this is set to 1, a per-game dedicated directory will be used. This
-# will be in a location like:
+# to choose which directory to open in when saving and loading files,
+# including save games, transcripts, and generic data files. This may
+# not be the most desirable location. Instead, if this is set to 1, a
+# per-game dedicated directory will be used, allowing each game's files
+# to be grouped together. This will be in a location like:
 #
-# $HOME/.local/share/io.github.garglk/Gargoyle/saves/zork1.z3 (Unix)
-# %APPDATA%\io.github.garglk\Gargoyle\saves\zork1.z3 (Windows)
-# $HOME/Library/Application Support/io.github.garglk/Gargoyle/saves/zork1.z3 (Mac)
-dedicated_save_directory 0
+# $HOME/.local/share/io.github.garglk/Gargoyle/gamedata/zork1.z3/ (Unix)
+# %APPDATA%\io.github.garglk\Gargoyle\gamedata\zork1.z3\ (Windows)
+# $HOME/Library/Application Support/io.github.garglk/Gargoyle/gamedata/zork1.z3/ (Mac)
+dedicated_gamedata_directory 0
 
 #===============================================================================
 # Fonts, sizes and spaces

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -550,7 +550,7 @@ static NSURL *get_save_dir(NSString *filename)
         return nil;
     }
 
-    dir = [dir URLByAppendingPathComponent: @"io.github.garglk/Gargoyle/saves"];
+    dir = [dir URLByAppendingPathComponent: @"io.github.garglk/Gargoyle/gamedata"];
     dir = [dir URLByAppendingPathComponent: filename];
     NSFileManager *fm = [NSFileManager defaultManager];
     [fm createDirectoryAtURL: dir withIntermediateDirectories: YES attributes: nil error: &error];

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -182,7 +182,7 @@ void winexit()
 
 static NSString *get_savedir(FileFilter filter)
 {
-    if (filter == FileFilter::Save && gli_conf_dedicated_save_directory && gli_workfile.has_value()) {
+    if (gli_conf_dedicated_gamedata_directory && gli_workfile.has_value()) {
         return [NSString stringWithUTF8String: gli_workfile->c_str()];
     }
 

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -171,11 +171,11 @@ static std::string winchoosefile(const QString &prompt, FileFilter filter, Actio
 
     QString dir = "";
 
-    if (filter == FileFilter::Save && gli_conf_dedicated_save_directory && gli_workfile.has_value()) {
+    if (gli_conf_dedicated_gamedata_directory && gli_workfile.has_value()) {
         auto path = QFileInfo(QString::fromStdString(*gli_workfile));
         if (!path.fileName().isEmpty()) {
             QDir basedir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-            QDir savepath = QDir(basedir.filePath("saves")).filePath(path.fileName());
+            QDir savepath = QDir(basedir.filePath("gamedata")).filePath(path.fileName());
             if (savepath.mkpath(savepath.absolutePath())) {
                 dir = savepath.absolutePath();
             }


### PR DESCRIPTION
The earlier iteration of this stored save games in a dedicated directory, but it probably makes sense to store _all_ game data in that directory, including transcripts and, less commonly, generic data files.