### PR TITLE
Revert type changes to upstream Magnetic

### DIFF
--- a/terps/magnetic/Generic/defs.h
+++ b/terps/magnetic/Generic/defs.h
@@ -38,15 +38,7 @@
 #include <stdint.h>
 
 typedef uint8_t type8;
-// The name implies a signed type, but this appears to generally be used
-// where "char" normally would (i.e. for C strings); that is, the fact
-// that it is signed does not appear to matter, and making it signed
-// causes all sorts of diagnostics due to the fact that "signed char"
-// and "char" are different types, even if "char" is signed. In any
-// case, making it "char" causes a lot fewer warnings, and regardless of
-// whether it's signed or plain char, the "solution" will be casting,
-// and this requires fewer casts.
-typedef char type8s;
+typedef int8_t type8s;
 
 typedef uint16_t type16;
 typedef int16_t type16s;
@@ -341,7 +333,7 @@ struct ms_hint
 {
   type16  elcount;
   type16  nodetype;
-  type8s * content;
+  type8 * content;
   type16  links[MAX_HITEMS];
   type16  parent;
 };

--- a/terps/magnetic/Generic/emu.c
+++ b/terps/magnetic/Generic/emu.c
@@ -268,6 +268,10 @@
 #include <time.h>
 #include "defs.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wpointer-sign"
+#endif
+
 #if defined(__MSDOS__) && defined(__BORLANDC__)
 
 #include <alloc.h>
@@ -346,7 +350,7 @@ type8 anim_repeat = 0;
 #define MAX_HINTS 260
 #define MAX_HCONTENTS 30000
 struct ms_hint* hints = 0;
-type8s* hint_contents = 0;
+type8* hint_contents = 0;
 const type8s no_hints[] = "[Hints are not available.]\n";
 const type8s not_supported[] = "[This function is not supported.]\n";
 
@@ -2691,7 +2695,7 @@ void output_number(type16 number)
 	ms_putchar('0'+number);
 }
 
-type16 output_text(const type8s* text)
+type16 output_text(const type8* text)
 {
 	type16 i;
 
@@ -2936,7 +2940,7 @@ void do_line_a(void)
 					{
 						type32 length = 0;
 						type16 tempo = 0;
-						type8* midi = sound_extract((type8s *)code + a1reg + 3,&length,&tempo);
+						type8* midi = sound_extract(code + a1reg + 3,&length,&tempo);
 						if (midi != NULL)
 							ms_playmusic(midi,length,tempo);
 					}

--- a/terps/magnetic/Glk/glk.c
+++ b/terps/magnetic/Glk/glk.c
@@ -49,6 +49,10 @@
 
 #include "glk.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wpointer-sign"
+#endif
+
 /*
  * True and false definitions -- usually defined in glkstart.h, but we need
  * them early, so we'll define them here too.  We also need NULL, but that's
@@ -5575,7 +5579,7 @@ ms_save_file (type8s * name, type8 * ptr, type16 size)
         }
 
       /* Write game state. */
-      glk_put_buffer_stream (stream, (char *)ptr, size);
+      glk_put_buffer_stream (stream, ptr, size);
 
       glk_stream_close (stream, NULL);
       glk_fileref_destroy (fileref);
@@ -5658,7 +5662,7 @@ ms_load_file (type8s * name, type8 * ptr, type16 size)
         }
 
       /* Restore saved game data. */
-      glk_get_buffer_stream (stream, (char *)ptr, size);
+      glk_get_buffer_stream (stream, ptr, size);
 
       glk_stream_close (stream, NULL);
       glk_fileref_destroy (fileref);


### PR DESCRIPTION
The Magnetic code has loads of pointer type mismatches, essentially assuming that type8s (signed char) is compatible with char, which it isn't. char can be unsigned (and is, on aarch64), and even where it's signed, char and signed char are distinct types, and you cannot convert between pointers to the two without casting.

Originally I used "char" for "type8s" since it is generally used synonymously with "char" in the code, but there are indeed some areas where it _needs_ to be signed, breaking things on aarch64. While compilers are allowed to reject invalid pointer conversions between differently-signed integers of the same rank, in reality they don't. GCC doesn't even warn about such conversions by default, although the standard mandates a diagnostic.

Clang does warn, so for Clang (and GCC, for good measure), use #pragmas to disable this particular warning. Eventually if a strict compiler comes along we'll have to just litter the code with casts, but this is good enough for now.