### PR TITLE
Switch the share directory name to "gargoyle"

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -104,7 +104,7 @@ warnings(garglk-common)
 
 if(UNIX AND NOT APPLE)
     target_compile_definitions(garglk-common PRIVATE "GARGLKINI=\"${GARGLKINI}\"")
-    target_compile_definitions(garglk-common PRIVATE "GARGLK_CONFIG_DATADIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}/io.github.garglk/Gargoyle\"")
+    target_compile_definitions(garglk-common PRIVATE "GARGLK_CONFIG_DATADIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}/gargoyle\"")
 endif()
 
 if(DEFAULT_SOUNDFONT)
@@ -436,7 +436,7 @@ elseif(UNIX)
         "${PROJECT_SOURCE_DIR}/fonts/Gargoyle-Serif.ttf"
         "${PROJECT_SOURCE_DIR}/fonts/unifont.otf"
         "${PROJECT_SOURCE_DIR}/fonts/unifont_upper.otf"
-        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/io.github.garglk/Gargoyle")
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/gargoyle")
 
     install(FILES
         "${PROJECT_SOURCE_DIR}/themes/Blue.json"
@@ -448,7 +448,7 @@ elseif(UNIX)
         "${PROJECT_SOURCE_DIR}/themes/Zoom.json"
         "${PROJECT_SOURCE_DIR}/themes/dark.json"
         "${PROJECT_SOURCE_DIR}/themes/light.json"
-        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/io.github.garglk/Gargoyle/themes")
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/gargoyle/themes")
 
 endif()
 

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -254,9 +254,9 @@ FontEntry Font::getglyph(glui32 cid)
 }
 
 // Look in a system-wide location for the fallback Gargoyle fonts; on
-// Unix this is generally somewhere like /usr/share/io.github.garglk/Gargoyle/
-// (although this can be changed at build time), and on Windows it's the
-// install directory (e.g. "C:\Program Files (x86)\Gargoyle").
+// Unix this is generally somewhere like /usr/share/gargoyle (although
+// this can be changed at build time), and on Windows it's the install
+// directory (e.g. "C:\Program Files (x86)\Gargoyle").
 static nonstd::optional<std::string> font_path_fallback_system(const std::string &fallback)
 {
 #ifdef _WIN32

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -169,6 +169,7 @@ bool set_lcdfilter(const std::string &filter);
 nonstd::optional<std::string> winfontpath(const std::string &filename);
 std::string windatadir();
 std::vector<std::string> winthemedirs();
+nonstd::optional<std::string> winlegacythemedir();
 nonstd::optional<std::string> winappdir();
 bool winisfullscreen();
 

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -160,9 +160,9 @@ wait_on_quit 1
 # If a centralized location is requested, a dedicated directory for each
 # game is created. This will be something like:
 #
-# $HOME/.local/share/io.github.garglk/Gargoyle/gamedata/zork1.z3/ (Unix)
-# %APPDATA%\io.github.garglk\Gargoyle\gamedata\zork1.z3\ (Windows)
-# $HOME/Library/Application Support/io.github.garglk/Gargoyle/gamedata/zork1.z3/ (Mac)
+# $HOME/.local/share/gargoyle/gamedata/zork1.z3/ (Unix)
+# %APPDATA%\Gargoyle\gamedata\zork1.z3\ (Windows)
+# $HOME/Library/Application Support/Gargoyle/gamedata/zork1.z3/ (Mac)
 #
 # To use the default, set this to "default". For a dedicated centralized
 # location, use "dedicated". For the game's containing directory, use

--- a/garglk/garversion.h.in
+++ b/garglk/garversion.h.in
@@ -19,8 +19,6 @@
 #ifndef GARGLK_VERSION_H
 #define GARGLK_VERSION_H
 
-#define GARGOYLE_NAME "Gargoyle"
 #define GARGOYLE_VERSION "${GARGOYLE_VERSION}"
-#define GARGOYLE_ORGANIZATION "io.github.garglk"
 
 #endif

--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -35,7 +35,7 @@
 
 #define MaxBuffer 1024
 
-static const char *AppName = GARGOYLE_NAME " " GARGOYLE_VERSION;
+static const char *AppName = "Gargoyle " GARGOYLE_VERSION;
 
 static std::string winpath();
 
@@ -550,7 +550,7 @@ static NSURL *get_save_dir(NSString *filename)
         return nil;
     }
 
-    dir = [dir URLByAppendingPathComponent: @"io.github.garglk/Gargoyle/gamedata"];
+    dir = [dir URLByAppendingPathComponent: @"Gargoyle/gamedata"];
     dir = [dir URLByAppendingPathComponent: filename];
     NSFileManager *fm = [NSFileManager defaultManager];
     [fm createDirectoryAtURL: dir withIntermediateDirectories: YES attributes: nil error: &error];

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -45,7 +45,7 @@
 
 #include GARGLKINI_H
 
