### PR TITLE
Add optional gamepad/Steam Controller input support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,6 +118,22 @@ In addition, Gargoyle supports the following options:
   for SDL3 sound support, "QT", for Qt sound support, and "NONE", for no sound
   support. "SDL" is accepted as a backward-compatible alias for "SDL2".
 
+- `WITH_CONTROLLER`: If true, enable gamepad/Steam Controller input support,
+  using SDL2. Defaults to false. Can be disabled at runtime, without a
+  rebuild, via the `controller` configuration file option.
+
+    - Not currently supported together with `SOUND=SDL3`, since SDL2 and
+      SDL3 cannot safely be linked into the same process; use `SOUND=SDL2`,
+      `QT`, or `NONE` instead, or leave this option off.
+
+    - Only takes effect with `INTERFACE=QT` (the only choice on Windows and
+      Linux, and optional on Apple). With `INTERFACE=COCOA`, the SDL
+      controller subsystem still initializes, but nothing polls it, so
+      gamepad input is silently inert rather than broken. Extending this to
+      Cocoa would mean wiring a poll into its distinct, IPC-based windowing
+      setup (`sysmac.mm`) rather than a simple timer addition, and hasn't
+      been done.
+
 - `IMAGES`: Selects the backend for image loading. `SYSTEM` uses libpng and
   libjpeg; `QT` uses Qt's built-in image loaders, which drops the libpng and
   libjpeg dependencies. The default is `QT` when `INTERFACE=QT`, and `SYSTEM`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -134,6 +134,22 @@ In addition, Gargoyle supports the following options:
   for SDL3 sound support, "QT", for Qt sound support, and "NONE", for no sound
   support. "SDL" is accepted as a backward-compatible alias for "SDL2".
 
+- `WITH_CONTROLLER`: If true, enable gamepad/Steam Controller input support,
+  using SDL2. Defaults to false. Can be disabled at runtime, without a
+  rebuild, via the `controller` configuration file option.
+
+    - Not currently supported together with `SOUND=SDL3`, since SDL2 and
+      SDL3 cannot safely be linked into the same process; use `SOUND=SDL2`,
+      `QT`, or `NONE` instead, or leave this option off.
+
+    - Only takes effect with `INTERFACE=QT` (the only choice on Windows and
+      Linux, and optional on Apple). With `INTERFACE=COCOA`, the SDL
+      controller subsystem still initializes, but nothing polls it, so
+      gamepad input is silently inert rather than broken. Extending this to
+      Cocoa would mean wiring a poll into its distinct, IPC-based windowing
+      setup (`sysmac.mm`) rather than a simple timer addition, and hasn't
+      been done.
+
 - `IMAGES`: Selects the backend for image loading. `SYSTEM` uses libpng and
   libjpeg; `QT` uses Qt's built-in image loaders, which drops the libpng and
   libjpeg dependencies. The default is `QT` when `INTERFACE=QT`, and `SYSTEM`

--- a/README.md
+++ b/README.md
@@ -209,3 +209,6 @@ reads input from the first connected game controller:
 This can be turned off at runtime, without a rebuild, by setting
 `controller 0` in the configuration file. Only available with the Qt
 interface; see INSTALL.md for details.
+
+Controllers are only detected at startup; connecting one after Gargoyle
+has launched requires a restart to be picked up.

--- a/README.md
+++ b/README.md
@@ -196,3 +196,6 @@ reads input from the first connected game controller:
 This can be turned off at runtime, without a rebuild, by setting
 `controller 0` in the configuration file. Only available with the Qt
 interface; see INSTALL.md for details.
+
+Controllers are only detected at startup; connecting one after Gargoyle
+has launched requires a restart to be picked up.

--- a/README.md
+++ b/README.md
@@ -195,3 +195,17 @@ Windows and Unix, and `Option` on Mac:
 * `Ctrl`/`Option`+`Right`: Move the cursor to the next word.
 * `Ctrl`/`Option`+`Backspace`: Erase the word to the left of the cursor.
 * `Ctrl`/`Option`+`Delete`: Erase the word to the right of the cursor.
+
+## Gamepad / Steam Controller support
+
+When built with the `WITH_CONTROLLER` option (see INSTALL.md), Gargoyle
+reads input from the first connected game controller:
+
+* D-pad: Arrow keys (movement, scrollback navigation).
+* `A`: Confirm, equivalent to `Return`.
+* `B`: Cancel, equivalent to `Escape`.
+* Left shoulder / Right shoulder: Page up / Page down through scrollback.
+
+This can be turned off at runtime, without a rebuild, by setting
+`controller 0` in the configuration file. Only available with the Qt
+interface; see INSTALL.md for details.

--- a/README.md
+++ b/README.md
@@ -182,3 +182,17 @@ In addition, Gargoyle supports many readline/Emacs-style line-editor bindings:
 * `Ctrl`+`n`: Next history entry.
 * `Ctrl`+`p`: Previous history entry.
 * `Ctrl`+`u`: Erase entire line.
