### PR TITLE
Set CMAKE_INSTALL_RPATH to handle library paths correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ string(STRIP "${GARGOYLE_VERSION}" GARGOYLE_VERSION)
 # CI builds which include the current Git revision as the version.
 project(garglk)
 
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
 if(POLICY CMP0069)
     cmake_policy(SET CMP0069 NEW)
     include(CheckIPOSupported)


### PR DESCRIPTION
This resolves: error while loading shared libraries: libgarglk.so: cannot open shared object file: No such file or directory

Now, is this the right approach? I'm unsure!

In my case, this allowed it to find the libs in `/usr/lib64`