### PR TITLE
Fix blurry fractional scaling on Wayland

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -85,6 +85,27 @@ std::string garglk::ConfigFile::format_type() const {
     }
 }
 
+// Auto-detecting the display scale factor is not currently done
+// because Qt on Wayland reports the integer buffer scale (e.g. 2.0
+// for 125%) rather than the true fractional scale. The Wayland
+// protocol wl_output::scale is integer-only, and while
+// wp_fractional_scale_v1 provides the true fractional scale, Qt does
+// not expose it through QScreen or QWindow devicePixelRatio().
+//
+// Therefore gli_backingscalefactor remains at its default 1.0
+// on non-macOS platforms. Users on HiDPI displays can set zoom
+// manually in garglk.ini.
+//
+// Note:
+//   - QScreen::devicePixelRatio() — returns 2.0 for 1.25x scaling.
+//   - QWindow::devicePixelRatio() on a temporary window — also
+//     returns 2.0.
+//
+// To get the true scale, we would need to use the native Wayland
+// protocol (wp_fractional_scale_v1) directly, or we could try computing
+// the scale from `QScreen::logicalDotsPerInch() / 96.0` but if Qt also
+// rounds DPI to match the integer buffer scale, we'd get 192 (2.0)
+// and still be wrong.
 double gli_backingscalefactor = 1.0;
 double gli_zoom = 1.0;
 

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -82,6 +82,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -295,7 +295,21 @@ void garglk::Window::resizeEvent(QResizeEvent *event)
     int newwid = event->size().width();
     int newhgt = event->size().height();
 