+
+## Gamepad / Steam Controller support
+
+When built with the `WITH_CONTROLLER` option (see INSTALL.md), Gargoyle
+reads input from the first connected game controller:
+
+* D-pad: Arrow keys (movement, scrollback navigation).
+* `A`: Confirm, equivalent to `Return`.
+* `B`: Cancel, equivalent to `Escape`.
+* Left shoulder / Right shoulder: Page up / Page down through scrollback.
+
+This can be turned off at runtime, without a rebuild, by setting
+`controller 0` in the configuration file. Only available with the Qt
+interface; see INSTALL.md for details.

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 option(WITH_LAUNCHER "Build the launcher (i.e. the gargoyle executable)" ON)
 option(BUILD_SHARED_LIBS "Build a shared libgarglk instead of a static library" ON)
 option(WITH_BUNDLED_FMT "Use Gargoyle's bundled fmt library instead of the system's fmt library" OFF)
+option(WITH_CONTROLLER "Enable gamepad/Steam Controller input support (requires SDL2)" OFF)
 
 if(UNIX AND NOT APPLE)
     option(WITH_FREEDESKTOP "Install freedesktop.org application, icon, and MIME files" ON)
@@ -327,6 +328,24 @@ elseif("${SOUND}" STREQUAL "NONE")
     target_compile_definitions(garglk-common PRIVATE GARGLK_CONFIG_NO_SOUND)
 else()
     message(FATAL_ERROR "Unknown SOUND backend \"${SOUND}\"; valid values are SDL2, SDL3, QT, or NONE (\"SDL\" is accepted as an alias for SDL2).")
+endif()
+
+if(WITH_CONTROLLER)
+    if(SOUND STREQUAL "SDL3")
+        # SDL2 and SDL3 export colliding SDL_-prefixed symbol names, so
+        # linking both into the same process is not safe.
+        message(FATAL_ERROR "WITH_CONTROLLER is not currently supported together with SOUND=SDL3, since SDL2 and SDL3 cannot safely be linked into the same process. Use SOUND=SDL2, QT, or NONE, or disable WITH_CONTROLLER.")
+    elseif(NOT SOUND STREQUAL "SDL2")
+        # SDL2 isn't already linked in (SOUND is QT or NONE); find our own copy.
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(SDL2_CONTROLLER REQUIRED IMPORTED_TARGET sdl2)
+        target_link_libraries(garglk-common PRIVATE PkgConfig::SDL2_CONTROLLER)
+    endif()
+    # When SOUND=SDL2, SDL2 is already found and linked via PkgConfig::SDL2
+    # above; reuse it instead of linking a second copy of the library.
+    target_sources(garglk-common PRIVATE ctlsdl2.cpp)
+else()
+    target_sources(garglk-common PRIVATE ctlnull.cpp)
 endif()
 
 if(IMAGES STREQUAL "SYSTEM")

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -340,6 +340,7 @@ if(WITH_CONTROLLER)
     # When SOUND=SDL2, SDL2 is already found and linked via PkgConfig::SDL2
     # above; reuse it instead of linking a second copy of the library.
     target_sources(garglk-common PRIVATE ctlsdl2.cpp)
+    target_compile_definitions(garglk-common PRIVATE GARGLK_CONFIG_CONTROLLER)
 else()
     target_sources(garglk-common PRIVATE ctlnull.cpp)
 endif()

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 option(WITH_LAUNCHER "Build the launcher (i.e. the gargoyle executable)" ON)
 option(BUILD_SHARED_LIBS "Build a shared libgarglk instead of a static library" ON)
 option(WITH_BUNDLED_FMT "Use Gargoyle's bundled fmt library instead of the system's fmt library" OFF)
+option(WITH_CONTROLLER "Enable gamepad/Steam Controller input support (requires SDL2)" OFF)
 
 if(UNIX AND NOT APPLE)
     option(WITH_FREEDESKTOP "Install freedesktop.org application, icon, and MIME files" ON)
@@ -323,6 +324,24 @@ elseif("${SOUND}" STREQUAL "NONE")
     target_compile_definitions(garglk-common PRIVATE GARGLK_CONFIG_NO_SOUND)
 else()
     message(FATAL_ERROR "Unknown SOUND backend \"${SOUND}\"; valid values are SDL2, SDL3, QT, or NONE (\"SDL\" is accepted as an alias for SDL2).")
+endif()
+
+if(WITH_CONTROLLER)
+    if(SOUND STREQUAL "SDL3")
+        # SDL2 and SDL3 export colliding SDL_-prefixed symbol names, so
+        # linking both into the same process is not safe.
+        message(FATAL_ERROR "WITH_CONTROLLER is not currently supported together with SOUND=SDL3, since SDL2 and SDL3 cannot safely be linked into the same process. Use SOUND=SDL2, QT, or NONE, or disable WITH_CONTROLLER.")
+    elseif(NOT SOUND STREQUAL "SDL2")
+        # SDL2 isn't already linked in (SOUND is QT or NONE); find our own copy.
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(SDL2_CONTROLLER REQUIRED IMPORTED_TARGET sdl2)
+        target_link_libraries(garglk-common PRIVATE PkgConfig::SDL2_CONTROLLER)
+    endif()
+    # When SOUND=SDL2, SDL2 is already found and linked via PkgConfig::SDL2
+    # above; reuse it instead of linking a second copy of the library.
+    target_sources(garglk-common PRIVATE ctlsdl2.cpp)
+else()
+    target_sources(garglk-common PRIVATE ctlnull.cpp)
 endif()
 
 if(IMAGES STREQUAL "SYSTEM")

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -344,6 +344,7 @@ if(WITH_CONTROLLER)
     # When SOUND=SDL2, SDL2 is already found and linked via PkgConfig::SDL2
     # above; reuse it instead of linking a second copy of the library.
     target_sources(garglk-common PRIVATE ctlsdl2.cpp)
