### PR TITLE
Fixes for the Windows-Clang build process

### DIFF
--- a/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
+++ b/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_target(frankendrift
     ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy "${GARGLK_FRANKEN_DYLIB}" "${CMAKE_CURRENT_SOURCE_DIR}"
-    COMMAND ${DOTNET} publish --self-contained -c Release -r "${GARGLK_DOTNET_RID}" -p:GarglkMode=dynamic "-p:BaseIntermediateOutputPath=${CMAKE_CURRENT_BINARY_DIR}/" "-p:BaseOutputPath=${CMAKE_CURRENT_BINARY_DIR}" -o "${CMAKE_CURRENT_BINARY_DIR}"
+    COMMAND ${DOTNET} publish --self-contained -c Release -r "${GARGLK_DOTNET_RID}" -p:GarglkMode=dynamic "-p:BaseIntermediateOutputPath=${CMAKE_CURRENT_BINARY_DIR}/obj/" "-p:BaseOutputPath=${CMAKE_CURRENT_BINARY_DIR}/bin/" -o "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "Building FrankenDrift with ${DOTNET}"
 )
 

--- a/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
+++ b/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
@@ -22,8 +22,6 @@ endif()
 # ... but CAN cross-compile for a different CPU architecture:
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x64)$")
     set(GARGLK_DOTNET_RID "${GARGLK_DOTNET_RID}-x64")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i386|i686|X86)$")
-    set(GARGLK_DOTNET_RID "${GARGLK_DOTNET_RID}-x86")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64|armv8l)$")
     set(GARGLK_DOTNET_RID "${GARGLK_DOTNET_RID}-arm64")
 else()

--- a/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/FrankenDrift.GlkRunner.Gargoyle.csproj
+++ b/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/FrankenDrift.GlkRunner.Gargoyle.csproj
@@ -13,12 +13,12 @@
 		<ProjectReference Include="..\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.csproj" />
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<PropertyGroup Condition="'$(FdAotEnabled)' != 'false'">
 		<PublishAot>true</PublishAot>
 		<TrimmerSingleWarn>false</TrimmerSingleWarn>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(GarglkMode)' == ''">
+	<PropertyGroup Condition="'$(GarglkMode)' == '' And '$(FdAotEnabled)' != 'false'">
 		<GarglkMode>runtime</GarglkMode>
 	</PropertyGroup>
 

--- a/winbuildrelease.ps1
+++ b/winbuildrelease.ps1
@@ -13,12 +13,18 @@
 $ErrorActionPreference = "Stop"
 $loc = Get-Location
 
-$builddir = "$PSScriptRoot\cmake-build-clang-$($buildType.ToLower())"
+if ($arm64Cross) {
+    $target = "arm64"
+} else {
+    $target = "x64"
+}
+
+$builddir = "$PSScriptRoot\cmake-build-clang-$($buildType.ToLower())-$target"
 if (Test-Path $builddir) {
     Remove-Item $builddir -Recurse
 }
 mkdir $builddir