-    if (newwid == gli_image_rgb.width() && newhgt == gli_image_rgb.height()) {
+    // Qt reports window sizes in **logical** pixels. The compositor then
+    // upscales the window surface by the DPR. So we size the
+    // internal buffer to **physical** pixels (`logical × dpr`), matching
+    // the actual surface resolution, to avoid blur.
+    double dpr;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    dpr = m_view->devicePixelRatio();
+#else
+    dpr = m_view->devicePixelRatioF();
+#endif
+
+    int physwid = std::round(newwid * dpr);
+    int physhgt = std::round(newhgt * dpr);
+
+    if (physwid == gli_image_rgb.width() && physhgt == gli_image_rgb.height()) {
         return;
     }
 
@@ -304,7 +318,7 @@ void garglk::Window::resizeEvent(QResizeEvent *event)
     // On startup, Qt posts a resize event as the window is created.
     // This resize occurs before the Glk program even starts, so
     // shouldn't create an arrange event.
-    gli_windows_size_change(newwid, newhgt, !first_resize);
+    gli_windows_size_change(physwid, physhgt, !first_resize);
 
     if (gli_conf_save_window_size) {
         m_settings->setValue("window/size", event->size());
@@ -364,6 +378,18 @@ void garglk::View::refresh()
 void garglk::View::paintEvent(QPaintEvent *event)
 {
     QImage image(gli_image_rgb.data(), gli_image_rgb.width(), gli_image_rgb.height(), gli_image_rgb.stride(), QImage::Format_RGB888);
+    double dpr;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    dpr = devicePixelRatio();
+#else
+    dpr = devicePixelRatioF();
+#endif
+    // The `QImage` we blit to the widget is sized in **physical**
+    // pixels (e.g. 1000×750), but the widget itself is sized in
+    // **logical** pixels (e.g. 800×600).  Setting the DPR tells Qt
+    // "this image is already at physical resolution" so it maps 1:1
+    // to the backing store.
+    image.setDevicePixelRatio(dpr);
     QPainter painter(this);
     painter.drawImage(QPoint(0, 0), image);
     event->accept();
@@ -620,12 +646,23 @@ void garglk::View::keyPressEvent(QKeyEvent *event)
 
 void garglk::View::mouseMoveEvent(QMouseEvent *event)
 {
+    // Mouse events report **logical** pixel coordinates
+    // (e.g. 400, 300), but the internal `gli_image_rgb` buffer is
+    // in **physical** pixels (e.g. 500, 375 at 1.25×) so position
+    // needs to be scaled
+    double dpr;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    dpr = devicePixelRatio();
+#else
+    dpr = devicePixelRatioF();
+#endif
+
     // hyperlinks and selection
     if (gli_copyselect) {
         setCursor(Qt::IBeamCursor);
-        gli_move_selection(event->pos().x(), event->pos().y());
+        gli_move_selection(event->pos().x() * dpr, event->pos().y() * dpr);
     } else {
-        if (gli_get_hyperlink(event->pos().x(), event->pos().y()) != 0) {
+        if (gli_get_hyperlink(event->pos().x() * dpr, event->pos().y() * dpr) != 0) {
             setCursor(Qt::PointingHandCursor);
         } else {
             unsetCursor();
@@ -637,8 +674,19 @@ void garglk::View::mouseMoveEvent(QMouseEvent *event)
 
 void garglk::View::mousePressEvent(QMouseEvent *event)
 {
+    // Mouse events report **logical** pixel coordinates
+    // (e.g. 400, 300), but the internal `gli_image_rgb` buffer is
+    // in **physical** pixels (e.g. 500, 375 at 1.25×) so position
+    // needs to be scaled
+    double dpr;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    dpr = devicePixelRatio();
+#else
+    dpr = devicePixelRatioF();
+#endif
+
     if (event->button() == Qt::LeftButton) {
-        gli_input_handle_click(event->pos().x(), event->pos().y());
+        gli_input_handle_click(event->pos().x() * dpr, event->pos().y() * dpr);
     } else if (event->button() == Qt::MiddleButton) {
         winclipreceive(QClipboard::Selection);
     }
@@ -703,6 +751,15 @@ void wininit()
     // fulfill QApplication's requirements.
     static int argc = 1;
     static char *argv[] = {const_cast<char *>("gargoyle"), nullptr};
+
+    // Qt 5 defaults to disabling high-DPI scaling unless this attribute
+    // is set. Without it, Qt 5 on a scaled display creates a 1× surface
+    // and the compositor upscales, which destroys subpixel rendering.
+    // Qt 6 enables it by default, so this is conditional.
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
     app = new QApplication(argc, argv);
     QApplication::setApplicationVersion(GARGOYLE_VERSION);
 

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -300,12 +300,7 @@ void garglk::Window::resizeEvent(QResizeEvent *event)
     // upscales the window surface by the DPR. So we size the
     // internal buffer to **physical** pixels (`logical × dpr`), matching
     // the actual surface resolution, to avoid blur.
-    double dpr;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    dpr = m_view->devicePixelRatio();
-#else
-    dpr = m_view->devicePixelRatioF();
-#endif
+    double dpr = m_view->devicePixelRatioF();
 
     int physwid = std::round(newwid * dpr);
     int physhgt = std::round(newhgt * dpr);
@@ -379,12 +374,7 @@ void garglk::View::refresh()
 void garglk::View::paintEvent(QPaintEvent *event)
 {
     QImage image(gli_image_rgb.data(), gli_image_rgb.width(), gli_image_rgb.height(), gli_image_rgb.stride(), QImage::Format_RGB888);
-    double dpr;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    dpr = devicePixelRatio();
-#else
-    dpr = devicePixelRatioF();
-#endif
+    double dpr = devicePixelRatioF();
     // The `QImage` we blit to the widget is sized in **physical**
     // pixels (e.g. 1000×750), but the widget itself is sized in
     // **logical** pixels (e.g. 800×600).  Setting the DPR tells Qt
@@ -651,12 +641,7 @@ void garglk::View::mouseMoveEvent(QMouseEvent *event)
     // (e.g. 400, 300), but the internal `gli_image_rgb` buffer is
     // in **physical** pixels (e.g. 500, 375 at 1.25×) so position
     // needs to be scaled
-    double dpr;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    dpr = devicePixelRatio();
-#else
-    dpr = devicePixelRatioF();
-#endif
+    double dpr = devicePixelRatioF();
 
     // hyperlinks and selection
     if (gli_copyselect) {
@@ -679,12 +664,7 @@ void garglk::View::mousePressEvent(QMouseEvent *event)
     // (e.g. 400, 300), but the internal `gli_image_rgb` buffer is
     // in **physical** pixels (e.g. 500, 375 at 1.25×) so position
     // needs to be scaled
-    double dpr;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    dpr = devicePixelRatio();
-#else
-    dpr = devicePixelRatioF();
-#endif
+    double dpr = devicePixelRatioF();
 
     if (event->button() == Qt::LeftButton) {
         gli_input_handle_click(event->pos().x() * dpr, event->pos().y() * dpr);

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -642,13 +642,15 @@ void garglk::View::mouseMoveEvent(QMouseEvent *event)
     // in **physical** pixels (e.g. 500, 375 at 1.25×) so position
     // needs to be scaled
     double dpr = devicePixelRatioF();
+    int x = std::round(event->pos().x() * dpr);
+    int y = std::round(event->pos().y() * dpr);
 
     // hyperlinks and selection
     if (gli_copyselect) {
         setCursor(Qt::IBeamCursor);
-        gli_move_selection(event->pos().x() * dpr, event->pos().y() * dpr);
+        gli_move_selection(x, y);
     } else {
-        if (gli_get_hyperlink(event->pos().x() * dpr, event->pos().y() * dpr) != 0) {
+        if (gli_get_hyperlink(x, y) != 0) {
             setCursor(Qt::PointingHandCursor);
         } else {
             unsetCursor();
@@ -667,7 +669,7 @@ void garglk::View::mousePressEvent(QMouseEvent *event)
     double dpr = devicePixelRatioF();
 
     if (event->button() == Qt::LeftButton) {
-        gli_input_handle_click(event->pos().x() * dpr, event->pos().y() * dpr);
+        gli_input_handle_click(std::round(event->pos().x() * dpr), std::round(event->pos().y() * dpr));
     } else if (event->button() == Qt::MiddleButton) {
         winclipreceive(QClipboard::Selection);
     }


### PR DESCRIPTION
Allows use of fractional display scaling (e.g. 1.25) on Wayland.  Only tested on QT6, not QT5.

It doesn't attempt to set the gli_backingscalefactor (see comment in code) so user will still need to set `zoom 1.25` in config file.