+    target_compile_definitions(garglk-common PRIVATE GARGLK_CONFIG_CONTROLLER)
 else()
     target_sources(garglk-common PRIVATE ctlnull.cpp)
 endif()

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -1130,6 +1130,7 @@ void garglk_startup(int argc, char *argv[])
     gli_initialize_fonts();
     gli_initialize_windows();
     gli_initialize_sound();
+    gli_initialize_controller();
 
     winopen();
 

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -287,6 +287,7 @@ bool gli_conf_caps = false;
 
 bool gli_conf_graphics = true;
 bool gli_conf_sound = true;
+bool gli_conf_controller = true;
 bool gli_conf_speak = false;
 bool gli_conf_speak_input = false;
 std::string gli_conf_speak_language;
@@ -844,6 +845,8 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 gli_conf_graphics = asbool(arg);
             } else if (cmd == "sound") {
                 gli_conf_sound = asbool(arg);
+            } else if (cmd == "controller") {
+                gli_conf_controller = asbool(arg);
             } else if (cmd == "zbleep") {
                 std::istringstream argstream(arg);
                 std::string number, frequency, duration;

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -238,6 +238,7 @@ bool gli_conf_caps = false;
 
 bool gli_conf_graphics = true;
 bool gli_conf_sound = true;
+bool gli_conf_controller = true;
 bool gli_conf_speak = false;
 bool gli_conf_speak_input = false;
 std::string gli_conf_speak_language;
@@ -767,6 +768,8 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 gli_conf_graphics = asbool(arg);
             } else if (cmd == "sound") {
                 gli_conf_sound = asbool(arg);
+            } else if (cmd == "controller") {
+                gli_conf_controller = asbool(arg);
             } else if (cmd == "zbleep") {
                 std::istringstream argstream(arg);
                 std::string number, frequency, duration;

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -1048,6 +1048,7 @@ void garglk_startup(int argc, char *argv[])
     gli_initialize_fonts();
     gli_initialize_windows();
     gli_initialize_sound();
+    gli_initialize_controller();
 
     winopen();
 

--- a/garglk/ctlnull.cpp
+++ b/garglk/ctlnull.cpp
@@ -21,3 +21,7 @@
 void gli_initialize_controller()
 {
 }
+
+void gli_controller_poll()
+{
+}

--- a/garglk/ctlnull.cpp
+++ b/garglk/ctlnull.cpp
@@ -1,0 +1,23 @@
+// This file is part of Gargoyle.
+//
+// Gargoyle is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// Gargoyle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Gargoyle; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "garglk.h"
+
+// Built when WITH_CONTROLLER is off: gamepad input support is disabled.
+
+void gli_initialize_controller()
+{
+}

--- a/garglk/ctlnull.cpp
+++ b/garglk/ctlnull.cpp
@@ -22,6 +22,7 @@ void gli_initialize_controller()
 {
 }
 
-void gli_controller_poll()
+bool gli_controller_poll()
 {
+    return false;
 }

--- a/garglk/ctlsdl2.cpp
+++ b/garglk/ctlsdl2.cpp
@@ -20,40 +20,46 @@
 
 #include <array>
 #include <cstdlib>
-#include <iostream>
 
 #include <SDL.h>
 
 #include "glk.h"
 #include "garglk.h"
 
-// Opens the first attached game controller, if any. Button polling and
-// input dispatch are added separately; this is just subsystem
-// init/teardown.
+// Opens the first attached game controller, if any; see
+// gli_controller_poll() below for button polling and input dispatch.
 
 static SDL_GameController *gli_controller = nullptr;
 
 namespace {
 
 // The buttons gli_controller_poll() tracks for edge (press/release)
-// detection. Only the buttons the default input mapping will use are
-// tracked; this is not a general-purpose "read every button" API.
+// detection, and the Glk keycode each dispatches to
+// gli_input_handle_key() on press (see event.cpp) -- the same
+// function keyboard input already goes through, so focus tracking,
+// scrollback paging, etc. all work identically regardless of input
+// source. Dispatch is press-edge only, single-shot: holding a button
+// does not auto-repeat (matching how a physical key held down would
+// need OS-level key-repeat, which this doesn't emulate).
+//
+// SDL_CONTROLLER_BUTTON_START has no mapping yet: opening Gargoyle's
+// config overlay is an app-level Qt action, not a Glk keycode, and is
+// deferred to whenever that gets wired up.
 struct TrackedButton {
     SDL_GameControllerButton button;
-    const char *name;
+    glui32 keycode;
     bool pressed = false;
 };
 
-std::array<TrackedButton, 9> gli_tracked_buttons {{
-    { SDL_CONTROLLER_BUTTON_DPAD_UP, "dpad_up" },
-    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, "dpad_down" },
-    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, "dpad_left" },
-    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, "dpad_right" },
-    { SDL_CONTROLLER_BUTTON_A, "a" },
-    { SDL_CONTROLLER_BUTTON_B, "b" },
-    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, "left_shoulder" },
-    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, "right_shoulder" },
-    { SDL_CONTROLLER_BUTTON_START, "start" },
+std::array<TrackedButton, 8> gli_tracked_buttons {{
+    { SDL_CONTROLLER_BUTTON_DPAD_UP, keycode_Up },
+    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, keycode_Down },
+    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, keycode_Left },
+    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, keycode_Right },
+    { SDL_CONTROLLER_BUTTON_A, keycode_Return },
+    { SDL_CONTROLLER_BUTTON_B, keycode_Escape },
+    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, keycode_PageUp },
+    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, keycode_PageDown },
 }};
 
 } // namespace
