### PR TITLE
Fix Wayland fractional-scale first-frame buffer sizing race

### DIFF
--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -280,21 +280,35 @@ garglk::Window::Window() :
     });
 }
 
+void garglk::Window::showEvent(QShowEvent *event)
+{
+    QMainWindow::showEvent(event);
+
+    // On Wayland, the very first resizeEvent() (and thus the very first
+    // updateBufferSize() call) typically fires *before* the compositor's
+    // async wp-fractional-scale-v1 preferred_scale event has arrived, so
+    // devicePixelRatioF() is still reporting a default/rounded value at
+    // that point (confirmed while debugging this: devicePixelRatioF()
+    // reports the correct fractional value, e.g. 1.25, on every call
+    // *after* the first - it just hasn't updated yet on that very first
+    // one). That bakes a wrong physical buffer size in permanently,
+    // since later calls with the same *logical* size are otherwise a
+    // no-op. Force one more buffer-size recompute shortly after the
+    // window is first shown, by which point the true scale has reliably
+    // arrived.
+    QTimer::singleShot(50, this, [this]() {
+        updateBufferSize(size());
+    });
+}
+
 void garglk::Window::closeEvent(QCloseEvent *)
 {
     gli_exit(0);
 }
 
-void garglk::Window::resizeEvent(QResizeEvent *event)
+void garglk::Window::updateBufferSize(const QSize &logicalSize)
 {
-    static bool first_resize = true;
-
-    QMainWindow::resizeEvent(event);
-
-    m_view->resize(event->size());
-
-    int newwid = event->size().width();
-    int newhgt = event->size().height();
+    static bool first_call = true;
 
     // Qt reports window sizes in **logical** pixels. The compositor then
     // upscales the window surface by the DPR. So we size the
@@ -302,8 +316,8 @@ void garglk::Window::resizeEvent(QResizeEvent *event)
     // the actual surface resolution, to avoid blur.
     double dpr = m_view->devicePixelRatioF();
 
-    int physwid = std::round(newwid * dpr);
-    int physhgt = std::round(newhgt * dpr);
+    int physwid = std::round(logicalSize.width() * dpr);
+    int physhgt = std::round(logicalSize.height() * dpr);
 
     if (physwid == gli_image_rgb.width() && physhgt == gli_image_rgb.height()) {
         return;
@@ -314,19 +328,28 @@ void garglk::Window::resizeEvent(QResizeEvent *event)
     // On startup, Qt posts a resize event as the window is created.
     // This resize occurs before the Glk program even starts, so
     // shouldn't create an arrange event.
-    gli_windows_size_change(physwid, physhgt, !first_resize);
+    gli_windows_size_change(physwid, physhgt, !first_call);
 
     if (gli_conf_save_window_size) {
-        m_settings->setValue("window/size", event->size());
+        m_settings->setValue("window/size", logicalSize);
     }
 
     if (gli_conf_save_window_location || gli_conf_save_window_size) {
         m_settings->setValue("window/fullscreen", ::window->isFullScreen());
     }
 
-    event->accept();
+    first_call = false;
+}
 
-    first_resize = false;
+void garglk::Window::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+
+    m_view->resize(event->size());
+
+    updateBufferSize(event->size());
+
+    event->accept();
 }
 
 void garglk::Window::moveEvent(QMoveEvent *event)

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -284,6 +284,7 @@ void garglk::Window::showEvent(QShowEvent *event)
 {
     QMainWindow::showEvent(event);
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
     // On Wayland, the very first resizeEvent() (and thus the very first
     // updateBufferSize() call) typically fires *before* the compositor's
     // async wp-fractional-scale-v1 preferred_scale event has arrived, so
@@ -293,13 +294,30 @@ void garglk::Window::showEvent(QShowEvent *event)
     // *after* the first - it just hasn't updated yet on that very first
     // one). That bakes a wrong physical buffer size in permanently,
     // since later calls with the same *logical* size are otherwise a
-    // no-op. Force one more buffer-size recompute shortly after the
+    // no-op. Qt 6.6 added QEvent::DevicePixelRatioChange, delivered
+    // exactly when this happens (see event() below) - that's used in
+    // preference to this timer where available, since a fixed delay is
+    // inherently racy (the real value could in principle arrive later
+    // than 50ms on a slow/loaded compositor). This is the fallback for
+    // older Qt: force one more buffer-size recompute shortly after the
     // window is first shown, by which point the true scale has reliably
-    // arrived.
+    // arrived in practice.
     QTimer::singleShot(50, this, [this]() {
         updateBufferSize(size());
     });
+#endif
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+bool garglk::Window::event(QEvent *event)
+{
+    if (event->type() == QEvent::DevicePixelRatioChange) {
+        updateBufferSize(size());
+    }
+
+    return QMainWindow::event(event);
+}
+#endif
 
 void garglk::Window::closeEvent(QCloseEvent *)
 {

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -61,6 +61,9 @@ protected:
     void closeEvent(QCloseEvent *) override;
     void resizeEvent(QResizeEvent *) override;
     void moveEvent(QMoveEvent *) override;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    bool event(QEvent *) override;
+#endif
 
 private:
     // Resizes gli_image_rgb to the physical-pixel size for the given

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -9,6 +9,7 @@
 #include <QPaintEvent>
 #include <QResizeEvent>
 #include <QSettings>
+#include <QShowEvent>
 #include <QTimer>
 #include <QWheelEvent>
 #include <QWidget>
@@ -56,11 +57,18 @@ public:
     const QSettings *settings() { return m_settings; }
 
 protected:
+    void showEvent(QShowEvent *) override;
     void closeEvent(QCloseEvent *) override;
     void resizeEvent(QResizeEvent *) override;
     void moveEvent(QMoveEvent *) override;
 
 private:
+    // Resizes gli_image_rgb to the physical-pixel size for the given
+    // logical size at the view's *current* effective_dpr(). Shared by
+    // resizeEvent() and the delayed call in showEvent() - see the
+    // comment there for why a second call is needed.
+    void updateBufferSize(const QSize &logicalSize);
+
     View *const m_view;
     QTimer *const m_timer;
     QSettings *const m_settings;

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -67,9 +67,9 @@ protected:
 
 private:
     // Resizes gli_image_rgb to the physical-pixel size for the given
-    // logical size at the view's *current* effective_dpr(). Shared by
-    // resizeEvent() and the delayed call in showEvent() - see the
-    // comment there for why a second call is needed.
+    // logical size at the view's current devicePixelRatioF(). Shared by
+    // resizeEvent() and the extra call triggered from showEvent()/
+    // event(), see the comments there for why a second call is needed.
     void updateBufferSize(const QSize &logicalSize);
 
     View *const m_view;


### PR DESCRIPTION
Fixes the remaining first-frame issue from #995: on Wayland with a fractional output scale, `preferred_scale` arrives asynchronously and generally hasn't been processed yet when the window's first `resizeEvent()` fires, so `devicePixelRatioF()` still reports the fallback/rounded value at that point. Since later `resizeEvent()` calls at the same logical size are a no-op, the wrong physical buffer size from that first call sticks around even though `devicePixelRatioF()` itself corrects on every call after.

Two commits:
1. Extracts the buffer-sizing logic into `updateBufferSize()` and re-runs it once, shortly after the window is first shown, using a timer.
2. Per review feedback, replaces the timer with `QEvent::DevicePixelRatioChange` (Qt 6.6+) where available, since a fixed delay is inherently racy. Kept the timer as a fallback for Qt < 6.6.

Tested locally on Qt 6.11.1 (KWin 6.7.3, 125% output scale), confirmed crisp rendering on first launch with no leftover blur/blank window.

Fixes #995