-static const char *AppName = GARGOYLE_NAME " " GARGOYLE_VERSION;
+static const char *AppName = "Gargoyle " GARGOYLE_VERSION;
 
 namespace {
 
@@ -292,8 +292,7 @@ int main(int argc, char **argv)
 {
     QApplication app(argc, argv);
 
-    QApplication::setOrganizationName(GARGOYLE_ORGANIZATION);
-    QApplication::setApplicationName(GARGOYLE_NAME);
+    QApplication::setApplicationName("gargoyle");
     QApplication::setApplicationVersion(GARGOYLE_VERSION);
 
     auto story = parse_args(app);

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -896,10 +896,14 @@ std::vector<std::string> garglk::winthemedirs()
     // This is what Qt returns for AppDataLocation (though Qt adds a
     // few more directories that aren't particularly relevant).
     for (NSString *appdir_path in appdir_paths) {
-        paths.push_back(Format("{}/{}/{}/themes", [appdir_path UTF8String], GARGOYLE_ORGANIZATION, GARGOYLE_NAME));
+        paths.push_back(Format("{}/Gargoyle/themes", [appdir_path UTF8String]));
     }
 
     return paths;
+}
+
+nonstd::optional<std::string> garglk::winlegacythemedir() {
+    return [[NSHomeDirectory() stringByAppendingPathComponent: @"Library/Application Support/io.github.garglk/Gargoyle/themes"] UTF8String];
 }
 
 nonstd::optional<std::string> garglk::winappdir()

--- a/garglk/theme.cpp
+++ b/garglk/theme.cpp
@@ -305,7 +305,27 @@ void garglk::theme::init()
         }
     }
 
-    for (const auto &themedir : garglk::theme::paths()) {
+    auto paths = garglk::theme::paths();
+
+    // Gargoyle used to set an organization of io.github.garglk and a name
+    // of Gargoyle (in Qt), which led to directories of the form
+    // share/io.github.garglk/Gargoyle, which is fairly ridiculous. Gargoyle
+    // now just sets the name to "gargoyle" and leaves the organization
+    // blank, resulting in the more standard "share/gargoyle"; but themes in
+    // earlier releases were stored in the more verbose location. Existing
+    // user themes in these locations should work, but the locations should
+    // _not_ be part of the "standard" theme paths, or they'll be shown to
+    // the user, e.g. in "gargoyle --paths", and users should be discouraged
+    // from using the older names. So, when doing the actual theme loading,
+    // try loading from the legacy location as well, but ensure the legacy
+    // location has the lowest priority (first in the list), so newer themes
+    // with the same name take precedence.
+    auto legacy = garglk::winlegacythemedir();
+    if (legacy.has_value()) {
+        paths.insert(paths.begin(), *legacy);
+    }
+
+    for (const auto &themedir : paths) {
         for (const auto &filename : directory_entries(themedir)) {
             auto dot = filename.find_last_of('.');
             if (dot != std::string::npos && filename.substr(dot) == ".json") {

--- a/gargoyle-buildrpm.sh
+++ b/gargoyle-buildrpm.sh
@@ -103,25 +103,25 @@ ${frankendrift_spec}
 %{_bindir}/gargoyle
 %{_datarootdir}/applications/io.github.garglk.Gargoyle.desktop
 %{_datarootdir}/applications/io.github.garglk.GargoyleEditConfig.desktop
-%{_datarootdir}/io.github.garglk/Gargoyle/themes/Blue.json
-"%{_datarootdir}/io.github.garglk/Gargoyle/themes/Breeze Darker.json"
-"%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Dark.json"
-"%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Sepia.json"
-"%{_datarootdir}/io.github.garglk/Gargoyle/themes/Lectrote Slate.json"
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono-Bold-Italic.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono-Bold.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono-Italic.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Mono.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif-Bold-Italic.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif-Bold.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif-Italic.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/Gargoyle-Serif.ttf
-%{_datarootdir}/io.github.garglk/Gargoyle/themes/Pencil.json
-%{_datarootdir}/io.github.garglk/Gargoyle/themes/Zoom.json
-%{_datarootdir}/io.github.garglk/Gargoyle/themes/dark.json
-%{_datarootdir}/io.github.garglk/Gargoyle/themes/light.json
-%{_datarootdir}/io.github.garglk/Gargoyle/unifont.otf
-%{_datarootdir}/io.github.garglk/Gargoyle/unifont_upper.otf
+%{_datarootdir}/gargoyle/themes/Blue.json
+"%{_datarootdir}/gargoyle/themes/Breeze Darker.json"
+"%{_datarootdir}/gargoyle/themes/Lectrote Dark.json"
+"%{_datarootdir}/gargoyle/themes/Lectrote Sepia.json"
+"%{_datarootdir}/gargoyle/themes/Lectrote Slate.json"
+%{_datarootdir}/gargoyle/Gargoyle-Mono-Bold-Italic.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Mono-Bold.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Mono-Italic.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Mono.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Serif-Bold-Italic.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Serif-Bold.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Serif-Italic.ttf
+%{_datarootdir}/gargoyle/Gargoyle-Serif.ttf
+%{_datarootdir}/gargoyle/themes/Pencil.json
+%{_datarootdir}/gargoyle/themes/Zoom.json
+%{_datarootdir}/gargoyle/themes/dark.json
+%{_datarootdir}/gargoyle/themes/light.json
+%{_datarootdir}/gargoyle/unifont.otf
+%{_datarootdir}/gargoyle/unifont_upper.otf
 %{_datarootdir}/icons/io.github.garglk.Gargoyle.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-adrift.png
 %{_datarootdir}/icons/hicolor/32x32/mimetypes/application-x-advsys.png


### PR DESCRIPTION
It used to be "io.github.garglk/Gargoyle" which is a mouthful and really annoying to deal with, so make it a whole lot more standard.

Since existing user themes might be installed with the older name, such locations are still checked for now.