### PR TITLE
Support the showing of a caret (cursor) in text grid windows

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -177,6 +177,7 @@ int gli_scroll_width = 0;
 
 int gli_caret_shape = 2;
 bool gli_underline_hyperlinks = true;
+bool gli_textgrid_caret = true;
 
 bool gli_conf_lcd = true;
 std::array<unsigned char, 5> gli_conf_lcd_weights = {28, 56, 85, 56, 28};
@@ -731,6 +732,8 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 gli_caret_shape = config_range(parse_int(arg), 0, 4);
             } else if (cmd == "linkstyle") {
                 gli_underline_hyperlinks = asbool(arg);
+            } else if (cmd == "gridcaret") {
+                gli_textgrid_caret = asbool(arg);
             } else if (cmd == "scrollwidth") {
                 gli_scroll_width = config_atleast(parse_int(arg), 0);
             } else if (cmd == "scrollbg") {

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -776,24 +776,24 @@ int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewi
     return gli_string_impl(0, face, text, len, spacewidth, [](int, const std::array<Bitmap, GLI_SUBPIX> &) {});
 }
 
-void gli_draw_caret(int x, int y)
+void gli_draw_caret(int x, int y, Color color)
 {
     x = x / GLI_SUBPIX;
     if (gli_caret_shape == 0) {
-        gli_draw_rect(x + 0, y + 1, 1, 1, gli_caret_color);
-        gli_draw_rect(x - 1, y + 2, 3, 1, gli_caret_color);
-        gli_draw_rect(x - 2, y + 3, 5, 1, gli_caret_color);
+        gli_draw_rect(x + 0, y + 1, 1, 1, color);
+        gli_draw_rect(x - 1, y + 2, 3, 1, color);
+        gli_draw_rect(x - 2, y + 3, 5, 1, color);
     } else if (gli_caret_shape == 1) {
-        gli_draw_rect(x + 0, y + 1, 1, 1, gli_caret_color);
-        gli_draw_rect(x - 1, y + 2, 3, 1, gli_caret_color);
-        gli_draw_rect(x - 2, y + 3, 5, 1, gli_caret_color);
-        gli_draw_rect(x - 3, y + 4, 7, 1, gli_caret_color);
+        gli_draw_rect(x + 0, y + 1, 1, 1, color);
+        gli_draw_rect(x - 1, y + 2, 3, 1, color);
+        gli_draw_rect(x - 2, y + 3, 5, 1, color);
+        gli_draw_rect(x - 3, y + 4, 7, 1, color);
     } else if (gli_caret_shape == 2) {
-        gli_draw_rect(x + 0, y - gli_baseline + 1, 1, gli_leading - 2, gli_caret_color);
+        gli_draw_rect(x + 0, y - gli_baseline + 1, 1, gli_leading - 2, color);
     } else if (gli_caret_shape == 3) {
-        gli_draw_rect(x + 0, y - gli_baseline + 1, 2, gli_leading - 2, gli_caret_color);
+        gli_draw_rect(x + 0, y - gli_baseline + 1, 2, gli_leading - 2, color);
     } else {
-        gli_draw_rect(x + 0, y - gli_baseline + 1, gli_cellw, gli_leading - 2, gli_caret_color);
+        gli_draw_rect(x + 0, y - gli_baseline + 1, gli_cellw, gli_leading - 2, color);
     }
 }
 

--- a/garglk/event.cpp
+++ b/garglk/event.cpp
@@ -37,7 +37,6 @@ static std::mutex event_mutex;
 
 static std::list<event_t> gli_events;
 
-static void gli_input_guess_focus();
 static void gli_input_more_focus();
 static void gli_input_next_focus();
 static void gli_input_scroll_focus();
@@ -235,7 +234,7 @@ void glk_select_poll(event_t *event)
 
 // Pick first window which might want input.
 // This is called after every keystroke.
-static void gli_input_guess_focus()
+void gli_input_guess_focus()
 {
     window_t *altwin = gli_focuswin;
 

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -571,8 +571,9 @@ extern nonstd::optional<Color> gli_override_fg;
 extern nonstd::optional<Color> gli_override_bg;
 extern bool gli_override_reverse;
 
-extern bool gli_underline_hyperlinks;
 extern int gli_caret_shape;
+extern bool gli_underline_hyperlinks;
+extern bool gli_textgrid_caret;
 extern int gli_wborderx;
 extern int gli_wbordery;
 
@@ -1042,6 +1043,8 @@ extern void win_pair_click(window_pair_t *dwin, int x, int y);
 
 extern void win_textgrid_rearrange(window_t *win, rect_t *box);
 extern void win_textgrid_redraw(window_t *win);
+extern void win_textgrid_init_char(window_t *win);
+extern void win_textgrid_cancel_char(window_t *win);
 extern void win_textgrid_putchar_uni(window_t *win, glui32 ch);
 extern bool win_textgrid_unputchar_uni(window_t *win, glui32 ch);
 extern void win_textgrid_clear(window_t *win);
@@ -1089,6 +1092,7 @@ extern void gli_window_click(window_t *win, int x, int y);
 
 void gli_redraw_rect(int x0, int y0, int x1, int y1);
 
+void gli_input_guess_focus();
 void gli_input_handle_key(glui32 key);
 void gli_input_handle_key_paste(glui32 key);
 void gli_input_handle_click(int x, int y);
@@ -1113,7 +1117,7 @@ void gli_draw_clear(const Color &rgb);
 void gli_draw_rect(int x, int y, int w, int h, const Color &rgb);
 int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb, const glui32 *text, int len, int spacewidth);
 int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth);
