### PR TITLE
Properly find the user's config file on Mac

### DIFF
--- a/garglk/launchmac.mm
+++ b/garglk/launchmac.mm
@@ -1078,16 +1078,11 @@ static void maybe_set_save_dir(NSSavePanel *panel, NSString *savedir)
 
 - (IBAction) toggle: (id) sender
 {
-    NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *home = [NSString stringWithFormat: @"%@/%@", [[[NSProcessInfo processInfo] environment] objectForKey: @"HOME"], @"garglk.ini"];
-    NSString *main = [NSString stringWithFormat: @"%@/%@", [[NSBundle mainBundle] resourcePath], @"garglk.ini"];
-
-    if (![fm isWritableFileAtPath: home] && [fm isReadableFileAtPath: main]) {
-        [fm createFileAtPath: home contents: [NSData dataWithContentsOfFile: main] attributes: nullptr];
-    }
-
-    [[NSWorkspace sharedWorkspace] openFile: home
-                            withApplication: @"TextEdit"];
+    auto config = [NSString stringWithUTF8String: garglk::user_config().c_str()];
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = @"/usr/bin/open";
+    task.arguments = @[@"-t", config];
+    [task launch];
 }
 
 @end


### PR DESCRIPTION
The "best" user config file is now found with garglk::user_config(). In the past, Mac would just flat out assume $HOME/garglk.ini was the location, but now Mac can also look in $HOME/.garglkrc. If you had .garglkrc, then editing the config would copy a brand new config into garglk.ini which would then take precedence, effectively rendering your actual config null.

Also, now use "open -t" to open the config file in the default text editor, rather than just assuming TextEdit.