@@ -102,22 +108,34 @@ void gli_initialize_controller()
     }
 }
 
-// Detects press/release edges on the tracked buttons and logs them.
-// This is a temporary diagnostic: real input dispatch (synthetic
-// QKeyEvents) replaces the logging in a follow-up change.
-void gli_controller_poll()
+// Detects press edges on the tracked buttons and dispatches the
+// mapped Glk keycode for each. gli_controller_poll() always runs on
+// the Qt main thread (it's driven by a QTimer owned by the app-wide
+// QApplication), the same thread all other input handling runs on, so
+// calling gli_input_handle_key() here is no different from it being
+// called from View::keyPressEvent() -- except that the caller (unlike
+// keyPressEvent(), which unconditionally sets sysqt.cpp's private
+// refresh_needed flag) has no access to that flag, so it can't signal
+// "something happened, repaint" itself. Returning whether any key was
+// dispatched lets the caller do that instead.
+bool gli_controller_poll()
 {
     if (gli_controller == nullptr) {
-        return;
+        return false;
     }
 
     SDL_GameControllerUpdate();
 
+    bool dispatched = false;
+
     for (auto &tracked : gli_tracked_buttons) {
         bool pressed = SDL_GameControllerGetButton(gli_controller, tracked.button) != 0;
-        if (pressed != tracked.pressed) {
-            tracked.pressed = pressed;
-            std::cerr << "controller: " << tracked.name << (pressed ? " pressed" : " released") << '\n';
+        if (pressed && !tracked.pressed) {
+            gli_input_handle_key(tracked.keycode);
+            dispatched = true;
         }
+        tracked.pressed = pressed;
     }
+
+    return dispatched;
 }

--- a/garglk/ctlsdl2.cpp
+++ b/garglk/ctlsdl2.cpp
@@ -19,7 +19,6 @@
 #endif
 
 #include <array>
-#include <cstdlib>
 
 #include <SDL.h>
 
@@ -64,16 +63,6 @@ std::array<TrackedButton, 8> gli_tracked_buttons {{
 
 } // namespace
 
-static void gli_shutdown_controller()
-{
-    if (gli_controller != nullptr) {
-        SDL_GameControllerClose(gli_controller);
-        gli_controller = nullptr;
-    }
-
-    SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
-}
-
 void gli_initialize_controller()
 {
     if (!gli_conf_controller) {
@@ -88,9 +77,10 @@ void gli_initialize_controller()
         return;
     }
 
-    if (std::atexit(gli_shutdown_controller) != 0) {
-        gli_strict_warning("controller: unable to register atexit handler");
-    }
+    // Unlike the SDL2/SDL3 sound backends (sndsdl2.cpp, sndsdl3.cpp),
+    // no SDL_QuitSubSystem()/handle-close teardown is registered here:
+    // the OS reclaims everything on process exit, and neither backend
+    // bothers with explicit cleanup either.
 
     // Button state is read directly via SDL_GameControllerGetButton()
     // in gli_controller_poll() rather than via the SDL event queue, so
@@ -99,7 +89,14 @@ void gli_initialize_controller()
     // life of the process.
     SDL_GameControllerEventState(SDL_IGNORE);
 
-    for (int i = 0; i < SDL_NumJoysticks(); i++) {
+    int num_joysticks = SDL_NumJoysticks();
+    if (num_joysticks < 0) {
+        gli_strict_warning("controller: unable to enumerate joysticks\n");
+        gli_strict_warning(SDL_GetError());
+        return;
+    }
+
+    for (int i = 0; i < num_joysticks; i++) {
         if (SDL_IsGameController(i)) {
             gli_controller = SDL_GameControllerOpen(i);
             if (gli_controller == nullptr) {

--- a/garglk/ctlsdl2.cpp
+++ b/garglk/ctlsdl2.cpp
@@ -76,6 +76,10 @@ static void gli_shutdown_controller()
 
 void gli_initialize_controller()
 {
+    if (!gli_conf_controller) {
+        return;
+    }
+
     SDL_SetMainReady();
 
     if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0) {

--- a/garglk/ctlsdl2.cpp
+++ b/garglk/ctlsdl2.cpp
@@ -1,0 +1,69 @@
+// This file is part of Gargoyle.
+//
+// Gargoyle is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// Gargoyle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Gargoyle; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifdef _WIN32
+#define SDL_MAIN_HANDLED
+#endif
+
+#include <cstdlib>
+
+#include <SDL.h>
+
+#include "glk.h"
+#include "garglk.h"
+
+// Opens the first attached game controller, if any. Button polling and
+// input dispatch are added separately; this is just subsystem
+// init/teardown.
+
+static SDL_GameController *gli_controller = nullptr;
+
+static void gli_shutdown_controller()
+{
+    if (gli_controller != nullptr) {
+        SDL_GameControllerClose(gli_controller);
+        gli_controller = nullptr;
+    }
+
+    SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+}
+
+void gli_initialize_controller()
+{
+    SDL_SetMainReady();
+
+    if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0) {
+        gli_strict_warning("controller: SDL init failed\n");
+        gli_strict_warning(SDL_GetError());
+        return;
+    }
+
+    if (std::atexit(gli_shutdown_controller) != 0) {
+        gli_strict_warning("controller: unable to register atexit handler");
+    }
+
+    for (int i = 0; i < SDL_NumJoysticks(); i++) {
+        if (SDL_IsGameController(i)) {
+            gli_controller = SDL_GameControllerOpen(i);
+            if (gli_controller == nullptr) {
+                gli_strict_warning("controller: failed to open controller\n");
+                gli_strict_warning(SDL_GetError());
+                continue;
+            }
+            break;
+        }
+    }
+}

--- a/garglk/ctlsdl2.cpp
+++ b/garglk/ctlsdl2.cpp
@@ -18,7 +18,9 @@
 #define SDL_MAIN_HANDLED
 #endif
 
+#include <array>
 #include <cstdlib>
+#include <iostream>
 
 #include <SDL.h>
 
@@ -30,6 +32,31 @@
 // init/teardown.
 
 static SDL_GameController *gli_controller = nullptr;
+
+namespace {
+
+// The buttons gli_controller_poll() tracks for edge (press/release)
+// detection. Only the buttons the default input mapping will use are
+// tracked; this is not a general-purpose "read every button" API.
+struct TrackedButton {
+    SDL_GameControllerButton button;
+    const char *name;
+    bool pressed = false;
+};
+
+std::array<TrackedButton, 9> gli_tracked_buttons {{
+    { SDL_CONTROLLER_BUTTON_DPAD_UP, "dpad_up" },
+    { SDL_CONTROLLER_BUTTON_DPAD_DOWN, "dpad_down" },
+    { SDL_CONTROLLER_BUTTON_DPAD_LEFT, "dpad_left" },
+    { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, "dpad_right" },
+    { SDL_CONTROLLER_BUTTON_A, "a" },
+    { SDL_CONTROLLER_BUTTON_B, "b" },
+    { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, "left_shoulder" },
+    { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, "right_shoulder" },
+    { SDL_CONTROLLER_BUTTON_START, "start" },
+}};
+
+} // namespace
 
 static void gli_shutdown_controller()
 {
@@ -55,6 +82,13 @@ void gli_initialize_controller()
         gli_strict_warning("controller: unable to register atexit handler");
     }
 
+    // Button state is read directly via SDL_GameControllerGetButton()
+    // in gli_controller_poll() rather than via the SDL event queue, so
+    // tell SDL not to generate queued events for this subsystem;
+    // otherwise nothing ever drains them and the queue grows for the
+    // life of the process.
+    SDL_GameControllerEventState(SDL_IGNORE);
+
     for (int i = 0; i < SDL_NumJoysticks(); i++) {
         if (SDL_IsGameController(i)) {
             gli_controller = SDL_GameControllerOpen(i);
@@ -64,6 +98,26 @@ void gli_initialize_controller()
                 continue;
             }
             break;
+        }
+    }
+}
+
+// Detects press/release edges on the tracked buttons and logs them.
+// This is a temporary diagnostic: real input dispatch (synthetic
+// QKeyEvents) replaces the logging in a follow-up change.
+void gli_controller_poll()
+{
+    if (gli_controller == nullptr) {
+        return;
+    }
+
+    SDL_GameControllerUpdate();
+
+    for (auto &tracked : gli_tracked_buttons) {
+        bool pressed = SDL_GameControllerGetButton(gli_controller, tracked.button) != 0;
+        if (pressed != tracked.pressed) {
+            tracked.pressed = pressed;
+            std::cerr << "controller: " << tracked.name << (pressed ? " pressed" : " released") << '\n';
         }
     }
 }

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -621,6 +621,7 @@ extern std::array<unsigned char, 5> gli_conf_lcd_weights;
 
 extern bool gli_conf_graphics;
 extern bool gli_conf_sound;
+extern bool gli_conf_controller;
 extern std::deque<std::string> gli_conf_soundfonts;
 
 extern bool gli_conf_fluidsynth_reverb;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1076,6 +1076,7 @@ struct window_graphics_t {
 
 extern void gli_initialize_sound();
 extern void gli_initialize_controller();
+extern void gli_controller_poll();
 extern void gli_initialize_tts();
 extern void gli_tts_speak(const glui32 *buf, std::size_t len);
 extern void gli_tts_flush();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1076,7 +1076,7 @@ struct window_graphics_t {
 
 extern void gli_initialize_sound();
 extern void gli_initialize_controller();
-extern void gli_controller_poll();
+extern bool gli_controller_poll();
 extern void gli_initialize_tts();
 extern void gli_tts_speak(const glui32 *buf, std::size_t len);
 extern void gli_tts_flush();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1041,6 +1041,7 @@ struct window_graphics_t {
 // ----------------------------------------------------------------------
 
 extern void gli_initialize_sound();
+extern void gli_initialize_controller();
 extern void gli_initialize_tts();
 extern void gli_tts_speak(const glui32 *buf, std::size_t len);
 extern void gli_tts_flush();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1042,7 +1042,7 @@ struct window_graphics_t {
 
 extern void gli_initialize_sound();
 extern void gli_initialize_controller();
-extern void gli_controller_poll();
+extern bool gli_controller_poll();
 extern void gli_initialize_tts();
 extern void gli_tts_speak(const glui32 *buf, std::size_t len);
 extern void gli_tts_flush();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -608,6 +608,7 @@ extern std::array<unsigned char, 5> gli_conf_lcd_weights;
 
 extern bool gli_conf_graphics;
 extern bool gli_conf_sound;
+extern bool gli_conf_controller;
 extern std::deque<std::string> gli_conf_soundfonts;
 
 extern bool gli_conf_fluidsynth_reverb;

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1075,6 +1075,7 @@ struct window_graphics_t {
 // ----------------------------------------------------------------------
 
 extern void gli_initialize_sound();
+extern void gli_initialize_controller();
 extern void gli_initialize_tts();
 extern void gli_tts_speak(const glui32 *buf, std::size_t len);
 extern void gli_tts_flush();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1042,6 +1042,7 @@ struct window_graphics_t {
 
 extern void gli_initialize_sound();
 extern void gli_initialize_controller();
+extern void gli_controller_poll();
 extern void gli_initialize_tts();
 extern void gli_tts_speak(const glui32 *buf, std::size_t len);
 extern void gli_tts_flush();

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -69,6 +69,7 @@ caps          0               # Force uppercase input  -- 0=off 1=on
 
 graphics      1               # enable graphics
 sound         1               # enable sound
+controller    1               # enable gamepad/Steam Controller input
 
 # Gargoyle supports MIDI files, as used by some Adrift games. Unlike other
 # supported file formats, MIDI files require external instruments, so can

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -70,6 +70,7 @@ caps          0               # Force uppercase input  -- 0=off 1=on
 
 graphics      1               # enable graphics
 sound         1               # enable sound
+controller    1               # enable gamepad/Steam Controller input
 
 # Gargoyle supports MIDI files, as used by some Adrift games. Unlike other
 # supported file formats, MIDI files require external instruments, so can

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -128,6 +128,13 @@ static bool refresh_needed = true;
 static constexpr int TICK_PERIOD_MILLIS = 10;
 static std::atomic<bool> process_events(false);
 
+// Nominal ~60Hz poll interval. Actual cadence is an upper bound, not a
+// guarantee: like Window::m_timer, this only fires when something
+// calls app->processEvents() (see gli_tick()/process_events above), so
+// it can lag behind 16ms during heavy interpretation or a long-running
+// opcode.
+static constexpr int CONTROLLER_POLL_PERIOD_MILLIS = 16;
+
 static void handle_input(const QString &input, bool from_paste)
 {
     auto fn = from_paste ? gli_input_handle_key_paste :
@@ -763,6 +770,18 @@ void wininit()
         }
     })
     .detach();
+
+#ifdef GARGLK_CONFIG_CONTROLLER
+    // Polls for gamepad/Steam Controller input. This isn't
+    // window-scoped (unlike Window::m_timer's glk-timeout handling),
+    // so it's owned here at the same app-wide lifetime as "app" itself
+    // rather than per-Window. Only created when WITH_CONTROLLER is on,
+    // so builds without it don't pay for an idle timer.
+    auto *controller_timer = new QTimer(app);
+    controller_timer->setTimerType(Qt::TimerType::PreciseTimer);
+    QObject::connect(controller_timer, &QTimer::timeout, app, gli_controller_poll);
+    controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
+#endif
 }
 
 void winopen()

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -840,35 +840,6 @@ void wininit()
         }
     })
     .detach();
-
-#ifdef GARGLK_CONFIG_CONTROLLER
-    // Polls for gamepad/Steam Controller input. This isn't
-    // window-scoped (unlike Window::m_timer's glk-timeout handling),
-    // so it's owned here at the same app-wide lifetime as "app" itself
-    // rather than per-Window. Only created when WITH_CONTROLLER is on,
-    // so builds without it don't pay for an idle timer.
-    //
-    // Only polls while a window belonging to this app has OS focus --
-    // real keyboard input never reaches keyPressEvent() when
-    // Gargoyle isn't focused (Qt simply doesn't deliver it), and
-    // gamepad input, having no such natural gate, needs an explicit
-    // one to match: otherwise a controller left connected while the
-    // user has alt-tabbed away could still inject input.
-    //
-    // gli_input_handle_key(), which gli_controller_poll() may call,
-    // has no way to signal "something happened, repaint" the way
-    // View::keyPressEvent() does (it unconditionally sets
-    // refresh_needed, a variable private to this file) -- so do that
-    // here instead, but only when a key was actually dispatched.
-    auto *controller_timer = new QTimer(app);
-    controller_timer->setTimerType(Qt::TimerType::PreciseTimer);
-    QObject::connect(controller_timer, &QTimer::timeout, app, []() {
-        if (QApplication::activeWindow() != nullptr && gli_controller_poll()) {
-            refresh_needed = true;
-        }
-    });
-    controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
-#endif
 }
 
 void winopen()
@@ -915,6 +886,41 @@ void winopen()
     } else {
         window->show();
     }
+
+#ifdef GARGLK_CONFIG_CONTROLLER
+    // Polls for gamepad/Steam Controller input. This isn't
+    // window-scoped the way Window::m_timer is (that's per-window glk
+    // timeout handling); it's owned here, once, at the same app-wide
+    // lifetime as "window" itself. Set up here rather than in
+    // wininit() specifically so gli_conf_controller (read from the
+    // config file between the two) can gate whether it's created at
+    // all -- if the user has disabled it, no timer exists, not just a
+    // no-op poll every tick.
+    //
+    // CoarseTimer, not PreciseTimer: unlike Window::m_timer, which
+    // implements glk's own timer-event API and must fire when a game
+    // asks it to, this only needs to feel responsive at a nominal
+    // ~60Hz -- there's no caller relying on exact timing, so there's
+    // no reason to pay CoarseTimer's power/wakeup-coalescing cost to
+    // avoid jitter nothing depends on.
+    if (gli_conf_controller) {
+        auto *controller_timer = new QTimer(app);
+        controller_timer->setTimerType(Qt::TimerType::CoarseTimer);
+        QObject::connect(controller_timer, &QTimer::timeout, app, []() {
+            // activeWindow() alone would stay non-null while an
+            // in-process modal dialog (a QMessageBox, a file picker)
+            // has real keyboard focus, letting gamepad input leak into
+            // the game behind it -- something a real keystroke can't
+            // do, since Qt routes it to the modal widget instead.
+            // Comparing against the game window specifically excludes
+            // that case, matching what a real key press would do.
+            if (QApplication::activeWindow() == window && gli_controller_poll()) {
+                refresh_needed = true;
+            }
+        });
+        controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
+    }
+#endif
 }
 
 void wintitle()

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -770,35 +770,6 @@ void wininit()
         }
     })
     .detach();