-void gli_draw_caret(int x, int y);
+void gli_draw_caret(int x, int y, Color color = gli_caret_color);
 void gli_draw_picture(const picture_t *pic, int x0, int y0, int dx0, int dy0, int dx1, int dy1);
 
 extern void gli_select(event_t *event, bool polled);

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -348,6 +348,18 @@ gamma         1.0             # this affects text rendering, not other colors
 caretshape    2               # 0=smalldot 1=fatdot 2=thinline 3=fatline 4=block
 linkstyle     1               # 1=underline hyperlinks 0=don't underline hyperlinks
 
+# The caret (input cursor) is always visible in text buffer windows when line
+# input is requested. For text grid windows, however, Gargoyle has historically
+# not shown a caret. But some games benefit from it (see the license application
+# in "Bureaucracy"), while it is a detriment to almost no games: so-called
+# Z-machine "absues" are probably the only types of game where the caret becomes
+# distracting. Given that, Gargoyle now displays a caret in text grid windows by
+# default, but this can be disabled for the traditional beahvior. Unlike text
+# buffers, the caret is shown during both line AND character input in text
+# grids, due to the fact that games (again see "Bureaucracy") sometimes simulate
+# line input via single-character input in grid windows.
+gridcaret     1               # 0=no caret in text grids 1=caret in text grids
+
 # moreprompt  ( more )
 # morealign   0               # 0=left 1=center 2=right
 # morefont    propb

