### PR TITLE
Add back accidentally-removed macro

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -221,6 +221,7 @@ elseif(UNIX OR MINGW OR MSVC)
         target_link_libraries(gargoyle PRIVATE Qt${QT_VERSION}::Widgets)
     endif()
 
+    target_compile_definitions(garglk PRIVATE GARGLK_CONFIG_TICK)
     set(GARGLK_NEEDS_TICK TRUE CACHE INTERNAL "")
 else()
     message(FATAL_ERROR "Unsupported platform (${CMAKE_SYSTEM_NAME}).")


### PR DESCRIPTION
Without GARGLK_CONFIG_TICK, glk_tick() won't ever call gli_tick().