-
-#ifdef GARGLK_CONFIG_CONTROLLER
-    // Polls for gamepad/Steam Controller input. This isn't
-    // window-scoped (unlike Window::m_timer's glk-timeout handling),
-    // so it's owned here at the same app-wide lifetime as "app" itself
-    // rather than per-Window. Only created when WITH_CONTROLLER is on,
-    // so builds without it don't pay for an idle timer.
-    //
-    // Only polls while a window belonging to this app has OS focus --
-    // real keyboard input never reaches keyPressEvent() when
-    // Gargoyle isn't focused (Qt simply doesn't deliver it), and
-    // gamepad input, having no such natural gate, needs an explicit
-    // one to match: otherwise a controller left connected while the
-    // user has alt-tabbed away could still inject input.
-    //
-    // gli_input_handle_key(), which gli_controller_poll() may call,
-    // has no way to signal "something happened, repaint" the way
-    // View::keyPressEvent() does (it unconditionally sets
-    // refresh_needed, a variable private to this file) -- so do that
-    // here instead, but only when a key was actually dispatched.
-    auto *controller_timer = new QTimer(app);
-    controller_timer->setTimerType(Qt::TimerType::PreciseTimer);
-    QObject::connect(controller_timer, &QTimer::timeout, app, []() {
-        if (QApplication::activeWindow() != nullptr && gli_controller_poll()) {
-            refresh_needed = true;
-        }
-    });
-    controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
-#endif
 }
 
 void winopen()
