### PR TITLE
Fix a few edge cases with images

### DIFF
--- a/garglk/garglk.cpp
+++ b/garglk/garglk.cpp
@@ -115,8 +115,10 @@ void garglk_window_get_size_pixels(window_t *win, glui32 *width, glui32 *height)
         wid = win->bbox.x1 - win->bbox.x0;
         hgt = win->bbox.y1 - win->bbox.y0;
     } else if (win->type == wintype_TextBuffer) {
-        wid = win->bbox.x1 - win->bbox.x0 - gli_tmarginx * 2;
-        hgt = win->bbox.y1 - win->bbox.y0 - gli_tmarginy * 2;
+        wid = win->bbox.x1 - win->bbox.x0;
+        wid -= std::min<glui32>(wid, gli_tmarginx * 2);
+        hgt = win->bbox.y1 - win->bbox.y0;
+        hgt -= std::min<glui32>(hgt, gli_tmarginy * 2);
     }
 
     if (width != nullptr) {

--- a/garglk/imgscale.cpp
+++ b/garglk/imgscale.cpp
@@ -51,6 +51,10 @@ std::shared_ptr<picture_t> gli_picture_scale(const picture_t *src, int newcols, 
     constexpr int HALFSCALE = 2048;
     constexpr long maxval = 255;
 
+    if (newcols == 0 || newrows == 0) {
+        return nullptr;
+    }
+
     auto dst = gli_picture_retrieve(src->id, true);
 
     if (dst && dst->w == newcols && dst->h == newrows) {

--- a/garglk/window.cpp
+++ b/garglk/window.cpp
@@ -531,8 +531,10 @@ void glk_window_get_size(window_t *win, glui32 *width, glui32 *height)
         hgt = hgt / gli_cellh;
         break;
     case wintype_TextBuffer:
-        wid = win->bbox.x1 - win->bbox.x0 - gli_tmarginx * 2;
-        hgt = win->bbox.y1 - win->bbox.y0 - gli_tmarginy * 2;
+        wid = win->bbox.x1 - win->bbox.x0;
+        wid -= std::min<glui32>(wid, gli_tmarginx * 2);
+        hgt = win->bbox.y1 - win->bbox.y0;
+        hgt -= std::min<glui32>(hgt, gli_tmarginy * 2);
         wid = wid / gli_cellw;
         hgt = hgt / gli_cellh;
         break;


### PR DESCRIPTION
1. When getting text buffer sizes, subtracting the margins could wrap below 0, resulting in large (unsigned) values. Effectively perform a saturating subtraction to ensure the value is limited to 0.
2. When scaling an image to 0 width or height, simply return a null pointer, preventing the image from ever being drawn in the first place. Without this, the image scaling code can try to write to nonexistent memory.