### PR TITLE
Add an ENABLE_GPL3 knob, disabled by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DSOUND=QT -DQT_VERSION=5
+          cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DSOUND=QT -DQT_VERSION=5 -DENABLE_GPL3=ON
 
       - name: Build
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ include(Compilers)
 option(WITH_INTERPRETERS "Build the included interpreters" ON)
 option(WITH_BABEL "Display Treaty of Babel-derived author and title if possible" ON)
 option(APPIMAGE "Tweak some settings to aid in AppImage building" OFF)
+option(ENABLE_GPL3 "Build libgarglk code which is GPLv3 only" OFF)
 
 if(MSVC)
     # MSVC defaults to the equivalent of "-fvisibility=hidden", which the code is not set up to support.
@@ -75,7 +76,11 @@ add_subdirectory(garglk)
 
 # xBRZ requires C++17.
 if(CXX_VERSION EQUAL 17)
-    add_subdirectory(support/xbrz)
+    if(ENABLE_GPL3)
+        add_subdirectory(support/xbrz)
+    else()
+        add_subdirectory(support/xbrz-null)
+    endif()
     add_subdirectory(support/hqx)
 endif()
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -123,6 +123,13 @@ In addition, Gargoyle supports the following options:
   will be used in the absence of a user's specified SoundFont, allowing
   distributions to create an out-of-the-box working MIDI experience.
 
+- `ENABLE_GPL3`: While garglk itself is licensed as GPLv2 or later, it can be
+  built with support for the xBRZ scaler, which is GPLv3, meaning libgarglk
+  built with xBRZ support is also GPLv3. Several interpreters are GPLv2 only,
+  so they cannot be distributed if built against a GPLv3 libgarglk. This
+  option, which is false by default, will enable GPLv3 code (which right now
+  is only xBRZ), resulting in a GPLv3 garglk.
+
 As with any standard CMake-based project, DESTDIR can be used to install to a
 staging area:
 

--- a/support/xbrz-null/CMakeLists.txt
+++ b/support/xbrz-null/CMakeLists.txt
@@ -1,0 +1,9 @@
+# xBRZ dummy interface
+
+add_library(xbrz STATIC xbrz.cpp)
+
+cxx_standard(xbrz 17)
+
+set_property(TARGET xbrz PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
+target_include_directories(xbrz PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/support/xbrz-null/xbrz.cpp
+++ b/support/xbrz-null/xbrz.cpp
@@ -1,0 +1,12 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+
+#include "xbrz.h"
+
+void xbrz::scale(std::size_t factor, const std::uint32_t *src, std::uint32_t *trg, int srcWidth, int srcHeight, ColorFormat colFmt)
+{
+    std::cerr << "warning: xBRZ suport requested, but disabled due to licensing issues\n";
+    std::copy(src, src + srcWidth * srcHeight, trg);
+}

--- a/support/xbrz-null/xbrz.h
+++ b/support/xbrz-null/xbrz.h
@@ -1,0 +1,20 @@
+#ifndef XBRZNULL_H
+#define XBRZNULL_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace xbrz
+{
+
+enum class ColorFormat
+{
+    ARGB,
+};
+
+const int SCALE_FACTOR_MAX = 1;
+void scale(std::size_t factor, const std::uint32_t *src, std::uint32_t *trg, int srcWidth, int srcHeight, ColorFormat colFmt);
+
+}
+
+#endif


### PR DESCRIPTION
xBRZ is GPLv3 only, but some interpreters are GPLv2 only. garglk is either 2 or 3, so building with xBRZ support forces it to be 3, and thus incompatible with GPLv2 interpreters.