@@ -841,6 +812,41 @@ void winopen()
     } else {
         window->show();
     }
+
+#ifdef GARGLK_CONFIG_CONTROLLER
+    // Polls for gamepad/Steam Controller input. This isn't
+    // window-scoped the way Window::m_timer is (that's per-window glk
+    // timeout handling); it's owned here, once, at the same app-wide
+    // lifetime as "window" itself. Set up here rather than in
+    // wininit() specifically so gli_conf_controller (read from the
+    // config file between the two) can gate whether it's created at
+    // all -- if the user has disabled it, no timer exists, not just a
+    // no-op poll every tick.
+    //
+    // CoarseTimer, not PreciseTimer: unlike Window::m_timer, which
+    // implements glk's own timer-event API and must fire when a game
+    // asks it to, this only needs to feel responsive at a nominal
+    // ~60Hz -- there's no caller relying on exact timing, so there's
+    // no reason to pay CoarseTimer's power/wakeup-coalescing cost to
+    // avoid jitter nothing depends on.
+    if (gli_conf_controller) {
+        auto *controller_timer = new QTimer(app);
+        controller_timer->setTimerType(Qt::TimerType::CoarseTimer);
+        QObject::connect(controller_timer, &QTimer::timeout, app, []() {
+            // activeWindow() alone would stay non-null while an
+            // in-process modal dialog (a QMessageBox, a file picker)
+            // has real keyboard focus, letting gamepad input leak into
+            // the game behind it -- something a real keystroke can't
+            // do, since Qt routes it to the modal widget instead.
+            // Comparing against the game window specifically excludes
+            // that case, matching what a real key press would do.
+            if (QApplication::activeWindow() == window && gli_controller_poll()) {
+                refresh_needed = true;
+            }
+        });
+        controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
+    }
+#endif
 }
 
 void wintitle()

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -777,9 +777,26 @@ void wininit()
     // so it's owned here at the same app-wide lifetime as "app" itself
     // rather than per-Window. Only created when WITH_CONTROLLER is on,
     // so builds without it don't pay for an idle timer.
