### PR TITLE
Support C++17 on Mac where appropriate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,20 +16,22 @@ if(POLICY CMP0069)
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9")
-    set(GCC_NO_CXX17 TRUE)
+    set(GARGLK_NO_CXX17 TRUE)
 endif()
 
-# At the moment C++17 is optional, and used in only one place. In the
-# near future, however, it will likely be required.
-# Completely disable on macOS, since although it claims C++17 support,
-# when building for older versions (as is done by gargoyle_osx.sh), not
-# all C++17 features are exposed. The C++17 code is unused on macOS
-# anyway, so there's no harm here.
+# Darwin 19.0 corresponds to MacOS 10.15.
+if(APPLE AND CMAKE_SYSTEM_VERSION VERSION_LESS 19.0)
+    set(GARGLK_NO_CXX17 TRUE)
+endif()
+
+# At the moment C++17 is optional, but it will likely be required in the
+# near future. MacOS introduced C++17 support in 10.15, so use C++14 for
+# any earlier versions.
 # In addition, CMake claims C++17 support for g++7, but std::filesystem
 # isn't available there. In fact, proper std::filesystem support didn't
 # land in gcc till version 9 (see https://gcc.gnu.org/gcc-9/changes.html),
 # so disable on gcc versions prior to 9.
-if("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES AND NOT APPLE AND NOT GCC_NO_CXX17)
+if("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES AND NOT GARGLK_NO_CXX17)
     set(CXX_VERSION 17)
 else()
     set(CXX_VERSION 14)

--- a/gargoyle_osx.sh
+++ b/gargoyle_osx.sh
@@ -28,7 +28,12 @@ else
   HOMEBREW_OR_MACPORTS_LOCATION="$(pushd "$(dirname "$(which port)")/.." > /dev/null ; pwd -P ; popd > /dev/null)"
 fi
 
-MACOS_MIN_VER="10.13"
+if [[ "$(sw_vers -productVersion)" =~ ^10\.([0-9]+) && ${BASH_REMATCH[1]} -lt 15 ]]; then
+  MACOS_MIN_VER="10.13"
+else
+    MACOS_MIN_VER="10.15"
+fi
+
 echo "MACOS_MIN_VER $MACOS_MIN_VER"
 
 # Use as many CPU cores as possible


### PR DESCRIPTION
C++17 usage has become a bit more pervasive, so enable it on MacOS version 10.15 and newer.