### PR TITLE
Disable warnings via CMake instead of #pragmas

### DIFF
--- a/terps/CMakeLists.txt
+++ b/terps/CMakeLists.txt
@@ -329,6 +329,12 @@ if(WITH_MAGNETIC)
         SRCS magnetic/Generic/emu.c magnetic/Glk/glk.c
         INCLUDE_DIRS magnetic/Generic
         MACROS MAGNETIC_GLKUNIX)
+
+    if(CMAKE_C_COMPILER_ID MATCHES "Clang$")
+        # The alternative to this is lots of casts; ignore this warning
+        # unless it becomes a problem with a more strict compiler.
+        target_compile_options(magnetic PRIVATE "-Wno-pointer-sign")
+    endif()
 endif()
 
 # ------------------------------------------------------------------------------

--- a/terps/magnetic/Generic/emu.c
+++ b/terps/magnetic/Generic/emu.c
@@ -268,10 +268,6 @@
 #include <time.h>
 #include "defs.h"
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wpointer-sign"
-#endif
-
 #if defined(__MSDOS__) && defined(__BORLANDC__)
 
 #include <alloc.h>

--- a/terps/magnetic/Glk/glk.c
+++ b/terps/magnetic/Glk/glk.c
@@ -49,10 +49,6 @@
 
 #include "glk.h"
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic ignored "-Wpointer-sign"
-#endif
-
 /*
  * True and false definitions -- usually defined in glkstart.h, but we need
  * them early, so we'll define them here too.  We also need NULL, but that's


### PR DESCRIPTION
Using #pragma was inconsistent with how warnings are managed in other interpreters, so switch this around. No functional changes.