+    //
+    // Only polls while a window belonging to this app has OS focus --
+    // real keyboard input never reaches keyPressEvent() when
+    // Gargoyle isn't focused (Qt simply doesn't deliver it), and
+    // gamepad input, having no such natural gate, needs an explicit
+    // one to match: otherwise a controller left connected while the
+    // user has alt-tabbed away could still inject input.
+    //
+    // gli_input_handle_key(), which gli_controller_poll() may call,
+    // has no way to signal "something happened, repaint" the way
+    // View::keyPressEvent() does (it unconditionally sets
+    // refresh_needed, a variable private to this file) -- so do that
+    // here instead, but only when a key was actually dispatched.
     auto *controller_timer = new QTimer(app);
     controller_timer->setTimerType(Qt::TimerType::PreciseTimer);
-    QObject::connect(controller_timer, &QTimer::timeout, app, gli_controller_poll);
+    QObject::connect(controller_timer, &QTimer::timeout, app, []() {
+        if (QApplication::activeWindow() != nullptr && gli_controller_poll()) {
+            refresh_needed = true;
+        }
+    });
     controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
 #endif
 }

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -847,9 +847,26 @@ void wininit()
     // so it's owned here at the same app-wide lifetime as "app" itself
     // rather than per-Window. Only created when WITH_CONTROLLER is on,
     // so builds without it don't pay for an idle timer.
