### PR TITLE
Various MSVC fixes

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -255,18 +255,25 @@ endif()
 
 if("${SOUND}" STREQUAL "QT")
     find_package(Qt${QT_VERSION} COMPONENTS Multimedia REQUIRED CONFIG)
-    if(MSVC)  # pkg-config on Windows does not work when cross-compiling for Windows-on-ARM
+    if(MSVC AND CMAKE_HOST_WIN32)  # native MSVC build on Windows: pkg-config is unreliable, fall back to find_library/find_path
         find_library(SNDFILE sndfile REQUIRED)
         find_library(MPG123 NAMES mpg123 libmpg123 REQUIRED)
         find_library(OPENMPT NAMES openmpt libopenmpt REQUIRED)
+        find_path(SNDFILE_INCLUDE_DIR sndfile.hh REQUIRED)
+        find_path(MPG123_INCLUDE_DIR mpg123.h REQUIRED)
+        find_path(OPENMPT_INCLUDE_DIR libopenmpt/libopenmpt.hpp REQUIRED)
+        target_include_directories(garglk-common PRIVATE
+            ${SNDFILE_INCLUDE_DIR} ${MPG123_INCLUDE_DIR} ${OPENMPT_INCLUDE_DIR})
         target_link_libraries(garglk-common PRIVATE Qt${QT_VERSION}::Multimedia ${SNDFILE} ${MPG123} ${OPENMPT})
 
         find_library(FLUIDSYNTH NAMES fluidsynth libfluidsynth)
         if(FLUIDSYNTH)
+            find_path(FLUIDSYNTH_INCLUDE_DIR fluidsynth.h REQUIRED)
             target_compile_definitions(garglk-common PRIVATE GARGLK_HAS_FLUIDSYNTH)
+            target_include_directories(garglk-common PRIVATE ${FLUIDSYNTH_INCLUDE_DIR})
             target_link_libraries(garglk-common PRIVATE ${FLUIDSYNTH})
         endif()
-    else()  # regular compile (on Linux/Mac/...)
+    else()  # Linux/Mac native, or Linux/Mac cross-compiling to MSVC: use pkg-config
         find_package(PkgConfig REQUIRED)
         pkg_check_modules(SOUND REQUIRED IMPORTED_TARGET sndfile libmpg123 libopenmpt)
 

--- a/msvc.sh
+++ b/msvc.sh
@@ -78,6 +78,9 @@ make install
 # explicitly. Plugins are copied before copy_dll_deps so their own
 # imports get picked up transitively.
 copy_plugin "${qt}/plugins" "platforms/qwindows"
+copy_plugin "${qt}/plugins" "imageformats/qjpeg"
 copy_plugin "${qt}/plugins" "multimedia/windowsmediaplugin"
 
-copy_dll_deps "${sysroot}/bin" "${qt}/bin"
+# ${sysroot}/lib is searched in addition to ${sysroot}/bin because
+# locally-built DLLs land in lib/ alongside their import libs.
+copy_dll_deps "${sysroot}/bin" "${sysroot}/lib" "${qt}/bin"


### PR DESCRIPTION
Previously the libpng finder was doing heavy lifting for adding include paths that other packages relied on implicitly. When libpng became optional, those stopped working.

Three changes:

1. When cross-compiling for MSVC, use pkg-config. This is a much cleaner solution and should be used where it works, i.e. anywhere but Windows.
2. When building on MSVC, explicitly search for dependencies that are used, so that incidental overlaps aren't relied upon.
3. Copy the Qt JPEG plugin for MSVC, and broaden paths to search for DLLs in general when installing.