### PR TITLE
Persist flow breaks across window reflows

### DIFF
--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -933,6 +933,7 @@ struct tbline_t {
         chars.fill(' ');
     }
     int len = 0;
+    int flow_break_pos = -1;
     bool newline = false, dirty = false, repaint = false;
     std::shared_ptr<picture_t> lpic, rpic;
     glui32 lhyper = 0, rhyper = 0;


### PR DESCRIPTION
This is an attempt to fix #222.

Gargoyle currently stores the "text stream" as "lines" object, and those lines are determined using the current window dimensions and font size, etc. Additionally, it doesn't support inline images, and allows for only one inline image per such "line".

When the window is resized, and it needs to reflow the text, it extract the data from those old "lines" and creates new ones.

The current implementation of `flow_break` emulates it by sticking a bunch of newlines as raw text. When the display is reflowed, they're still treated as regular newlines.

I tried changing that to a "flow break" marking on the line, which says that at position X in the text, insert a flow break. It relies on the fact that when inline images are inserted, Gargoyle currently sticks them in their own separate line. So this flow break is always assumed to be called AFTER the inline images.

I tested it with the sample program linked in the issue - note that it inserts a flow-break before the margin image, which is ignored as it's reset in `put_picture`.

I also tested with [Everybody Dies](https://ifdb.org/viewgame?id=lyblvftb8xtlo0a1), which opens with an inline image followed by a flow break.

I also tested it with [imagetest.gblorb](https://eblong.com/zarf/glulx/imagetest.gblorb), which displays the image like it did before the change.

Tests include printing the images with various initial window sizes, and then trying to resize the window to make sure it still flows correctly.

I did NOT test flow-break commands between two text strings.

Please let me know if it breaks in other situations where Gargoyle used to work in the past.