+    //
+    // Only polls while a window belonging to this app has OS focus --
+    // real keyboard input never reaches keyPressEvent() when
+    // Gargoyle isn't focused (Qt simply doesn't deliver it), and
+    // gamepad input, having no such natural gate, needs an explicit
+    // one to match: otherwise a controller left connected while the
+    // user has alt-tabbed away could still inject input.
+    //
+    // gli_input_handle_key(), which gli_controller_poll() may call,
+    // has no way to signal "something happened, repaint" the way
+    // View::keyPressEvent() does (it unconditionally sets
+    // refresh_needed, a variable private to this file) -- so do that
+    // here instead, but only when a key was actually dispatched.
     auto *controller_timer = new QTimer(app);
     controller_timer->setTimerType(Qt::TimerType::PreciseTimer);
-    QObject::connect(controller_timer, &QTimer::timeout, app, gli_controller_poll);
+    QObject::connect(controller_timer, &QTimer::timeout, app, []() {
+        if (QApplication::activeWindow() != nullptr && gli_controller_poll()) {
+            refresh_needed = true;
+        }
+    });
     controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
 #endif
 }

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -128,6 +128,13 @@ static bool refresh_needed = true;
 static constexpr int TICK_PERIOD_MILLIS = 10;
 static std::atomic<bool> process_events(false);
 
+// Nominal ~60Hz poll interval. Actual cadence is an upper bound, not a
+// guarantee: like Window::m_timer, this only fires when something
+// calls app->processEvents() (see gli_tick()/process_events above), so
+// it can lag behind 16ms during heavy interpretation or a long-running
+// opcode.
+static constexpr int CONTROLLER_POLL_PERIOD_MILLIS = 16;
+
 static void handle_input(const QString &input, bool from_paste)
 {
     auto fn = from_paste ? gli_input_handle_key_paste :
@@ -833,6 +840,18 @@ void wininit()
         }
     })
     .detach();
+
+#ifdef GARGLK_CONFIG_CONTROLLER
+    // Polls for gamepad/Steam Controller input. This isn't
+    // window-scoped (unlike Window::m_timer's glk-timeout handling),
+    // so it's owned here at the same app-wide lifetime as "app" itself
+    // rather than per-Window. Only created when WITH_CONTROLLER is on,
+    // so builds without it don't pay for an idle timer.
+    auto *controller_timer = new QTimer(app);
+    controller_timer->setTimerType(Qt::TimerType::PreciseTimer);
+    QObject::connect(controller_timer, &QTimer::timeout, app, gli_controller_poll);
+    controller_timer->start(CONTROLLER_POLL_PERIOD_MILLIS);
+#endif
 }
 
 void winopen()


### PR DESCRIPTION
Adds `WITH_CONTROLLER` (CMake option, off by default), which lets Gargoyle read input from a connected game controller via SDL2 — D-pad → arrows, A → Return, B → Escape, shoulders → Page Up/Down — usable standalone or as a non-Steam game with Steam Input. Runtime-togglable via a new `controller` config option, independent of the `SOUND` backend choice.

Only wired up for the Qt interface (Windows and Linux always use it; on macOS it's opt-in and the Cocoa build stays unaffected — documented in INSTALL.md). Not currently supported together with `SOUND=SDL3` (SDL2/SDL3 can't safely link into the same process; documented and enforced at configure time).

**Testing:** Built and reviewed across every `SOUND`/`WITH_CONTROLLER` combination, and manually verified end-to-end via a Qt6 macOS build with a real controller (button dispatch, config toggle, focus gating). **Not yet verified on the actual target platform (Linux/SteamOS)** or against Steam Input's translation layer specifically — macOS testing hit environment-specific dead ends unrelated to this code (details on request). Would appreciate testing from anyone with a Deck or Linux+controller setup before merge.

Built with AI-assisted tooling (Claude Code); human-reviewed throughout, happy to adjust process if that's a concern.