### PR TITLE
Make MIME types of hicolor icons match gargoyle.xml

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -395,7 +395,7 @@ elseif(UNIX)
         install(FILES "shared-mime-info.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages" RENAME "gargoyle.xml")
         install(FILES "io.github.garglk.Gargoyle.appdata.xml" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo")
 
-        foreach(terp adrift advsys agt alan blorb glulx hugo-image level9 magscroll tads zmachine)
+        foreach(terp adrift advsys agt alan-adventure-game alan3-adventure-game blorb glulx hugo-image level9 magscroll tads t3vm-image zmachine)
             install(FILES "gargoyle-docu2.png" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/mimetypes" RENAME "application-x-${terp}.png")
         endforeach()
     endif()

--- a/gargoyle-buildrpm.sh
+++ b/gargoyle-buildrpm.sh
@@ -125,13 +125,15 @@ ${frankendrift_spec}
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-adrift.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-advsys.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-agt.png
-%{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-alan.png
+%{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-alan-adventure-game.png
+%{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-alan3-adventure-game.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-blorb.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-glulx.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-hugo-image.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-level9.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-magscroll.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-tads.png
+%{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-t3vm-image.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-zmachine.png
 %{_datarootdir}/man/man6/gargoyle.6.gz
 %{_datarootdir}/metainfo/io.github.garglk.Gargoyle.appdata.xml


### PR DESCRIPTION
Icons for Alan and TADS 3 story files weren't showing up even though the MIME types were detected.