### PR TITLE
Install fallback fonts to data directory alongside Unifont

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -425,13 +425,6 @@ elseif(UNIX)
         endforeach()
     endif()
 
-    if(APPIMAGE)
-        set(FONT_DIRECTORY "${CMAKE_INSTALL_BINDIR}")
-    else()
-        set(FONT_DIRECTORY "${CMAKE_INSTALL_DATADIR}/fonts/gargoyle")
-        target_compile_definitions(garglk-common PRIVATE "GARGLK_CONFIG_FONT_PATH=\"${CMAKE_INSTALL_FULL_DATADIR}/fonts/gargoyle\"")
-    endif()
-
     install(FILES
         "${PROJECT_SOURCE_DIR}/fonts/Gargoyle-Mono-Bold-Italic.ttf"
         "${PROJECT_SOURCE_DIR}/fonts/Gargoyle-Mono-Bold.ttf"
@@ -441,9 +434,6 @@ elseif(UNIX)
         "${PROJECT_SOURCE_DIR}/fonts/Gargoyle-Serif-Bold.ttf"
         "${PROJECT_SOURCE_DIR}/fonts/Gargoyle-Serif-Italic.ttf"
         "${PROJECT_SOURCE_DIR}/fonts/Gargoyle-Serif.ttf"
-        DESTINATION "${FONT_DIRECTORY}")
-
-    install(FILES
         "${PROJECT_SOURCE_DIR}/fonts/unifont.otf"
         "${PROJECT_SOURCE_DIR}/fonts/unifont_upper.otf"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/io.github.garglk/Gargoyle")

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -254,7 +254,7 @@ FontEntry Font::getglyph(glui32 cid)
 }
 
 // Look in a system-wide location for the fallback Gargoyle fonts; on
-// Unix this is generally somewhere like /usr/share/fonts/gargoyle
+// Unix this is generally somewhere like /usr/share/io.github.garglk/Gargoyle/
 // (although this can be changed at build time), and on Windows it's the
 // install directory (e.g. "C:\Program Files (x86)\Gargoyle").
 static nonstd::optional<std::string> font_path_fallback_system(const std::string &fallback)
@@ -267,10 +267,8 @@ static nonstd::optional<std::string> font_path_fallback_system(const std::string
     }
 
     return Format("{}\\{}", directory, fallback);
-#elif defined(GARGLK_CONFIG_FONT_PATH)
-    return Format("{}/{}", GARGLK_CONFIG_FONT_PATH, fallback);
 #else
-    return nonstd::nullopt;
+    return Format("{}/{}", garglk::windatadir(), fallback);
 #endif
 }
 

--- a/gargoyle-buildrpm.sh
+++ b/gargoyle-buildrpm.sh
@@ -103,19 +103,19 @@ ${frankendrift_spec}
 %{_bindir}/gargoyle
 %{_datarootdir}/applications/io.github.garglk.Gargoyle.desktop
 %{_datarootdir}/applications/io.github.garglk.GargoyleEditConfig.desktop
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Mono-Bold-Italic.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Mono-Bold.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Mono-Italic.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Mono.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Serif-Bold-Italic.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Serif-Bold.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Serif-Italic.ttf
-%{_datarootdir}/fonts/gargoyle/Gargoyle-Serif.ttf
 %{_datarootdir}/io.github.garglk/Gargoyle/themes/Blue.json
 "%{_datarootdir}/io.github.garglk/Gargoyle/themes/Breeze Darker.json"
 "%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Dark.json"
 "%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Sepia.json"
 "%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Slate.json"
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono-Bold-Italic.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono-Bold.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono-Italic.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif-Bold-Italic.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif-Bold.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif-Italic.ttf
+%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif.ttf
 %{_datarootdir}/io.github.garglk/Gargoyle/themes/Pencil.json
 %{_datarootdir}/io.github.garglk/Gargoyle/themes/Zoom.json
 %{_datarootdir}/io.github.garglk/Gargoyle/themes/dark.json


### PR DESCRIPTION
Gargoyle needs to be able to find several different fonts:

• Fallback monospace and proportional, in case the user's selected fonts
  can't be found.
• Unifont for missing glyphs.

Until now, the fallback fonts (on Unix) were placed in /usr/share/fonts by default, i.e. the system font directory. But that's not really ideal: even though Gargoyle asks for the fonts by name and they are custom-named fonts, so won't clash with the system, there's no requirement for them to actually _be_ system fonts. Nobody is going to use Gargoyle's fonts outside of Gargoyle. Even if they wanted to, Gargoyle's fonts are just Charis SIL and Go Mono, so those fonts could be used directly.

All that _needs_ to happen is for Gargoyle to be able to find these fonts when necessary. It used to embed the fonts directly in libgarglk, but due to licensing issues (the OFL isn't compatible with the GPL) they had to be installed separately, and _somehow_ discoverable.

Unifont was always placed in a "data" directory, e.g. /usr/share/io.github.garglk/Gargoyle on Unix. It's not installed as a system font (the user very possibly already has it, anyway), and just needs to be discoverable by Gargoyle. So it's a "data file" as far as Gargoyle is concerned.

Given that, there's no reason for there to be two separate font locations, so the fallback fonts are now also installed to the data directory. Theoretically there's no reason for them to be called "Gargoyle Serif" and "Gargoyle Mono" anymore, but since previous Gargoyle versions shipped with those names, it's probably too late to do anything. Perhaps it's better this way, in case the default fonts need to change again: the "Gargoyle" names stick around regardless of the underlying font name.

In short, fonts are simplified by placing all needed fonts in the same location now.