### PR TITLE
Be more specific when looking up the data directory

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -104,6 +104,7 @@ warnings(garglk-common)
 
 if(UNIX AND NOT APPLE)
     target_compile_definitions(garglk-common PRIVATE "GARGLKINI=\"${GARGLKINI}\"")
+    target_compile_definitions(garglk-common PRIVATE "GARGLK_CONFIG_DATADIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}/io.github.garglk/Gargoyle\"")
 endif()
 
 if(DEFAULT_SOUNDFONT)

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -358,13 +358,11 @@ static std::vector<Font> make_substitution_fonts(FontFace fontface)
 
     auto files = gli_conf_glyph_substitution_files[fontface];
 
-    for (const auto &datadir : garglk::winappdata()) {
-        files.push_back(Format("{}/unifont.otf", datadir));
-        files.push_back(Format("{}/unifont_upper.otf", datadir));
-    }
 
-    files.emplace_back("./unifont.otf");
-    files.emplace_back("./unifont_upper.otf");
+    for (const auto &path : {garglk::windatadir(), "."s}) {
+        files.push_back(Format("{}/unifont.otf", path));
+        files.push_back(Format("{}/unifont_upper.otf", path));
+    }
 
     for (const auto &file : files) {
         if (FT_New_Face(ftlib, file.c_str(), 0, &face) == 0) {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -167,7 +167,8 @@ void config_entries(const std::string &fname, bool accept_bare, const std::vecto
 std::string user_config();
 bool set_lcdfilter(const std::string &filter);
 nonstd::optional<std::string> winfontpath(const std::string &filename);
-std::vector<std::string> winappdata();
+std::string windatadir();
+std::vector<std::string> winthemedirs();
 nonstd::optional<std::string> winappdir();
 bool winisfullscreen();
 

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -872,20 +872,31 @@ nonstd::optional<std::string> garglk::winfontpath(const std::string &filename)
     return nonstd::nullopt;
 }
 
-std::vector<std::string> garglk::winappdata()
+std::string garglk::windatadir()
+{
+    char *resources = std::getenv("GARGLK_RESOURCES");
+
+    if (resources != nullptr) {
+        return resources;
+    }
+
+    return ".";
+}
+
+std::vector<std::string> garglk::winthemedirs()
 {
     NSArray *appdir_paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
     char *resources = std::getenv("GARGLK_RESOURCES");
     std::vector<std::string> paths;
 
     if (resources != nullptr) {
-        paths.emplace_back(resources);
+        paths.push_back(Format("{}/themes", resources));
     }
 
     // This is what Qt returns for AppDataLocation (though Qt adds a
     // few more directories that aren't particularly relevant).
     for (NSString *appdir_path in appdir_paths) {
-        paths.push_back(Format("{}/{}/{}", [appdir_path UTF8String], GARGOYLE_ORGANIZATION, GARGOYLE_NAME));
+        paths.push_back(Format("{}/{}/{}/themes", [appdir_path UTF8String], GARGOYLE_ORGANIZATION, GARGOYLE_NAME));
     }
 
     return paths;

--- a/garglk/theme.cpp
+++ b/garglk/theme.cpp
@@ -248,8 +248,8 @@ std::vector<std::string> garglk::theme::paths()
 {
     std::vector<std::string> theme_paths;
 
-    for (const auto &path : garglk::winappdata()) {
-        theme_paths.push_back(Format("{}/themes", path));
+    for (const auto &path : garglk::winthemedirs()) {
+        theme_paths.push_back(path);
     }
 
     return theme_paths;


### PR DESCRIPTION
There are two things the winappdata() method was used for:

1. Looking up theme paths
2. Finding Unifont

But these are distinct operations. When looking for themes, the system themes should be used (as a base), but the user should also be able to add themes. As such, the concept of XDG's data directories, being configurable, makes perfect sense: allow the user to specify where he wants his data directories to be, and use those. And also use a "standard" set of system paths.

But Unifont is a different animal: Gargoyle installs it, and wants to find its Unifont, and its Unifont only. The user shouldn't be able to specify where it is.

Now Unifont and themes are searched differently. Themese still use the concept of "data directories", which on Unix systems means following XDG (via Qt's QStandardPaths), or some platform-specific hackery for Windows and Mac DMG files.

But Unifont is installed to a known location, and found directly. For Unix systems, CMake knows where it installs it, and directly tells Gargoyle where that is. As usual with Gargoyle on Windows, the location is the same as the Gargoyle binary. And as usual on Mac, it's in a specific location in the DMG bundle.