### PR TITLE
Properly support Unicode in text grids

### DIFF
--- a/garglk/wingrid.cpp
+++ b/garglk/wingrid.cpp
@@ -470,7 +470,11 @@ static void acceptline(window_t *win, glui32 keycode)
 
     if (!inunicode) {
         for (ix = 0; ix < dwin->inlen; ix++) {
-            (static_cast<char *>(inbuf))[ix] = static_cast<char>(ln->chars[dwin->inorgx + ix]);
+            glui32 ch = ln->chars[dwin->inorgx + ix];
+            if (ch > 0xff) {
+                ch = '?';
+            }
+            (static_cast<char *>(inbuf))[ix] = ch;
         }
         if (win->echostr != nullptr) {
             gli_stream_echo_line(win->echostr, static_cast<char *>(inbuf), dwin->inlen);
@@ -612,7 +616,7 @@ void gcmd_grid_accept_readline(window_t *win, glui32 arg)
             return;
         }
 
-        if (arg < 32 || arg > 0xff) {
+        if (arg < 32 || arg > 0x10ffff) {
             return;
         }
 


### PR DESCRIPTION
This fixes two bugs:

1. Gargoyle was completely discarding any line input values over 255, regardless of whether Unicode was requested.
2. When copying from the window into the user's buffer on accepting a line, the window value (glui32) was being converted to char by direct assignment, which is invalid for values >255.

Because of #1, #2 actually wasn't a problem, since no such values were being stored. But with #1 fixed, #2 became an actual issue.