### PR TITLE
Ensure MacGlk code isn't being used with Gargoyle

### DIFF
--- a/terps/agility/os_glk.c
+++ b/terps/agility/os_glk.c
@@ -6744,6 +6744,7 @@ glkunix_startup_code (glkunix_startup_t * data)
 /*---------------------------------------------------------------------*/
 /*  Glk linkage relevant only to the Mac platform                      */
 /*---------------------------------------------------------------------*/
+#ifndef GARGLK
 #if TARGET_OS_MAC
 
 #include "macglk_startup.h"
@@ -6817,3 +6818,4 @@ macglk_startup_code (macglk_startup_t * data)
   return TRUE;
 }
 #endif /* TARGET_OS_MAC */
+#endif

--- a/terps/level9/Glk/glk.c
+++ b/terps/level9/Glk/glk.c
@@ -6695,6 +6695,7 @@ glkunix_startup_code (glkunix_startup_t * data)
 /*---------------------------------------------------------------------*/
 /*  Glk linkage relevant only to the Mac platform                      */
 /*---------------------------------------------------------------------*/
+#ifndef GARGLK
 #ifdef TARGET_OS_MAC
 
 #include "macglk_startup.h"
@@ -6770,3 +6771,4 @@ macglk_startup_code (macglk_startup_t * data)
   return TRUE;
 }
 #endif /* TARGET_OS_MAC */
+#endif

--- a/terps/magnetic/Glk/glk.c
+++ b/terps/magnetic/Glk/glk.c
@@ -6284,6 +6284,7 @@ glkunix_startup_code (glkunix_startup_t * data)
 /*---------------------------------------------------------------------*/
 /*  Glk linkage relevant only to the Mac platform                      */
 /*---------------------------------------------------------------------*/
+#ifndef GARGLK
 #if TARGET_OS_MAC
 
 #include "macglk_startup.h"
@@ -6357,3 +6358,4 @@ macglk_startup_code (macglk_startup_t * data)
   return TRUE;
 }
 #endif /* TARGET_OS_MAC */
+#endif


### PR DESCRIPTION
TARGET_OS_MAC is used by a few interpreters to decide whether they're being built against MagGlk. This was never a problem until recently, when TARGET_OS_MAC started being defined out of nowhere.

Apparently now on MacOS, TARGET_OS_* macros are unconditionally defined _by the compiler_ instead of just in TargetConditionals.h. It's not allowed to do that given that those names aren't reserved, but why let a little thing like the C standard get in your way.