### PR TITLE
Build garglkmain as C

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -147,8 +147,8 @@ if(MATH_LIBRARY)
     target_link_libraries(garglk-common PRIVATE ${MATH_LIBRARY})
 endif()
 
-add_library(garglkmain STATIC main.cpp)
-cxx_standard(garglkmain ${CXX_VERSION})
+add_library(garglkmain STATIC main.c)
+c_standard(garglkmain 11)
 warnings(garglkmain)
 target_include_directories(garglkmain PRIVATE cheapglk)
 

--- a/garglk/main.c
+++ b/garglk/main.c
@@ -17,12 +17,11 @@
 // along with Gargoyle; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include <cstdlib>
-#include <cstring>
+#include <stdlib.h>
+#include <string.h>
 
 #include "glk.h"
 #include "glkstart.h"
-#include "garglk.h"
 
 int main(int argc, char *argv[])
 {
@@ -30,8 +29,8 @@ int main(int argc, char *argv[])
 
     glkunix_startup_t startdata;
     startdata.argc = argc;
-    startdata.argv = new char *[argc + 1];
-    std::memcpy(startdata.argv, argv, (argc + 1) * sizeof(char *));
+    startdata.argv = malloc((argc + 1) * sizeof(char *));
+    memcpy(startdata.argv, argv, (argc + 1) * sizeof(char *));
 
     if (!glkunix_startup_code(&startdata)) {
         glk_exit();


### PR DESCRIPTION
Since this is a static library, it cannot indicate that it needs libstdc++ (or equivalent), meaning if it's C++, out-of-tree projects would need to manually link it in, with no indication of that.