-cd $builddir
+Set-Location $builddir
 
 if ($withFrankendrift) {
 	$cmFd = "ON"
@@ -27,13 +33,35 @@ if ($withFrankendrift) {
 }
 
 if ($arm64cross) {
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_LINKER=lld-link -DINTERFACE=QT -DCMAKE_PREFIX_PATH="$qtPath/msvc2019_arm64" -DCMAKE_TOOLCHAIN_FILE="$vcpkgPath/scripts/buildsystems/vcpkg.cmake" -DSOUND=QT -DWITH_FRANKENDRIFT=ON -DCMAKE_C_COMPILER_TARGET=arm64-pc-windows-msvc -DCMAKE_CXX_COMPILER_TARGET=arm64-pc-windows-msvc -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_CROSSCOMPILING=ON -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=arm64 -DCMAKE_STATIC_LINKER_FLAGS="/machine:arm64 " -DCMAKE_SHARED_LINKER_FLAGS="/machine:arm64 " -DCMAKE_EXE_LINKER_FLAGS="/machine:arm64 " -DWITH_FRANKENDRIFT=ON -DDIST_INSTALL=ON ..
+    cmake -G Ninja -DCMAKE_BUILD_TYPE="$buildType" -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_LINKER=lld-link -DINTERFACE=QT -DCMAKE_PREFIX_PATH="$qtPath/msvc2019_arm64" -DCMAKE_TOOLCHAIN_FILE="$vcpkgPath/scripts/buildsystems/vcpkg.cmake" -DSOUND=QT -DWITH_FRANKENDRIFT=ON -DCMAKE_C_COMPILER_TARGET=arm64-pc-windows-msvc -DCMAKE_CXX_COMPILER_TARGET=arm64-pc-windows-msvc -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY -DCMAKE_CROSSCOMPILING=ON -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=arm64 -DCMAKE_STATIC_LINKER_FLAGS="/machine:arm64 " -DCMAKE_SHARED_LINKER_FLAGS="/machine:arm64 " -DCMAKE_EXE_LINKER_FLAGS="/machine:arm64 " -DWITH_FRANKENDRIFT="$cmFd" -DDIST_INSTALL=ON ..
 } else {
     cmake -G Ninja -DCMAKE_BUILD_TYPE="$buildType" -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_LINKER=lld-link -DINTERFACE=QT -DCMAKE_PREFIX_PATH="$qtPath/msvc2019_64" -DCMAKE_TOOLCHAIN_FILE="$vcpkgPath/scripts/buildsystems/vcpkg.cmake" -DSOUND=QT -DDIST_INSTALL=ON -DWITH_FRANKENDRIFT="$cmFd" ..
 }
 ninja
 
-$stagedir = "$PSScriptRoot\gargoyle-staging"
+# I do not know why, I do not want to know why, I should not have to wonder why, but sometimes dotnet will simply stop before the NativeAOT step. (When switching from building for one arch to the other.)
+# Usually it starts working on the fourth attempt for no apparent reason, so I settled for this nonsense:
+if ($withFrankendrift) {
+    $i = 1
+    # The NativeAOT executable should be around 8.5MB large.
+    while ($i -le 10 -and (Get-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe").Length -lt 8000000) {
+        Write-Host "[$i/10] FrankenDrift Exe too small, trying again..." -ForegroundColor Red
+        Remove-Item -r "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\bin"
+        Remove-Item -r "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\obj"
+        Remove-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.pdb"
+        Remove-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.exe"
+        Remove-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.dll"
+        ninja frankendrift
+        $i += 1
+    }
+    if ($i -gt 10) {
+        Write-Error "Failed to produce a working FrankenDrift executable in a reasonable number of attempts."
+    } else {
+        Write-Host "Produced a working FrankenDrift executable in $i attempt(s)." -ForegroundColor Green
+    }
+}
+
+$stagedir = "$PSScriptRoot\gargoyle-staging-$target"
 if (Test-Path "$stagedir") {
     Remove-Item $stagedir -Recurse
 }
@@ -58,10 +86,31 @@ if ($withFrankendrift) {
     }
 }
 
-cd "$stagedir"
+Set-Location "$stagedir"
+$deployArgs = @("--no-opengl-sw","--no-compiler-runtime","--no-system-d3d-compiler","--no-system-dxc-compiler","--no-pdf","--exclude-plugins","ffmpegmediaplugin,qopensslbackend","--skip-plugin-types","iconengines,imageformats,tls")
 if ($withPdbs) {
-    windeployqt --no-opengl-sw --no-compiler-runtime --no-system-d3d-compiler --no-pdf --pdb garglk.dll
-} else {
-    windeployqt --no-opengl-sw --no-compiler-runtime --no-system-d3d-compiler --no-pdf garglk.dll
+    $deployArgs += "--pdb"
 }
-cd $loc
+if ($arm64Cross) {
+    # windeployqt doesn't understand cross-compilation and will deploy x64 Qt binaries, so we need to do this ourselves:
+    $deployInfo = (windeployqt @deployArgs --dry-run --json garglk.dll | ConvertFrom-Json).files
+    # (`--json` mode ignores most of the exclusions we made above, so we have to do this terribleness)
+    $deployInfo = $deployInfo | Where-Object {
+        (-not ((Split-Path $_.target -Leaf) -in @("tls","iconengines","imageformats"))) -and (-not ((Split-Path $_.source -Leaf) -in @("ffmpegmediaplugin.dll","avcodec-60.dll","avformat-60.dll","avutil-58.dll","swresample-4.dll","swscale-7.dll")))
+    }
+    # create target directories
+    New-Item -Type Directory -Force -Path ($deployInfo | Select-Object -ExpandProperty target -Unique)
+    $deployInfo | ForEach-Object {
+        Write-Host "Deploying:" (Split-Path $_.source -Leaf) "-->" $_.target
+        Copy-Item $_.source.Replace('\msvc2019_64\', '\msvc2019_arm64\') $_.target
+        # The `--pdb` switch is also ignored.
+        # (I'm starting to get the impression that `--json` mode isn't very good...)
+        if ($withPdbs -and $_.source.EndsWith(".dll")) {
+            Write-Host "Deploying:" (Split-Path $_.source -Leaf).Replace(".dll", ".pdb") "-->" $_.target
+            Copy-Item $_.source.Replace('\msvc2019_64\', '\msvc2019_arm64\').Replace(".dll", ".pdb") $_.target
+        }
+    }
+} else {
+    windeployqt @deployArgs garglk.dll
+}
+Set-Location $loc

--- a/winbuildrelease.ps1
+++ b/winbuildrelease.ps1
@@ -52,9 +52,9 @@ if ($withPdbs) {
 }
 
 if ($withFrankendrift) {
-    Copy-Item "$PSScriptRoot\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe" "$stagedir"
+    Copy-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe" "$stagedir"
     if ($withPdbs) {
-        Copy-Item "$PSScriptRoot\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.pdb" "$stagedir"
+        Copy-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.pdb" "$stagedir"
     }
 }
 

--- a/winbuildrelease.ps1
+++ b/winbuildrelease.ps1
@@ -60,8 +60,8 @@ if ($withFrankendrift) {
 
 cd "$stagedir"
 if ($withPdbs) {
-    windeployqt --no-opengl-sw --no-compiler-runtime --no-system-d3d-compiler --no-network --no-pdf --pdb garglk.dll
+    windeployqt --no-opengl-sw --no-compiler-runtime --no-system-d3d-compiler --no-pdf --pdb garglk.dll
 } else {
-    windeployqt --no-opengl-sw --no-compiler-runtime --no-system-d3d-compiler --no-network --no-pdf garglk.dll
+    windeployqt --no-opengl-sw --no-compiler-runtime --no-system-d3d-compiler --no-pdf garglk.dll
 }
 cd $loc


### PR DESCRIPTION
* adapt build script to building FrankenDrift in the cmake build directory
* disable FrankenDrift on x86 targets because .NET Native AOT doesn't support those
* ensure FrankenDrift cross-compilation works (with a terrible hack job because I can't seem to figure out the underlying issue)