### PR TITLE
Bocfel: Add ZTERP_GLK_NO_STDIO version of zterp_os_aux_file

### DIFF
--- a/terps/bocfel/osdep.cpp
+++ b/terps/bocfel/osdep.cpp
@@ -1003,28 +1003,6 @@ void zterp_os_set_style(const Style &style, const Color &fg, const Color &bg)
 #define have_zterp_os_set_style
 #endif
 
-// ╔══════════════════════════════════════════════════════════════════════════════╗
-// ║ ZTERP_GLK_NO_STDIO                                                           ║
-// ╚══════════════════════════════════════════════════════════════════════════════╝
-
-#elif defined(ZTERP_GLK_NO_STDIO)
-
-extern "C" {
-#include <glkstart.h>
-}
-
-std::unique_ptr<std::string> zterp_os_aux_file(const std::string &filename)
-{
-    frefid_t fref = glk_fileref_create_by_name(fileusage_Data | fileusage_BinaryMode, const_cast<char *>(filename.c_str()), 0);
-    if (fref != nullptr) {
-        auto result = std::make_unique<std::string>(glkunix_fileref_get_filename(fref));
-        glk_fileref_destroy(fref);
-        return result;
-    }
-    return nullptr;
-}
-#define have_zterp_os_aux_file
-
 #endif
 
 // ╔══════════════════════════════════════════════════════════════════════════════╗
@@ -1064,8 +1042,23 @@ std::unique_ptr<std::string> zterp_os_autosave_name()
 #endif
 
 #ifndef have_zterp_os_aux_file
-std::unique_ptr<std::string> zterp_os_aux_file(const std::string &)
+
+#ifdef ZTERP_GLK_UNIX
+extern "C" {
+#include <glkstart.h>
+}
+#endif
+
+std::unique_ptr<std::string> zterp_os_aux_file(const std::string &filename)
 {
+#if defined(ZTERP_GLK_UNIX) && defined(GLKUNIX_FILEREF_GET_FILENAME)
+    frefid_t fref = glk_fileref_create_by_name(fileusage_Data | fileusage_BinaryMode, const_cast<char *>(filename.c_str()), 0);
+    if (fref != nullptr) {
+        auto result = std::make_unique<std::string>(glkunix_fileref_get_filename(fref));
+        glk_fileref_destroy(fref);
+        return result;
+    }
+#endif
     return nullptr;
 }
 #endif


### PR DESCRIPTION
This seems to be working with @EmptySpaceRun's game that uses the Z-Machine's `@save`/`@restore` no-prompt data file feature.

My C++ is very rudimentary, but does it look okay to you?