--- a/garglk/window.cpp
+++ b/garglk/window.cpp
@@ -850,8 +850,13 @@ void glk_request_char_event(window_t *win)
 
     switch (win->type) {
     case wintype_TextBuffer:
+        win->char_request = true;
+        gli_focuswin = win;
+        break;
     case wintype_TextGrid:
         win->char_request = true;
+        win_textgrid_init_char(win);
+        gli_focuswin = win;
         break;
     default:
         gli_strict_warning("request_char_event: window does not support keyboard input");
@@ -873,8 +878,13 @@ void glk_request_char_event_uni(window_t *win)
 
     switch (win->type) {
     case wintype_TextBuffer:
+        win->char_request_uni = true;
+        gli_focuswin = win;
+        break;
     case wintype_TextGrid:
         win->char_request_uni = true;
+        win_textgrid_init_char(win);
+        gli_focuswin = win;
         break;
     default:
         gli_strict_warning("request_char_event_uni: window does not support keyboard input");
@@ -899,10 +909,12 @@ void glk_request_line_event(window_t *win, char *buf, glui32 maxlen,
     case wintype_TextBuffer:
         win->line_request = true;
         win_textbuffer_init_line(win, buf, maxlen, initlen);
+        gli_focuswin = win;
         break;
     case wintype_TextGrid:
         win->line_request = true;
         win_textgrid_init_line(win, buf, maxlen, initlen);
+        gli_focuswin = win;
         break;
     default:
         gli_strict_warning("request_line_event: window does not support keyboard input");
@@ -927,10 +939,12 @@ void glk_request_line_event_uni(window_t *win, glui32 *buf, glui32 maxlen,
     case wintype_TextBuffer:
         win->line_request_uni = true;
         win_textbuffer_init_line_uni(win, buf, maxlen, initlen);
+        gli_focuswin = win;
         break;
     case wintype_TextGrid:
         win->line_request_uni = true;
         win_textgrid_init_line_uni(win, buf, maxlen, initlen);
+        gli_focuswin = win;
         break;
     default:
         gli_strict_warning("request_line_event_uni: window does not support keyboard input");
@@ -1032,9 +1046,15 @@ void glk_cancel_char_event(window_t *win)
 
     switch (win->type) {
     case wintype_TextBuffer:
+        win->char_request = false;
+        win->char_request_uni = false;
+        gli_input_guess_focus();
+        break;
     case wintype_TextGrid:
         win->char_request = false;
         win->char_request_uni = false;
+        win_textgrid_cancel_char(win);
+        gli_input_guess_focus();
         break;
     default:
         // do nothing
@@ -1062,11 +1082,13 @@ void glk_cancel_line_event(window_t *win, event_t *ev)
         if (win->line_request || win->line_request_uni) {
             win_textbuffer_cancel_line(win, ev);
         }
+        gli_input_guess_focus();
         break;
     case wintype_TextGrid:
         if (win->line_request || win->line_request_uni) {
             win_textgrid_cancel_line(win, ev);
         }
+        gli_input_guess_focus();
         break;
     default:
         // do nothing

--- a/garglk/wintext.cpp
+++ b/garglk/wintext.cpp
@@ -1291,6 +1291,8 @@ void gcmd_buffer_accept_readchar(window_t *win, glui32 arg)
     win->char_request = false;
     win->char_request_uni = false;
     gli_event_store(evtype_CharInput, win, key, 0);
+
+    gli_input_guess_focus();
 }
 
 // Return or enter, during line input. Ends line input.
@@ -1389,6 +1391,8 @@ static void acceptline(window_t *win, glui32 keycode)
         dwin->numchars = dwin->infence;
         touch(dwin, 0);
     }
+
+    gli_input_guess_focus();
 
     if (gli_unregister_arr != nullptr) {
         const char *typedesc = (inunicode ? "&+#!Iu" : "&+#!Cn");


### PR DESCRIPTION
Glk specifically notes that grid windows won't necessarily show a cursor (see §3.5.4), so Gargoyle's traditional behavior isn't wrong. However, the license application at the beginning of the game Bureaucracy is extremely frustrating to use without a visible cursor. While such frustration actually dovetails nicely with the goal of the game, Infocom's interpreters weren't so cruel, and did provide a cursor. So do that here as well. The game My Angel also benefits, as it does line input in the upper window.

This feature is optional, though enabled by default. The "gridcaret" config option allows it to be disabled if the traditional behavior is desired.

This also introduces a small change in how the focused (for input) window is chosen. Previously Gargoyle would, every time a key was pressed, search for a window requesting input and, upon finding one, make it the currently-focused window. Caret-drawing functions then check whether they are in a focused window before drawing, so that, if there are multiple inputs being requested, for example, only one window actually draws the cursor.

This reactive behavior can cause the cursor to _not_ be displayed in some circumstances. This was immediately obvious with Bureaucracy: the main buffer window had focus, and when the upper window was selected and input requested, the cursor was _not_ drawn, because no input had yet occurred. Once a key was pressed, the cursor showed up.

But this is not a new problem. Current Gargoyle has the same issue. It's just not really noticeable, generally, since most games don't flip back and forth between windows while doing input on both.

Consider the following Inform program:

    Array text -> 63;
    Array parse -> 42;

    [Main;
        print "Hit a key...";
        @split_window 1;
        @set_window 1;
        @read_char 1 -> sp;
        @set_window 0;
        text->0 = 60;
        parse->0 = 10;
        print "^> ";
        read text parse;
    ];

In current Gargoyle, once window 0 is selected and `read` is called, the cursor _is not visible_, because the focus was on window 1 due to the @read_char call. When the user hit a key at @read_char, window 1 got focus. Then when window 0 was re-selected, it _did not_ get focus, because of the previously-noted reactive nature of focus selection.

Now whenever input is requested, the window on which the input is requested becomes focused. This does change behavior slightly:

    winid_t mainwin = glk_window_open(0, 0, 0, wintype_TextBuffer, 0);
    winid_t upperwin = glk_window_open(mainwin, winmethod_Above | winmethod_Fixed, 10, wintype_TextGrid, 0);

    char mainbuf[30];
    char upperbuf[30];

    glk_request_line_event(mainwin, mainbuf, sizeof mainbuf, 0);

    event_t event;
    do {
        glk_select(&event);
    } while (event.type != evtype_LineInput);

    glk_request_line_event(mainwin, mainbuf, sizeof mainbuf, 0);
    glk_request_line_event(upperwin, upperbuf, sizeof upperbuf, 0);

    while (true) {
        glk_select(&event);
    }

In the original Gargoyle code, `mainwin` retains focus. When a key is pressed, Gargoyle sees that the currently-focused window (`mainwin`) has pending input, so it maintains focus. The new Gargoyle code will forcibly set the focus window to `upperin` upon request for input on it. At this point, before any keypresses, `upperwin` becomes the focused window.

What that means is that in the old Gargoyle, after the initial line input, when there are now two simultaneous line inputs, the user will be typing in the main window. But in the new Gargoyle, the user will be typing in the upper window. Glk makes no statements one way or the other about how this ought to work, leaving it up to the implementation.