### PR TITLE
Basic menu bar (… and an IPC system?!?)

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -99,7 +99,7 @@ if(INTERFACE STREQUAL "QT")
     set_property(SOURCE ${GARGLKINI_CXX} ${THEME_DARK_CXX} ${THEME_DARK_H} ${THEME_LIGHT_CXX} ${THEME_LIGHT_H} PROPERTY SKIP_AUTOMOC ON)
 
     if(NOT WITH_NATIVE_FILE_DIALOGS)
-        set_property(SOURCE sysqt.cpp launchqt.cpp APPEND PROPERTY COMPILE_DEFINITIONS GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS)
+        set_property(SOURCE sysqt.cpp launchqt.cpp menubarqt.cpp APPEND PROPERTY COMPILE_DEFINITIONS GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS)
     endif()
 endif()
 
@@ -149,7 +149,7 @@ if(INTERFACE STREQUAL "COCOA")
     target_sources(garglk-common PRIVATE sysmac.mm)
     target_compile_options(garglk-common PRIVATE "-Wno-deprecated-declarations")
 else()
-    target_sources(garglk-common PRIVATE sysqt.cpp)
+    target_sources(garglk-common PRIVATE sysqt.cpp ipc.cpp ipclientqt.cpp menubarqt.cpp)
     find_package(Threads REQUIRED)
     target_link_libraries(garglk-common PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 endif()
@@ -205,7 +205,7 @@ if(WITH_LAUNCHER)
         target_sources(gargoyle PRIVATE launchmac.mm)
         target_compile_options(gargoyle PRIVATE "-Wno-deprecated-declarations")
     else()
-        target_sources(gargoyle PRIVATE launchqt.cpp)
+        target_sources(gargoyle PRIVATE launchqt.cpp sessionqt.cpp)
 
         # For AppImage, interpreters are installed in the same directory as the
         # launcher, so don't provide GARGLK_CONFIG_INTERPRETER_DIR: in its
@@ -227,8 +227,8 @@ else()
     set(QT_VERSION "6" CACHE STRING "Specify which major Qt version to use (5 or 6)")
     option(WITH_KDE "Use KDE Frameworks (improves discovery of a text editor for config file editing)" OFF)
 
-    find_package(Qt${QT_VERSION} COMPONENTS Widgets REQUIRED CONFIG)
-    target_link_libraries(garglk-common PRIVATE Qt${QT_VERSION}::Widgets)
+    find_package(Qt${QT_VERSION} COMPONENTS Widgets Network REQUIRED CONFIG)
+    target_link_libraries(garglk-common PRIVATE Qt${QT_VERSION}::Widgets Qt${QT_VERSION}::Network)
 
     # QDBus exists on Windows, but almost nobody will be running DBus
     # there, so using QDBus would effectively just require shipping the
@@ -258,7 +258,7 @@ else()
     endif()
 
     if(WITH_LAUNCHER)
-        target_link_libraries(gargoyle PRIVATE Qt${QT_VERSION}::Widgets)
+        target_link_libraries(gargoyle PRIVATE Qt${QT_VERSION}::Widgets Qt${QT_VERSION}::Network)
     endif()
 
     target_compile_definitions(garglk-common PRIVATE GARGLK_CONFIG_TICK)

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -302,6 +302,11 @@ bool gli_conf_fluidsynth_reverb = true;
 
 bool gli_conf_fullscreen = false;
 
+bool gli_conf_menu_bar = true;
+
+bool gli_conf_ipc = true;
+std::string gli_conf_ipc_server;
+
 bool gli_wait_on_quit = true;
 
 bool gli_conf_stylehint = true;
@@ -876,6 +881,12 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 gli_conf_fluidsynth_chorus = asbool(arg);
             } else if (cmd == "fullscreen") {
                 gli_conf_fullscreen = asbool(arg);
+            } else if (cmd == "menu_bar") {
+                gli_conf_menu_bar = asbool(arg);
+            } else if (cmd == "ipc") {
+                gli_conf_ipc = asbool(arg);
+            } else if (cmd == "ipc_server") {
+                gli_conf_ipc_server = arg;
             } else if (cmd == "zoom") {
                 gli_zoom = config_atleast(parse_double(arg), 0.1);
             } else if (cmd == "scaler") {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -1235,6 +1235,8 @@ void winrepaint(int x0, int y0, int x1, int y1);
 bool windark();
 void winexit();
 void winclipstore(const std::vector<glui32> &text);
+void winclipsend();
+void winclipreceive();
 
 void fontload();
 void fontunload();

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -647,6 +647,14 @@ extern bool gli_conf_fluidsynth_chorus;
 
 extern bool gli_conf_fullscreen;
 
+// When true (default on Qt), show a File menu (Open / Recent / Settings).
+extern GARGLK_API bool gli_conf_menu_bar;
+
+// When true (default on Qt), Gargoyle runs interpreters as IPC subprocesses
+// and owns all game windows in one long-lived launcher process.
+extern GARGLK_API bool gli_conf_ipc;
+extern GARGLK_API std::string gli_conf_ipc_server;
+
 extern bool gli_wait_on_quit;
 
 extern bool gli_conf_speak;

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -70,6 +70,17 @@ caps          0               # Force uppercase input  -- 0=off 1=on
 graphics      1               # enable graphics
 sound         1               # enable sound
 
+# On Windows and Linux (Qt), show a menu bar.
+menu_bar      1
+
+# On Windows and Linux (Qt), interpreters can run as IPC subprocesses of a
+# long-lived gargoyle process that owns all game windows. This matches macOS
+# behavior and lets File → Open keep multiple games in one app instance.
+# Set to 0 to restore the older one-terp-process-per-window model.
+ipc           1
+# Optional QLocalServer name used for parent/child communication.
+# ipc_server   io.github.garglk.Gargoyle
+
 # Gargoyle supports MIDI files, as used by some Adrift games. Unlike other
 # supported file formats, MIDI files require external instruments, so can
 # require a bit more effort to get working. With the SDL2 backend, native

--- a/garglk/ipc.cpp
+++ b/garglk/ipc.cpp
@@ -1,0 +1,252 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+//
+// Gargoyle is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+
+#include "ipc.h"
+
+#include <cstring>
+
+#include "garglk.h"
+
+namespace garglk::ipc {
+namespace {
+
+constexpr int HEADER_SIZE = 8; // type + payload length
+
+}
+
+void append_u32(QByteArray &out, std::uint32_t v)
+{
+    char buf[4];
+    std::memcpy(buf, &v, 4);
+    out.append(buf, 4);
+}
+
+void append_i32(QByteArray &out, std::int32_t v)
+{
+    append_u32(out, static_cast<std::uint32_t>(v));
+}
+
+void append_f64(QByteArray &out, double v)
+{
+    char buf[8];
+    std::memcpy(buf, &v, 8);
+    out.append(buf, 8);
+}
+
+void append_string(QByteArray &out, const QString &s)
+{
+    auto utf8 = s.toUtf8();
+    append_u32(out, static_cast<std::uint32_t>(utf8.size()));
+    out.append(utf8);
+}
+
+void append_bytes(QByteArray &out, const void *data, std::size_t n)
+{
+    out.append(static_cast<const char *>(data), static_cast<int>(n));
+}
+
+bool read_u32(const QByteArray &in, int &off, std::uint32_t &v)
+{
+    if (off + 4 > in.size()) {
+        return false;
+    }
+    std::memcpy(&v, in.constData() + off, 4);
+    off += 4;
+    return true;
+}
+
+bool read_i32(const QByteArray &in, int &off, std::int32_t &v)
+{
+    std::uint32_t u = 0;
+    if (!read_u32(in, off, u)) {
+        return false;
+    }
+    v = static_cast<std::int32_t>(u);
+    return true;
+}
+
+bool read_f64(const QByteArray &in, int &off, double &v)
+{
+    if (off + 8 > in.size()) {
+        return false;
+    }
+    std::memcpy(&v, in.constData() + off, 8);
+    off += 8;
+    return true;
+}
+
+bool read_string(const QByteArray &in, int &off, QString &s)
+{
+    std::uint32_t len = 0;
+    if (!read_u32(in, off, len)) {
+        return false;
+    }
+    if (off + static_cast<int>(len) > in.size()) {
+        return false;
+    }
+    s = QString::fromUtf8(in.constData() + off, static_cast<int>(len));
+    off += static_cast<int>(len);
+    return true;
+}
+
+QByteArray encode(Msg type, const QByteArray &payload)
+{
+    QByteArray out;
+    out.reserve(HEADER_SIZE + payload.size());
+    append_u32(out, static_cast<std::uint32_t>(type));
+    append_u32(out, static_cast<std::uint32_t>(payload.size()));
+    out.append(payload);
+    return out;
+}
+
+bool try_decode(QByteArray &buffer, Message &out)
+{
+    if (buffer.size() < HEADER_SIZE) {
+        return false;
+    }
+
+    int off = 0;
+    std::uint32_t type = 0;
+    std::uint32_t len = 0;
+    if (!read_u32(buffer, off, type) || !read_u32(buffer, off, len)) {
+        return false;
+    }
+
+    if (buffer.size() < HEADER_SIZE + static_cast<int>(len)) {
+        return false;
+    }
+
+    out.type = static_cast<Msg>(type);
+    out.payload = buffer.mid(HEADER_SIZE, static_cast<int>(len));
+    buffer.remove(0, HEADER_SIZE + static_cast<int>(len));
+    return true;
+}
+
+QByteArray make_init_window(bool move, int x, int y, int width, int height,
+        bool fullscreen, unsigned char r, unsigned char g, unsigned char b,
+        std::uint32_t pid)
+{
+    QByteArray p;
+    append_u32(p, move ? 1u : 0u);
+    append_i32(p, x);
+    append_i32(p, y);
+    append_i32(p, width);
+    append_i32(p, height);
+    append_u32(p, fullscreen ? 1u : 0u);
+    append_u32(p, r);
+    append_u32(p, g);
+    append_u32(p, b);
+    append_u32(p, pid);
+    return p;
+}
+
+QByteArray make_set_title(const QString &title)
+{
+    QByteArray p;
+    append_string(p, title);
+    return p;
+}
+
+QByteArray make_set_contents(int width, int height, const unsigned char *rgb, std::size_t nbytes)
+{
+    QByteArray p;
+    append_i32(p, width);
+    append_i32(p, height);
+    append_bytes(p, rgb, nbytes);
+    return p;
+}
+
+QByteArray make_dialog(const QString &prompt, FileFilter filter, const QString &savedir)
+{
+    QByteArray p;
+    append_string(p, prompt);
+    append_u32(p, static_cast<std::uint32_t>(filter));
+    append_string(p, savedir);
+    return p;
+}
+
+QByteArray make_abort_dialog(const QString &prompt)
+{
+    QByteArray p;
+    append_string(p, prompt);
+    return p;
+}
+
+QByteArray make_set_cursor(std::uint32_t cursor)
+{
+    QByteArray p;
+    append_u32(p, cursor);
+    return p;
+}
+
+QByteArray make_event_key(std::uint32_t modifiers, std::int32_t key, const QString &text)
+{
+    QByteArray p;
+    append_u32(p, modifiers);
+    append_i32(p, key);
+    append_string(p, text);
+    return p;
+}
+
+QByteArray make_event_mouse(MouseKind kind, std::int32_t x, std::int32_t y,
+        std::int32_t wheel_delta, std::int32_t clicks)
+{
+    QByteArray p;
+    append_u32(p, static_cast<std::uint32_t>(kind));
+    append_i32(p, x);
+    append_i32(p, y);
+    append_i32(p, wheel_delta);
+    append_i32(p, clicks);
+    return p;
+}
+
+QByteArray make_event_arrange(int width, int height, double dpr)
+{
+    QByteArray p;
+    append_i32(p, width);
+    append_i32(p, height);
+    append_f64(p, dpr);
+    return p;
+}
+
+QByteArray make_dialog_result(const QString &path)
+{
+    QByteArray p;
+    append_string(p, path);
+    return p;
+}
+
+QByteArray make_fullscreen_result(bool fullscreen)
+{
+    QByteArray p;
+    append_u32(p, fullscreen ? 1u : 0u);
+    return p;
+}
+
+QByteArray make_backing_info(int width, int height, double dpr)
+{
+    return make_event_arrange(width, height, dpr);
+}
+
+QByteArray make_open_game(const QString &path)
+{
+    QByteArray p;
+    append_string(p, path);
+    return p;
+}
+
+std::string server_name_from_config()
+{
+    if (!gli_conf_ipc_server.empty()) {
+        return gli_conf_ipc_server;
+    }
+    return DEFAULT_SERVER_NAME;
+}
+
+}

--- a/garglk/ipc.h
+++ b/garglk/ipc.h
@@ -1,0 +1,102 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+//
+// Gargoyle is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+
+#ifndef GARGLK_IPC_H
+#define GARGLK_IPC_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <QByteArray>
+#include <QString>
+
+#include "garglk.h"
+
+namespace garglk::ipc {
+
+// Default QLocalServer name; overridable via garglk.ini "ipc_server".
+constexpr const char *DEFAULT_SERVER_NAME = "io.github.garglk.Gargoyle";
+
+enum class Msg : std::uint32_t {
+    // Child -> parent
+    InitWindow = 1,
+    SetTitle = 2,
+    SetContents = 3,
+    CloseWindow = 4,
+    OpenDialog = 5,
+    SaveDialog = 6,
+    AbortDialog = 7,
+    SetCursor = 8,
+    ToggleFullScreen = 9,
+    QueryFullScreen = 10,
+    RequestBacking = 11,
+
+    // Parent -> child
+    EventKey = 100,
+    EventMouse = 101,
+    EventArrange = 102,
+    EventQuit = 103,
+    DialogResult = 104,
+    FullScreenResult = 105,
+    BackingInfo = 106,
+
+    // Launcher -> existing parent (handoff)
+    OpenGame = 200,
+    HandoffAck = 201,
+};
+
+enum class MouseKind : std::uint32_t {
+    Move = 0,
+    Press = 1,
+    Release = 2,
+    Wheel = 3,
+};
+
+struct Message {
+    Msg type = Msg::InitWindow;
+    QByteArray payload;
+};
+
+QByteArray encode(Msg type, const QByteArray &payload = {});
+bool try_decode(QByteArray &buffer, Message &out);
+
+void append_u32(QByteArray &out, std::uint32_t v);
+void append_i32(QByteArray &out, std::int32_t v);
+void append_f64(QByteArray &out, double v);
+void append_string(QByteArray &out, const QString &s);
+void append_bytes(QByteArray &out, const void *data, std::size_t n);
+
+bool read_u32(const QByteArray &in, int &off, std::uint32_t &v);
+bool read_i32(const QByteArray &in, int &off, std::int32_t &v);
+bool read_f64(const QByteArray &in, int &off, double &v);
+bool read_string(const QByteArray &in, int &off, QString &s);
+
+QByteArray make_init_window(bool move, int x, int y, int width, int height,
+        bool fullscreen, unsigned char r, unsigned char g, unsigned char b,
+        std::uint32_t pid);
+QByteArray make_set_title(const QString &title);
+QByteArray make_set_contents(int width, int height, const unsigned char *rgb, std::size_t nbytes);
+QByteArray make_dialog(const QString &prompt, FileFilter filter, const QString &savedir);
+QByteArray make_abort_dialog(const QString &prompt);
+QByteArray make_set_cursor(std::uint32_t cursor);
+QByteArray make_event_key(std::uint32_t modifiers, std::int32_t key, const QString &text);
+QByteArray make_event_mouse(MouseKind kind, std::int32_t x, std::int32_t y,
+        std::int32_t wheel_delta, std::int32_t clicks = 0);
+QByteArray make_event_arrange(int width, int height, double dpr);
+QByteArray make_dialog_result(const QString &path);
+QByteArray make_fullscreen_result(bool fullscreen);
+QByteArray make_backing_info(int width, int height, double dpr);
+QByteArray make_open_game(const QString &path);
+
+std::string server_name_from_config();
+
+}
+
+#endif

--- a/garglk/ipclientqt.cpp
+++ b/garglk/ipclientqt.cpp
@@ -4,6 +4,8 @@
 
 #include "ipclientqt.h"
 
+#include <QKeyEvent>
+#include <QKeySequence>
 #include <QLocalSocket>
 #include <QtGlobal>
 
@@ -118,8 +120,28 @@ void handle_message(const ipc::Message &msg)
 
 void handle_key(std::uint32_t modifiers, std::int32_t key, const QString &text)
 {
-    Qt::KeyboardModifiers modmasked = static_cast<Qt::KeyboardModifiers>(modifiers)
+    Qt::KeyboardModifiers mods = static_cast<Qt::KeyboardModifiers>(modifiers);
+    Qt::KeyboardModifiers modmasked = mods
             & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+
+    // Match platform Cut/Copy/Paste (e.g. Ctrl+X/C/V), including synthetic
+    // EventKey messages from the session Edit menu.
+    QKeyEvent key_event(QEvent::KeyPress, key, mods, text);
+    if (key_event.matches(QKeySequence::Cut)) {
+        gli_store_input_selection();
+        winclipsend();
+        gli_delete_input_selection();
+        return;
+    }
+    if (key_event.matches(QKeySequence::Copy)) {
+        gli_store_input_selection();
+        winclipsend();
+        return;
+    }
+    if (key_event.matches(QKeySequence::Paste)) {
+        winclipreceive();
+        return;
+    }
 
     static const std::map<std::pair<Qt::KeyboardModifiers, int>, std::function<void()>> keys = {
         {{kRealCtrl, Qt::Key_A}, []{ gli_input_handle_key(keycode_Home); }},

--- a/garglk/ipclientqt.cpp
+++ b/garglk/ipclientqt.cpp
@@ -1,0 +1,379 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+
+#include "ipclientqt.h"
+
+#include <QLocalSocket>
+#include <QtGlobal>
+
+#include <atomic>
+#include <functional>
+#include <map>
+#include <optional>
+#include <utility>
+
+#ifdef _WIN32
+#include <process.h>
+#define garglk_getpid() _getpid()
+#else
+#include <unistd.h>
+#define garglk_getpid() getpid()
+#endif
+
+#include "garglk.h"
+#include "ipc.h"
+
+namespace garglk::ipc_client {
+namespace {
+
+QLocalSocket *g_socket = nullptr;
+QByteArray g_readbuf;
+bool g_active = false;
+std::atomic<bool> g_dead{false};
+bool g_fullscreen = false;
+int g_back_w = 0;
+int g_back_h = 0;
+double g_back_dpr = 1.0;
+bool g_arrange_pending = false;
+std::optional<QString> g_dialog_result;
+
+#ifdef Q_OS_MAC
+constexpr Qt::KeyboardModifier kRealCtrl = Qt::MetaModifier;
+#else
+constexpr Qt::KeyboardModifier kRealCtrl = Qt::ControlModifier;
+#endif
+
+void send_msg(ipc::Msg type, const QByteArray &payload = {})
+{
+    if (g_socket && g_socket->state() == QLocalSocket::ConnectedState) {
+        g_socket->write(ipc::encode(type, payload));
+        g_socket->flush();
+    }
+}
+
+void handle_key(std::uint32_t modifiers, std::int32_t key, const QString &text);
+void handle_mouse(ipc::MouseKind kind, std::int32_t x, std::int32_t y,
+        std::int32_t wheel_delta, std::int32_t clicks);
+
+void handle_message(const ipc::Message &msg)
+{
+    int off = 0;
+    switch (msg.type) {
+    case ipc::Msg::EventKey: {
+        std::uint32_t modifiers = 0;
+        std::int32_t key = 0;
+        QString text;
+        ipc::read_u32(msg.payload, off, modifiers);
+        ipc::read_i32(msg.payload, off, key);
+        ipc::read_string(msg.payload, off, text);
+        handle_key(modifiers, key, text);
+        break;
+    }
+    case ipc::Msg::EventMouse: {
+        std::uint32_t kind = 0;
+        std::int32_t x = 0, y = 0, wheel = 0, clicks = 0;
+        ipc::read_u32(msg.payload, off, kind);
+        ipc::read_i32(msg.payload, off, x);
+        ipc::read_i32(msg.payload, off, y);
+        ipc::read_i32(msg.payload, off, wheel);
+        ipc::read_i32(msg.payload, off, clicks);
+        handle_mouse(static_cast<ipc::MouseKind>(kind), x, y, wheel, clicks);
+        break;
+    }
+    case ipc::Msg::EventArrange:
+    case ipc::Msg::BackingInfo: {
+        std::int32_t w = 0, h = 0;
+        double dpr = 1.0;
+        ipc::read_i32(msg.payload, off, w);
+        ipc::read_i32(msg.payload, off, h);
+        ipc::read_f64(msg.payload, off, dpr);
+        if (w > 0 && h > 0 && (w != g_back_w || h != g_back_h || dpr != g_back_dpr)) {
+            g_back_w = w;
+            g_back_h = h;
+            g_back_dpr = dpr;
+            g_arrange_pending = true;
+        }
+        break;
+    }
+    case ipc::Msg::EventQuit:
+        g_dead = true;
+        break;
+    case ipc::Msg::DialogResult: {
+        QString path;
+        ipc::read_string(msg.payload, off, path);
+        g_dialog_result = path;
+        break;
+    }
+    case ipc::Msg::FullScreenResult: {
+        std::uint32_t v = 0;
+        ipc::read_u32(msg.payload, off, v);
+        g_fullscreen = v != 0;
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void handle_key(std::uint32_t modifiers, std::int32_t key, const QString &text)
+{
+    Qt::KeyboardModifiers modmasked = static_cast<Qt::KeyboardModifiers>(modifiers)
+            & (Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+
+    static const std::map<std::pair<Qt::KeyboardModifiers, int>, std::function<void()>> keys = {
+        {{kRealCtrl, Qt::Key_A}, []{ gli_input_handle_key(keycode_Home); }},
+        {{kRealCtrl, Qt::Key_B}, []{ gli_input_handle_key(keycode_Left); }},
+        {{kRealCtrl, Qt::Key_D}, []{ gli_input_handle_key(keycode_Erase); }},
+        {{kRealCtrl, Qt::Key_E}, []{ gli_input_handle_key(keycode_End); }},
+        {{kRealCtrl, Qt::Key_F}, []{ gli_input_handle_key(keycode_Right); }},
+        {{kRealCtrl, Qt::Key_H}, []{ gli_input_handle_key(keycode_Delete); }},
+        {{kRealCtrl, Qt::Key_N}, []{ gli_input_handle_key(keycode_Down); }},
+        {{kRealCtrl, Qt::Key_P}, []{ gli_input_handle_key(keycode_Up); }},
+        {{kRealCtrl, Qt::Key_U}, []{ gli_input_handle_key(keycode_Escape); }},
+#ifdef Q_OS_WIN
+        {{Qt::ControlModifier, Qt::Key_Q}, []{ gli_exit(0); }},
+#endif
+        {{Qt::ControlModifier, Qt::Key_Comma}, gli_edit_config},
+        {{Qt::ShiftModifier, Qt::Key_Backspace}, []{ gli_input_handle_key(keycode_Delete); }},
+        {{Qt::NoModifier, Qt::Key_Escape},    []{ gli_input_handle_key(keycode_Escape); }},
+        {{Qt::NoModifier, Qt::Key_Tab},       []{ gli_input_handle_key(keycode_Tab); }},
+        {{Qt::NoModifier, Qt::Key_Backspace}, []{ gli_input_handle_key(keycode_Delete); }},
+        {{Qt::NoModifier, Qt::Key_Return},    []{ gli_input_handle_key(keycode_Return); }},
+        {{Qt::NoModifier, Qt::Key_Enter},     []{ gli_input_handle_key(keycode_Return); }},
+        {{Qt::NoModifier, Qt::Key_Left},      []{ gli_input_handle_key(keycode_Left); }},
+        {{Qt::NoModifier, Qt::Key_Up},        []{ gli_input_handle_key(keycode_Up); }},
+        {{Qt::NoModifier, Qt::Key_Right},     []{ gli_input_handle_key(keycode_Right); }},
+        {{Qt::NoModifier, Qt::Key_Down},      []{ gli_input_handle_key(keycode_Down); }},
+        {{Qt::NoModifier, Qt::Key_PageUp},    []{ gli_input_handle_key(keycode_PageUp); }},
+        {{Qt::NoModifier, Qt::Key_PageDown},  []{ gli_input_handle_key(keycode_PageDown); }},
+        {{Qt::NoModifier, Qt::Key_Home},      []{ gli_input_handle_key(keycode_Home); }},
+        {{Qt::NoModifier, Qt::Key_End},       []{ gli_input_handle_key(keycode_End); }},
+        {{Qt::NoModifier, Qt::Key_Delete},    []{ gli_input_handle_key(keycode_Erase); }},
+        {{Qt::NoModifier, Qt::Key_F1},        []{ gli_input_handle_key(keycode_Func1); }},
+        {{Qt::NoModifier, Qt::Key_F2},        []{ gli_input_handle_key(keycode_Func2); }},
+        {{Qt::NoModifier, Qt::Key_F3},        []{ gli_input_handle_key(keycode_Func3); }},
+        {{Qt::NoModifier, Qt::Key_F4},        []{ gli_input_handle_key(keycode_Func4); }},
+        {{Qt::NoModifier, Qt::Key_F5},        []{ gli_input_handle_key(keycode_Func5); }},
+        {{Qt::NoModifier, Qt::Key_F6},        []{ gli_input_handle_key(keycode_Func6); }},
+        {{Qt::NoModifier, Qt::Key_F7},        []{ gli_input_handle_key(keycode_Func7); }},
+        {{Qt::NoModifier, Qt::Key_F8},        []{ gli_input_handle_key(keycode_Func8); }},
+        {{Qt::NoModifier, Qt::Key_F9},        []{ gli_input_handle_key(keycode_Func9); }},
+        {{Qt::NoModifier, Qt::Key_F10},       []{ gli_input_handle_key(keycode_Func10); }},
+        {{Qt::NoModifier, Qt::Key_F11},       []{ gli_input_handle_key(keycode_Func11); }},
+        {{Qt::NoModifier, Qt::Key_F12},       []{ gli_input_handle_key(keycode_Func12); }},
+#ifdef Q_OS_MAC
+        {{Qt::MetaModifier | Qt::ControlModifier, Qt::Key_F}, []{ toggle_fullscreen(); }},
+#else
+        {{Qt::AltModifier, Qt::Key_Return}, []{ toggle_fullscreen(); }},
+#endif
+    };
+
+    auto it = keys.find({modmasked, key});
+    if (it != keys.end()) {
+        it->second();
+        return;
+    }
+
+    for (const auto &ch : text) {
+        if (ch.isPrint() || ch == '\n' || ch == '\r' || ch == '\t') {
+            gli_input_handle_key(ch.unicode());
+        }
+    }
+}
+
+void handle_mouse(ipc::MouseKind kind, std::int32_t x, std::int32_t y,
+        std::int32_t wheel_delta, std::int32_t clicks)
+{
+    switch (kind) {
+    case ipc::MouseKind::Move:
+        if (gli_copyselect) {
+            send_msg(ipc::Msg::SetCursor, ipc::make_set_cursor(1));
+            gli_move_selection(x, y);
+        } else if (gli_get_hyperlink(x, y) != 0) {
+            send_msg(ipc::Msg::SetCursor, ipc::make_set_cursor(2));
+        } else {
+            send_msg(ipc::Msg::SetCursor, ipc::make_set_cursor(0));
+        }
+        break;
+    case ipc::MouseKind::Press:
+        gli_input_handle_click(x, y, clicks);
+        send_msg(ipc::Msg::SetCursor, ipc::make_set_cursor(0));
+        break;
+    case ipc::MouseKind::Release:
+        gli_copyselect = false;
+        send_msg(ipc::Msg::SetCursor, ipc::make_set_cursor(0));
+        break;
+    case ipc::MouseKind::Wheel:
+        if (wheel_delta > 0) {
+            gli_input_handle_key(keycode_MouseWheelUp);
+        } else if (wheel_delta < 0) {
+            gli_input_handle_key(keycode_MouseWheelDown);
+        }
+        break;
+    }
+}
+
+bool wait_for(ipc::Msg expected, int timeout_ms = 60000)
+{
+    while (g_socket && g_socket->state() == QLocalSocket::ConnectedState) {
+        ipc::Message msg;
+        while (ipc::try_decode(g_readbuf, msg)) {
+            if (msg.type == expected) {
+                handle_message(msg);
+                return true;
+            }
+            handle_message(msg);
+        }
+        if (!g_socket->waitForReadyRead(timeout_ms)) {
+            return false;
+        }
+        g_readbuf.append(g_socket->readAll());
+    }
+    return false;
+}
+
+std::string dialog_common(bool save, const QString &prompt, FileFilter filter, const QString &savedir)
+{
+    g_dialog_result.reset();
+    send_msg(save ? ipc::Msg::SaveDialog : ipc::Msg::OpenDialog,
+            ipc::make_dialog(prompt, filter, savedir));
+    if (!wait_for(ipc::Msg::DialogResult)) {
+        return {};
+    }
+#ifdef _WIN32
+    return g_dialog_result->toLocal8Bit().toStdString();
+#else
+    return g_dialog_result->toStdString();
+#endif
+}
+
+} // namespace
+
+bool connect_to_parent()
+{
+    if (!gli_conf_ipc) {
+        return false;
+    }
+
+    g_socket = new QLocalSocket;
+    g_socket->connectToServer(QString::fromStdString(ipc::server_name_from_config()));
+    if (!g_socket->waitForConnected(1000)) {
+        delete g_socket;
+        g_socket = nullptr;
+        return false;
+    }
+
+    QObject::connect(g_socket, &QLocalSocket::disconnected, []() {
+        g_dead = true;
+    });
+
+    g_active = true;
+    return true;
+}
+
+bool active()
+{
+    return g_active;
+}
+
+void init_window(bool move, int x, int y, int width, int height, bool fullscreen,
+        unsigned char r, unsigned char g, unsigned char b)
+{
+    send_msg(ipc::Msg::InitWindow,
+            ipc::make_init_window(move, x, y, width, height, fullscreen, r, g, b,
+                static_cast<std::uint32_t>(garglk_getpid())));
+    wait_for(ipc::Msg::BackingInfo, 5000);
+    if (g_arrange_pending && g_back_w > 0 && g_back_h > 0) {
+        gli_windows_size_change(g_back_w, g_back_h, false);
+        g_arrange_pending = false;
+    }
+}
+
+void set_title(const QString &title)
+{
+    send_msg(ipc::Msg::SetTitle, ipc::make_set_title(title));
+}
+
+bool set_contents(int width, int height, const unsigned char *rgb, std::size_t nbytes)
+{
+    send_msg(ipc::Msg::SetContents, ipc::make_set_contents(width, height, rgb, nbytes));
+    return true;
+}
+
+void request_close()
+{
+    send_msg(ipc::Msg::CloseWindow);
+}
+
+std::string open_dialog(const QString &prompt, FileFilter filter, const QString &savedir)
+{
+    return dialog_common(false, prompt, filter, savedir);
+}
+
+std::string save_dialog(const QString &prompt, FileFilter filter, const QString &savedir)
+{
+    return dialog_common(true, prompt, filter, savedir);
+}
+
+void abort_dialog(const QString &prompt)
+{
+    send_msg(ipc::Msg::AbortDialog, ipc::make_abort_dialog(prompt));
+}
+
+void set_cursor(std::uint32_t cursor)
+{
+    send_msg(ipc::Msg::SetCursor, ipc::make_set_cursor(cursor));
+}
+
+void toggle_fullscreen()
+{
+    send_msg(ipc::Msg::ToggleFullScreen);
+    wait_for(ipc::Msg::FullScreenResult, 2000);
+}
+
+bool is_fullscreen()
+{
+    send_msg(ipc::Msg::QueryFullScreen);
+    wait_for(ipc::Msg::FullScreenResult, 1000);
+    return g_fullscreen;
+}
+
+void poll()
+{
+    if (!g_socket) {
+        return;
+    }
+
+    if (g_socket->bytesAvailable() > 0) {
+        g_readbuf.append(g_socket->readAll());
+    }
+
+    ipc::Message msg;
+    while (ipc::try_decode(g_readbuf, msg)) {
+        handle_message(msg);
+    }
+
+    if (g_arrange_pending && g_back_w > 0 && g_back_h > 0) {
+        gli_windows_size_change(g_back_w, g_back_h, true);
+        g_arrange_pending = false;
+    }
+
+    if (g_dead) {
+        gli_exit(0);
+    }
+}
+
+bool window_dead()
+{
+    return g_dead;
+}
+
+void backing_size(int &width, int &height, double &dpr)
+{
+    width = g_back_w;
+    height = g_back_h;
+    dpr = g_back_dpr;
+}
+
+}

--- a/garglk/ipclientqt.h
+++ b/garglk/ipclientqt.h
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+
+#ifndef GARGLK_IPCLIENTQT_H
+#define GARGLK_IPCLIENTQT_H
+
+#include <cstdint>
+#include <string>
+
+#include <QString>
+
+#include "garglk.h"
+
+namespace garglk::ipc_client {
+
+// Attempt to connect to the parent session when gli_conf_ipc is set.
+// Returns true if connected (headless IPC mode).
+bool connect_to_parent();
+
+bool active();
+
+void init_window(bool move, int x, int y, int width, int height, bool fullscreen,
+        unsigned char r, unsigned char g, unsigned char b);
+
+void set_title(const QString &title);
+bool set_contents(int width, int height, const unsigned char *rgb, std::size_t nbytes);
+void request_close();
+
+std::string open_dialog(const QString &prompt, FileFilter filter, const QString &savedir);
+std::string save_dialog(const QString &prompt, FileFilter filter, const QString &savedir);
+void abort_dialog(const QString &prompt);
+
+void set_cursor(std::uint32_t cursor);
+void toggle_fullscreen();
+bool is_fullscreen();
+
+// Process inbound IPC messages (keys, mouse, arrange, quit).
+void poll();
+
+// True after parent sent EventQuit or the socket disconnected.
+bool window_dead();
+
+// Last known backing store size from parent (physical pixels).
+void backing_size(int &width, int &height, double &dpr);
+
+}
+
+#endif

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -41,6 +41,7 @@
 #include <QList>
 #include <QMessageBox>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QPushButton>
 #include <QStandardPaths>
 #include <QString>
@@ -156,6 +157,12 @@ bool garglk::winterp(const std::string &exe, const std::vector<std::string> &fla
 
     QProcess proc;
     proc.setProcessChannelMode(QProcess::ForwardedChannels);
+
+    // So interpreters can re-launch Gargoyle (File → Open / Open Recent).
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert("GARGLK_LAUNCHER", QCoreApplication::applicationFilePath());
+    proc.setProcessEnvironment(env);
+
     proc.start(argv0, args);
 
     if (!proc.waitForStarted(5000)) {

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -20,11 +20,10 @@
 // along with Gargoyle; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-#include <algorithm>
 #include <cstdlib>
 #include <iostream>
-#include <iterator>
 #include <string>
+#include <vector>
 
 #ifdef _WIN32
 #include <cstdio>
@@ -36,93 +35,25 @@
 #include <QCommandLineParser>
 #include <QDir>
 #include <QFile>
-#include <QFileDialog>
 #include <QFileInfo>
-#include <QList>
 #include <QMessageBox>
 #include <QProcess>
 #include <QProcessEnvironment>
-#include <QPushButton>
 #include <QStandardPaths>
 #include <QString>
 #include <QStringList>
-#include <QVector>
 
 #include "garglk.h"
 #include "garversion.h"
 #include "launcher.h"
+#include "menubarqt.h"
+#include "sessionqt.h"
 
 #include GARGLKINI_H
-
-static const char *AppName = "Gargoyle " GARGOYLE_VERSION;
-
-namespace {
-
-class Filter {
-public:
-    Filter(QString name, QStringList extensions) : m_name(std::move(name)), m_extensions(std::move(extensions)) {}
-
-    [[nodiscard]] QString format() const {
-        return QString("%1 Games (%2)")
-            .arg(m_name, format_extensions().join(" "));
-    }
-
-    [[nodiscard]] QStringList format_extensions() const {
-        QList<QString> mapped_extensions;
-        std::transform(m_extensions.begin(), m_extensions.end(),
-                std::back_inserter(mapped_extensions),
-                [](const QString &ext) { return QString("*.") + ext; });
-        return mapped_extensions;
-    }
-
-private:
-    QString m_name;
-    QStringList m_extensions;
-};
-
-}
 
 void garglk::winmsg(const std::string &msg)
 {
     QMessageBox::critical(nullptr, "Error", msg.c_str());
-}
-
-static QString winbrowsefile()
-{
-    const QVector<Filter> filters = {
-        Filter("Adrift", {"taf"}),
-        Filter("AdvSys", {"dat"}),
-        Filter("AGT", {"agx", "d$$"}),
-        Filter("Alan", {"acd", "a3c"}),
-        Filter("Glulx", {"ulx", "blb", "blorb", "glb", "gblorb"}),
-        Filter("Hugo", {"hex"}),
-        Filter("JACL", {"jacl", "j2"}),
-        Filter("Level 9", {"l9", "sna"}),
-        Filter("Magnetic Scrolls", {"mag"}),
-        Filter("TADS", {"gam", "t3"}),
-        Filter("Z-code", {"z1", "z2", "z3", "z4", "z5", "z6", "z7", "z8", "zlb", "zblorb"}),
-    };
-    QList<QString> mapped_filters;
-    std::transform(filters.begin(), filters.end(),
-            std::back_inserter(mapped_filters),
-            [](const Filter &filter) { return filter.format(); });
-
-    QStringList all_extensions;
-    for (const auto &filter : filters) {
-        all_extensions << filter.format_extensions();
-    }
-
-    QString filter_string = QString("All Games (%1);;All Files (*);;%2")
-        .arg(all_extensions.join(" "), mapped_filters.join(";;"));
-
-    // Hide filter details because the sheer number in "All Games" makes
-    // the dialog ridiculously wide (Qt probably should cut it off, but
-    // it doesn't, so try to compensate here).
-    QFileDialog::Options options(QFileDialog::HideNameFilterDetails);
-#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-    return QFileDialog::getOpenFileName(nullptr, AppName, "", filter_string, nullptr, options);
 }
 
 bool garglk::winterp(const std::string &exe, const std::vector<std::string> &flags, const std::string &game)
@@ -154,6 +85,15 @@ bool garglk::winterp(const std::string &exe, const std::vector<std::string> &fla
         args.push_back(QString::fromStdString(flag));
     }
     args.push_back(QString::fromStdString(game));
+
+    if (garglk::session_is_parent()) {
+        // IPC session: launch non-blocking; the parent owns windows.
+        if (!QProcess::startDetached(argv0, args)) {
+            garglk::winmsg("Could not start interpreter " + argv0.toStdString());
+            return false;
+        }
+        return true;
+    }
 
     QProcess proc;
     proc.setProcessChannelMode(QProcess::ForwardedChannels);
@@ -344,15 +284,52 @@ int main(int argc, char **argv)
     }
 #endif
 
+    // Read config early so ipc / ipc_server are available for handoff.
+    // If a story was passed on the CLI, per-game config applies too.
+    gli_read_config(argc, argv);
+
+    if (gli_conf_ipc) {
+        if (!story.isEmpty() && garglk::session_try_handoff(story)) {
+            return 0;
+        }
+
+        if (story.isEmpty()) {
+            story = garglk::browse_for_game();
+        }
+        if (story.isEmpty()) {
+            return 1;
+        }
+
+        // Re-read so per-game config from the chosen story applies.
+        // Build a synthetic argv with the story path.
+        std::string story_std = story.toStdString();
+        std::vector<char *> config_argv;
+        config_argv.push_back(argv[0]);
+        config_argv.push_back(story_std.data());
+        gli_read_config(static_cast<int>(config_argv.size()), config_argv.data());
+
+        if (!garglk::session_init_parent()) {
+            return 1;
+        }
+
+        garglk::session_set_launcher([](const std::string &game) {
+            return garglk::rungame(game);
+        });
+
+        if (!garglk::session_open_game(story)) {
+            return 1;
+        }
+
+        return garglk::session_exec();
+    }
+
     if (story.isEmpty()) {
-        story = winbrowsefile();
+        story = garglk::browse_for_game();
     }
 
     if (story.isEmpty()) {
         return 1;
     }
-
-    gli_read_config(argc, argv);
 
     // run story file
     return garglk::rungame(story.toStdString()) ? 0 : 1;

--- a/garglk/menubarqt.cpp
+++ b/garglk/menubarqt.cpp
@@ -138,7 +138,8 @@ QString browse_for_game(QWidget *parent)
 }
 
 void setup_file_menu(QMainWindow *window, QSettings *settings,
-        const std::function<void(const QString &)> &open_game)
+        const std::function<void(const QString &)> &open_game,
+        const std::function<void()> &on_exit)
 {
     auto *file_menu = window->menuBar()->addMenu("&File");
 
@@ -172,6 +173,17 @@ void setup_file_menu(QMainWindow *window, QSettings *settings,
         settings_action->setShortcuts(prefs);
     }
 
+    file_menu->addSeparator();
+
+    auto *exit_action = file_menu->addAction("E&xit", window, on_exit);
+    // QKeySequence::Quit is empty on Windows; Ctrl+Q matches the
+    // existing key binding in keyPressEvent.
+    auto quit = QKeySequence::keyBindings(QKeySequence::Quit);
+    if (quit.isEmpty()) {
+        exit_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Q));
+    } else {
+        exit_action->setShortcuts(quit);
+    }
 }
 
 }

--- a/garglk/menubarqt.cpp
+++ b/garglk/menubarqt.cpp
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+
+#include "menubarqt.h"
+
+#include <QAction>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QKeySequence>
+#include <QMenu>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QStandardPaths>
+#include <QStringList>
+#include <QVector>
+
+#include "garglk.h"
+
+namespace garglk {
+
+namespace {
+
+constexpr int MAX_RECENT_FILES = 10;
+const char *RECENT_FILES_KEY = "recent/files";
+const char *SETTINGS_ORG = "io.github.garglk";
+const char *SETTINGS_APP = "Gargoyle";
+
+// Prefer the folder of the most recently opened game; otherwise Downloads.
+QString default_browse_directory(QSettings *settings)
+{
+    auto recent = settings->value(RECENT_FILES_KEY).toStringList();
+    for (const auto &path : recent) {
+        QFileInfo info(path);
+        auto dir = info.absolutePath();
+        if (!dir.isEmpty() && QDir(dir).exists()) {
+            return dir;
+        }
+    }
+
+    return QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+}
+
+void populate_recent_menu(QMenu *recent_menu, QSettings *settings,
+        const std::function<void(const QString &)> &open_game, QWidget *parent)
+{
+    recent_menu->clear();
+
+    auto recent = settings->value(RECENT_FILES_KEY).toStringList();
+    if (recent.isEmpty()) {
+        auto *empty = recent_menu->addAction("No Recent Files");
+        empty->setEnabled(false);
+        return;
+    }
+
+    for (const auto &path : recent) {
+        auto *action = recent_menu->addAction(QFileInfo(path).fileName());
+        action->setData(path);
+        action->setToolTip(path);
+        QObject::connect(action, &QAction::triggered, parent, [parent, settings, open_game, path] {
+            if (!QFileInfo::exists(path)) {
+                QMessageBox::warning(parent, "Warning", QString("File not found:\n%1").arg(path));
+                auto recent = settings->value(RECENT_FILES_KEY).toStringList();
+                recent.removeAll(path);
+                settings->setValue(RECENT_FILES_KEY, recent);
+                return;
+            }
+            open_game(path);
+        });
+    }
+}
+
+}
+
+void note_recent_file(QSettings *settings, const QString &path)
+{
+    if (path.isEmpty()) {
+        return;
+    }
+
+    auto absolute = QFileInfo(path).absoluteFilePath();
+    auto recent = settings->value(RECENT_FILES_KEY).toStringList();
+    recent.removeAll(absolute);
+    recent.prepend(absolute);
+    while (recent.size() > MAX_RECENT_FILES) {
+        recent.removeLast();
+    }
+    settings->setValue(RECENT_FILES_KEY, recent);
+}
+
+QString browse_for_game(QWidget *parent)
+{
+    struct Filter {
+        QString name;
+        QStringList extensions;
+    };
+
+    const QVector<Filter> game_filters = {
+        {"Adrift", {"taf"}},
+        {"AdvSys", {"dat"}},
+        {"AGT", {"agx", "d$$"}},
+        {"Alan", {"acd", "a3c"}},
+        {"Glulx", {"ulx", "blb", "blorb", "glb", "gblorb"}},
+        {"Hugo", {"hex"}},
+        {"JACL", {"jacl", "j2"}},
+        {"Level 9", {"l9", "sna"}},
+        {"Magnetic Scrolls", {"mag"}},
+        {"TADS", {"gam", "t3"}},
+        {"Z-code", {"z1", "z2", "z3", "z4", "z5", "z6", "z7", "z8", "zlb", "zblorb"}},
+    };
+
+    QStringList mapped_filters;
+    QStringList all_extensions;
+    for (const auto &filter : game_filters) {
+        QStringList exts;
+        for (const auto &ext : filter.extensions) {
+            exts << QString("*.%1").arg(ext);
+        }
+        all_extensions << exts;
+        mapped_filters << QString("%1 Games (%2)").arg(filter.name, exts.join(" "));
+    }
+
+    // Hide filter details because the sheer number in "All Games" makes
+    // the dialog ridiculously wide (Qt probably should cut it off, but
+    // it doesn't, so try to compensate here).
+    QString filter_string = QString("All Games (%1);;All Files (*);;%2")
+        .arg(all_extensions.join(" "), mapped_filters.join(";;"));
+
+    QSettings settings(SETTINGS_ORG, SETTINGS_APP);
+    auto start_dir = default_browse_directory(&settings);
+
+    QFileDialog::Options options(QFileDialog::HideNameFilterDetails);
+#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+    return QFileDialog::getOpenFileName(parent, "Open", start_dir, filter_string, nullptr, options);
+}
+
+void setup_file_menu(QMainWindow *window, QSettings *settings,
+        const std::function<void(const QString &)> &open_game)
+{
+    auto *file_menu = window->menuBar()->addMenu("&File");
+
+    auto *open_action = file_menu->addAction("&Open…");
+    open_action->setShortcut(QKeySequence::Open);
+    QObject::connect(open_action, &QAction::triggered, window, [window, open_game] {
+        auto game = browse_for_game(window);
+        if (!game.isEmpty()) {
+            open_game(game);
+        }
+    });
+
+    auto *recent_menu = file_menu->addMenu("Open &Recent");
+    auto populate = [recent_menu, settings, open_game, window] {
+        populate_recent_menu(recent_menu, settings, open_game, window);
+    };
+    QObject::connect(recent_menu, &QMenu::aboutToShow, window, populate);
+    populate();
+
+    file_menu->addSeparator();
+
+    auto *settings_action = file_menu->addAction("&Settings", window, [] {
+        gli_edit_config();
+    });
+    // QKeySequence::Preferences is empty on Windows; Ctrl+, matches the
+    // existing key binding in keyPressEvent.
+    auto prefs = QKeySequence::keyBindings(QKeySequence::Preferences);
+    if (prefs.isEmpty()) {
+        settings_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Comma));
+    } else {
+        settings_action->setShortcuts(prefs);
+    }
+
+}
+
+}

--- a/garglk/menubarqt.cpp
+++ b/garglk/menubarqt.cpp
@@ -5,6 +5,7 @@
 #include "menubarqt.h"
 
 #include <QAction>
+#include <QApplication>
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -69,6 +70,18 @@ void populate_recent_menu(QMenu *recent_menu, QSettings *settings,
             open_game(path);
         });
     }
+}
+
+void show_about(QWidget *parent)
+{
+    auto version = QApplication::applicationVersion();
+    if (version.isEmpty()) {
+        version = "unknown";
+    }
+    QMessageBox::about(parent, "About Gargoyle",
+            QString("<h3>Gargoyle</h3>"
+                    "<p>Version %1</p>"
+                    "<p>An interactive fiction player</p>").arg(version));
 }
 
 }
@@ -137,9 +150,13 @@ QString browse_for_game(QWidget *parent)
     return QFileDialog::getOpenFileName(parent, "Open", start_dir, filter_string, nullptr, options);
 }
 
-void setup_file_menu(QMainWindow *window, QSettings *settings,
+void setup_menus(QMainWindow *window, QSettings *settings,
         const std::function<void(const QString &)> &open_game,
-        const std::function<void()> &on_exit)
+        const std::function<void()> &on_close,
+        const std::function<void()> &on_exit,
+        const std::function<void()> &on_cut,
+        const std::function<void()> &on_copy,
+        const std::function<void()> &on_paste)
 {
     auto *file_menu = window->menuBar()->addMenu("&File");
 
@@ -158,6 +175,11 @@ void setup_file_menu(QMainWindow *window, QSettings *settings,
     };
     QObject::connect(recent_menu, &QMenu::aboutToShow, window, populate);
     populate();
+
+    file_menu->addSeparator();
+
+    auto *close_action = file_menu->addAction("&Close", window, on_close);
+    close_action->setShortcut(QKeySequence::Close);
 
     file_menu->addSeparator();
 
@@ -184,6 +206,20 @@ void setup_file_menu(QMainWindow *window, QSettings *settings,
     } else {
         exit_action->setShortcuts(quit);
     }
+
+    auto *edit_menu = window->menuBar()->addMenu("&Edit");
+    auto *cut_action = edit_menu->addAction("Cu&t", window, on_cut);
+    cut_action->setShortcut(QKeySequence::Cut);
+    auto *copy_action = edit_menu->addAction("&Copy", window, on_copy);
+    copy_action->setShortcut(QKeySequence::Copy);
+    auto *paste_action = edit_menu->addAction("&Paste", window, on_paste);
+    paste_action->setShortcut(QKeySequence::Paste);
+
+    auto *help_menu = window->menuBar()->addMenu("&Help");
+    auto *about_action = help_menu->addAction("&About Gargoyle", window, [window] {
+        show_about(window);
+    });
+    about_action->setMenuRole(QAction::AboutRole);
 }
 
 }

--- a/garglk/menubarqt.h
+++ b/garglk/menubarqt.h
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+
+#ifndef GARGLK_MENUBARQT_H
+#define GARGLK_MENUBARQT_H
+
+#include <functional>
+
+#include <QMainWindow>
+#include <QSettings>
+#include <QString>
+#include <QWidget>
+
+#include "garglk.h"
+
+namespace garglk {
+
+// Shared File menu used by the IPC session host and the non-IPC
+// interpreter window fallback.
+GARGLK_API void note_recent_file(QSettings *settings, const QString &path);
+GARGLK_API QString browse_for_game(QWidget *parent = nullptr);
+GARGLK_API void setup_file_menu(QMainWindow *window, QSettings *settings,
+        const std::function<void(const QString &)> &open_game);
+
+}
+
+#endif

--- a/garglk/menubarqt.h
+++ b/garglk/menubarqt.h
@@ -21,7 +21,8 @@ namespace garglk {
 GARGLK_API void note_recent_file(QSettings *settings, const QString &path);
 GARGLK_API QString browse_for_game(QWidget *parent = nullptr);
 GARGLK_API void setup_file_menu(QMainWindow *window, QSettings *settings,
-        const std::function<void(const QString &)> &open_game);
+        const std::function<void(const QString &)> &open_game,
+        const std::function<void()> &on_exit);
 
 }
 

--- a/garglk/menubarqt.h
+++ b/garglk/menubarqt.h
@@ -16,13 +16,17 @@
 
 namespace garglk {
 
-// Shared File menu used by the IPC session host and the non-IPC
-// interpreter window fallback.
+// Shared menus used by the IPC session host and the non-IPC interpreter
+// window fallback.
 GARGLK_API void note_recent_file(QSettings *settings, const QString &path);
 GARGLK_API QString browse_for_game(QWidget *parent = nullptr);
-GARGLK_API void setup_file_menu(QMainWindow *window, QSettings *settings,
+GARGLK_API void setup_menus(QMainWindow *window, QSettings *settings,
         const std::function<void(const QString &)> &open_game,
-        const std::function<void()> &on_exit);
+        const std::function<void()> &on_close,
+        const std::function<void()> &on_exit,
+        const std::function<void()> &on_cut,
+        const std::function<void()> &on_copy,
+        const std::function<void()> &on_paste);
 
 }
 

--- a/garglk/sessionqt.cpp
+++ b/garglk/sessionqt.cpp
@@ -124,6 +124,7 @@ public:
     int exec();
     void note_window_closed(GameWindow *window);
     void adopt_window(std::unique_ptr<GameWindow> window);
+    void quit_all();
 
 private:
     Session();
@@ -258,7 +259,8 @@ GameWindow::GameWindow(QLocalSocket *socket, QWidget *parent) :
     m_socket->setParent(this);
     if (gli_conf_menu_bar) {
         setup_file_menu(this, m_settings,
-                [](const QString &game) { Session::instance().open_game(game); });
+                [](const QString &game) { Session::instance().open_game(game); },
+                [] { Session::instance().quit_all(); });
     } else {
         menuBar()->hide();
     }
@@ -629,6 +631,22 @@ void Session::note_window_closed(GameWindow *window)
         it->second.release();
         m_windows.erase(it);
         window->deleteLater();
+    }
+    if (m_windows.empty()) {
+        QApplication::quit();
+    }
+}
+
+void Session::quit_all()
+{
+    // Snapshot pointers: closeEvent mutates m_windows.
+    std::vector<GameWindow *> windows;
+    windows.reserve(m_windows.size());
+    for (auto &entry : m_windows) {
+        windows.push_back(entry.first);
+    }
+    for (auto *window : windows) {
+        window->close();
     }
     if (m_windows.empty()) {
         QApplication::quit();

--- a/garglk/sessionqt.cpp
+++ b/garglk/sessionqt.cpp
@@ -1,0 +1,691 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+
+#include "sessionqt.h"
+
+#include <QApplication>
+#include <QCloseEvent>
+#include <QElapsedTimer>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QImage>
+#include <QKeyEvent>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QResizeEvent>
+#include <QSettings>
+#include <QShowEvent>
+#include <QTimer>
+#include <QWheelEvent>
+#include <QWidget>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "garglk.h"
+#include "ipc.h"
+#include "menubarqt.h"
+
+namespace garglk {
+namespace session_detail {
+
+const std::unordered_map<FileFilter, std::pair<QString, QString>> dialog_filters = {
+    {FileFilter::Save, {"Saved game files (*.glksave *.sav)", "glksave"}},
+    {FileFilter::Text, {"Text files (*.txt)", "txt"}},
+    {FileFilter::Data, {"Data files (*.glkdata)", "glkdata"}},
+};
+
+class GameWindow;
+
+class GameView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit GameView(GameWindow *window);
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+
+private:
+    // Qt reports the third click as an ordinary press, so count it here.
+    int count_click(const QPoint &pos);
+
+    GameWindow *m_window;
+    QElapsedTimer m_click_timer;
+    QPoint m_click_pos;
+    int m_clicks = 0;
+};
+
+class GameWindow : public QMainWindow {
+    Q_OBJECT
+
+public:
+    explicit GameWindow(QLocalSocket *socket, QWidget *parent = nullptr);
+
+    void send(ipc::Msg type, const QByteArray &payload = {});
+    void handle_message(const ipc::Message &msg);
+    void feed_bytes(const QByteArray &bytes);
+
+    QImage &frame() { return m_frame; }
+
+public slots:
+    void consumeLeftover();
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
+
+private:
+    void send_backing_info();
+    void apply_frame(int width, int height, const QByteArray &rgb);
+    QString run_file_dialog(bool save, const QString &prompt, FileFilter filter, const QString &savedir);
+    void on_ready_read();
+
+    QLocalSocket *m_socket;
+    GameView *m_view;
+    QSettings *m_settings;
+    QImage m_frame;
+    QByteArray m_readbuf;
+    bool m_closing = false;
+};
+
+class PendingConnection;
+
+class Session : public QObject {
+    Q_OBJECT
+
+public:
+    static Session &instance();
+
+    bool is_parent() const { return m_parent; }
+    bool try_handoff(const QString &game);
+    bool init_parent();
+    void set_launcher(LaunchGameFn fn);
+    bool open_game(const QString &game);
+    int exec();
+    void note_window_closed(GameWindow *window);
+    void adopt_window(std::unique_ptr<GameWindow> window);
+
+private:
+    Session();
+    void on_new_connection();
+
+    QLocalServer *m_server = nullptr;
+    bool m_parent = false;
+    LaunchGameFn m_launch;
+    QSettings m_settings;
+    std::unordered_map<GameWindow *, std::unique_ptr<GameWindow>> m_windows;
+    std::vector<PendingConnection *> m_pending;
+
+    friend class PendingConnection;
+    friend class GameWindow;
+};
+
+class PendingConnection : public QObject {
+    Q_OBJECT
+
+public:
+    PendingConnection(QLocalSocket *socket, Session *session);
+
+signals:
+    void finished();
+
+private:
+    void on_ready_read();
+
+    QLocalSocket *m_socket;
+    Session *m_session;
+    QByteArray m_buf;
+};
+
+GameView::GameView(GameWindow *window) : QWidget(window), m_window(window)
+{
+    setFocusPolicy(Qt::StrongFocus);
+    setMouseTracking(true);
+    setAttribute(Qt::WA_InputMethodEnabled, true);
+}
+
+void GameView::paintEvent(QPaintEvent *)
+{
+    QPainter painter(this);
+    if (!m_window->frame().isNull()) {
+        QImage image = m_window->frame();
+        image.setDevicePixelRatio(devicePixelRatioF());
+        painter.drawImage(QPoint(0, 0), image);
+    } else {
+        painter.fillRect(rect(), QColor(0, 0, 0));
+    }
+}
+
+void GameView::keyPressEvent(QKeyEvent *event)
+{
+    m_window->send(ipc::Msg::EventKey,
+            ipc::make_event_key(
+                static_cast<std::uint32_t>(event->modifiers()),
+                static_cast<std::int32_t>(event->key()),
+                event->text()));
+    event->accept();
+}
+
+void GameView::mouseMoveEvent(QMouseEvent *event)
+{
+    double dpr = devicePixelRatioF();
+    int x = std::round(event->pos().x() * dpr);
+    int y = std::round(event->pos().y() * dpr);
+    m_window->send(ipc::Msg::EventMouse, ipc::make_event_mouse(ipc::MouseKind::Move, x, y, 0));
+    event->accept();
+}
+
+int GameView::count_click(const QPoint &pos)
+{
+    if (m_click_timer.isValid()
+            && !m_click_timer.hasExpired(QApplication::doubleClickInterval())
+            && (pos - m_click_pos).manhattanLength() <= QApplication::startDragDistance()) {
+        m_clicks = std::min(m_clicks + 1, 3);
+    } else {
+        m_clicks = 1;
+    }
+
+    m_click_timer.restart();
+    m_click_pos = pos;
+
+    return m_clicks;
+}
+
+void GameView::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton) {
+        return;
+    }
+    double dpr = devicePixelRatioF();
+    int x = std::round(event->pos().x() * dpr);
+    int y = std::round(event->pos().y() * dpr);
+    m_window->send(ipc::Msg::EventMouse,
+            ipc::make_event_mouse(ipc::MouseKind::Press, x, y, 0, count_click(event->pos())));
+    event->accept();
+}
+
+void GameView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    mousePressEvent(event);
+}
+
+void GameView::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton) {
+        return;
+    }
+    double dpr = devicePixelRatioF();
+    int x = std::round(event->pos().x() * dpr);
+    int y = std::round(event->pos().y() * dpr);
+    m_window->send(ipc::Msg::EventMouse, ipc::make_event_mouse(ipc::MouseKind::Release, x, y, 0));
+    event->accept();
+}
+
+void GameView::wheelEvent(QWheelEvent *event)
+{
+    m_window->send(ipc::Msg::EventMouse,
+            ipc::make_event_mouse(ipc::MouseKind::Wheel, 0, 0, event->angleDelta().y()));
+    event->accept();
+}
+
+GameWindow::GameWindow(QLocalSocket *socket, QWidget *parent) :
+    QMainWindow(parent),
+    m_socket(socket),
+    m_view(new GameView(this)),
+    m_settings(new QSettings("io.github.garglk", "Gargoyle", this))
+{
+    setCentralWidget(m_view);
+    m_socket->setParent(this);
+    if (gli_conf_menu_bar) {
+        setup_file_menu(this, m_settings,
+                [](const QString &game) { Session::instance().open_game(game); });
+    } else {
+        menuBar()->hide();
+    }
+
+    connect(m_socket, &QLocalSocket::readyRead, this, &GameWindow::on_ready_read);
+    connect(m_socket, &QLocalSocket::disconnected, this, [this]() {
+        if (!m_closing) {
+            close();
+        }
+    });
+}
+
+void GameWindow::consumeLeftover()
+{
+    auto leftover = m_socket->property("garglk_leftover").toByteArray();
+    m_socket->setProperty("garglk_leftover", QVariant());
+    feed_bytes(leftover);
+}
+
+void GameWindow::feed_bytes(const QByteArray &bytes)
+{
+    if (bytes.isEmpty()) {
+        return;
+    }
+    m_readbuf.append(bytes);
+    ipc::Message msg;
+    while (ipc::try_decode(m_readbuf, msg)) {
+        handle_message(msg);
+    }
+}
+
+void GameWindow::on_ready_read()
+{
+    feed_bytes(m_socket->readAll());
+}
+
+void GameWindow::send(ipc::Msg type, const QByteArray &payload)
+{
+    if (m_socket && m_socket->state() == QLocalSocket::ConnectedState) {
+        m_socket->write(ipc::encode(type, payload));
+    }
+}
+
+void GameWindow::send_backing_info()
+{
+    double dpr = m_view->devicePixelRatioF();
+    int width = std::round(m_view->width() * dpr);
+    int height = std::round(m_view->height() * dpr);
+    send(ipc::Msg::BackingInfo, ipc::make_backing_info(width, height, dpr));
+    send(ipc::Msg::EventArrange, ipc::make_event_arrange(width, height, dpr));
+}
+
+void GameWindow::apply_frame(int width, int height, const QByteArray &rgb)
+{
+    if (width <= 0 || height <= 0 || rgb.size() < width * height * 3) {
+        return;
+    }
+
+    m_frame = QImage(width, height, QImage::Format_RGB888);
+    std::memcpy(m_frame.bits(), rgb.constData(), static_cast<std::size_t>(width * height * 3));
+    // QImage may require bytesPerLine alignment; copy line-by-line if needed.
+    if (m_frame.bytesPerLine() != width * 3) {
+        for (int y = 0; y < height; y++) {
+            std::memcpy(m_frame.scanLine(y), rgb.constData() + y * width * 3,
+                    static_cast<std::size_t>(width * 3));
+        }
+    }
+    m_view->update();
+}
+
+QString GameWindow::run_file_dialog(bool save, const QString &prompt, FileFilter filter, const QString &savedir)
+{
+    QFileDialog::Options options;
+#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+
+    QString dir = savedir;
+    auto it = dialog_filters.find(filter);
+    QString filterstring = it != dialog_filters.end() ? it->second.first : "All files (*)";
+
+    if (save) {
+        if (dir.isEmpty()) {
+            dir = ".";
+        }
+        if (it != dialog_filters.end()) {
+            dir += QString("/Untitled.%1").arg(it->second.second);
+        }
+        return QFileDialog::getSaveFileName(this, prompt, dir, filterstring, nullptr, options);
+    }
+
+    QString full = QString("%1;;All files (*)").arg(filterstring);
+    return QFileDialog::getOpenFileName(this, prompt, dir, full, nullptr, options);
+}
+
+void GameWindow::handle_message(const ipc::Message &msg)
+{
+    int off = 0;
+
+    switch (msg.type) {
+    case ipc::Msg::InitWindow: {
+        std::uint32_t do_move = 0, fullscreen = 0, r = 0, g = 0, b = 0, pid = 0;
+        std::int32_t x = 0, y = 0, width = 0, height = 0;
+        ipc::read_u32(msg.payload, off, do_move);
+        ipc::read_i32(msg.payload, off, x);
+        ipc::read_i32(msg.payload, off, y);
+        ipc::read_i32(msg.payload, off, width);
+        ipc::read_i32(msg.payload, off, height);
+        ipc::read_u32(msg.payload, off, fullscreen);
+        ipc::read_u32(msg.payload, off, r);
+        ipc::read_u32(msg.payload, off, g);
+        ipc::read_u32(msg.payload, off, b);
+        ipc::read_u32(msg.payload, off, pid);
+        Q_UNUSED(pid);
+
+        setMinimumSize(40, 40);
+        int menu_h = gli_conf_menu_bar ? menuBar()->sizeHint().height() : 0;
+        resize(width, height + menu_h);
+        if (do_move) {
+            QWidget::move(x, y);
+        }
+
+        QPalette pal = palette();
+        pal.setColor(QPalette::Window, QColor(static_cast<int>(r), static_cast<int>(g), static_cast<int>(b)));
+        setPalette(pal);
+
+        if (fullscreen) {
+            showFullScreen();
+        } else {
+            show();
+        }
+        send_backing_info();
+        break;
+    }
+
+    case ipc::Msg::SetTitle: {
+        QString title;
+        if (ipc::read_string(msg.payload, off, title)) {
+            setWindowTitle(title);
+        }
+        break;
+    }
+
+    case ipc::Msg::SetContents: {
+        std::int32_t width = 0, height = 0;
+        ipc::read_i32(msg.payload, off, width);
+        ipc::read_i32(msg.payload, off, height);
+        apply_frame(width, height, msg.payload.mid(off));
+        break;
+    }
+
+    case ipc::Msg::CloseWindow:
+        close();
+        break;
+
+    case ipc::Msg::OpenDialog:
+    case ipc::Msg::SaveDialog: {
+        QString prompt, savedir;
+        std::uint32_t filter_u = 0;
+        ipc::read_string(msg.payload, off, prompt);
+        ipc::read_u32(msg.payload, off, filter_u);
+        ipc::read_string(msg.payload, off, savedir);
+        auto path = run_file_dialog(msg.type == ipc::Msg::SaveDialog, prompt,
+                static_cast<FileFilter>(filter_u), savedir);
+        send(ipc::Msg::DialogResult, ipc::make_dialog_result(path));
+        break;
+    }
+
+    case ipc::Msg::AbortDialog: {
+        QString prompt;
+        ipc::read_string(msg.payload, off, prompt);
+        QMessageBox::critical(this, "Error", prompt);
+        break;
+    }
+
+    case ipc::Msg::SetCursor: {
+        std::uint32_t cursor = 0;
+        ipc::read_u32(msg.payload, off, cursor);
+        if (cursor == 1) {
+            m_view->setCursor(Qt::IBeamCursor);
+        } else if (cursor == 2) {
+            m_view->setCursor(Qt::PointingHandCursor);
+        } else {
+            m_view->unsetCursor();
+        }
+        break;
+    }
+
+    case ipc::Msg::ToggleFullScreen:
+        if (isFullScreen()) {
+            showNormal();
+        } else {
+            showFullScreen();
+        }
+        send(ipc::Msg::FullScreenResult, ipc::make_fullscreen_result(isFullScreen()));
+        break;
+
+    case ipc::Msg::QueryFullScreen:
+        send(ipc::Msg::FullScreenResult, ipc::make_fullscreen_result(isFullScreen()));
+        break;
+
+    case ipc::Msg::RequestBacking:
+        send_backing_info();
+        break;
+
+    default:
+        break;
+    }
+}
+
+void GameWindow::closeEvent(QCloseEvent *event)
+{
+    m_closing = true;
+    send(ipc::Msg::EventQuit);
+    if (m_socket) {
+        m_socket->disconnectFromServer();
+    }
+    Session::instance().note_window_closed(this);
+    event->accept();
+    // Owned by Session's unique_ptr map; release and deleteLater to avoid
+    // destroying this object while closeEvent is still on the stack.
+}
+
+void GameWindow::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+    send_backing_info();
+}
+
+void GameWindow::showEvent(QShowEvent *event)
+{
+    QMainWindow::showEvent(event);
+    QTimer::singleShot(0, this, [this]() { send_backing_info(); });
+}
+
+PendingConnection::PendingConnection(QLocalSocket *socket, Session *session) :
+    QObject(session),
+    m_socket(socket),
+    m_session(session)
+{
+    m_socket->setParent(this);
+    connect(m_socket, &QLocalSocket::readyRead, this, &PendingConnection::on_ready_read);
+    connect(m_socket, &QLocalSocket::disconnected, this, &PendingConnection::finished);
+}
+
+void PendingConnection::on_ready_read()
+{
+    m_buf.append(m_socket->readAll());
+    ipc::Message msg;
+    while (ipc::try_decode(m_buf, msg)) {
+        if (msg.type == ipc::Msg::OpenGame) {
+            int off = 0;
+            QString path;
+            if (ipc::read_string(msg.payload, off, path)) {
+                m_socket->write(ipc::encode(ipc::Msg::HandoffAck));
+                m_socket->flush();
+                m_session->open_game(path);
+            }
+            emit finished();
+            return;
+        }
+
+        if (msg.type == ipc::Msg::InitWindow) {
+            m_socket->setParent(nullptr);
+            disconnect(m_socket, nullptr, this, nullptr);
+
+            auto window = std::make_unique<GameWindow>(m_socket);
+            auto *raw = window.get();
+            if (!m_buf.isEmpty()) {
+                m_socket->setProperty("garglk_leftover", m_buf);
+                m_buf.clear();
+            }
+            m_session->adopt_window(std::move(window));
+            raw->handle_message(msg);
+            QMetaObject::invokeMethod(raw, "consumeLeftover", Qt::QueuedConnection);
+            emit finished();
+            return;
+        }
+    }
+}
+
+Session &Session::instance()
+{
+    static Session session;
+    return session;
+}
+
+Session::Session() : m_settings("io.github.garglk", "Gargoyle")
+{
+}
+
+bool Session::try_handoff(const QString &game)
+{
+    if (!gli_conf_ipc || game.isEmpty()) {
+        return false;
+    }
+
+    QLocalSocket sock;
+    sock.connectToServer(QString::fromStdString(ipc::server_name_from_config()));
+    if (!sock.waitForConnected(500)) {
+        return false;
+    }
+
+    sock.write(ipc::encode(ipc::Msg::OpenGame, ipc::make_open_game(game)));
+    sock.flush();
+
+    if (!sock.waitForReadyRead(2000)) {
+        return false;
+    }
+
+    QByteArray buf = sock.readAll();
+    ipc::Message reply;
+    return ipc::try_decode(buf, reply) && reply.type == ipc::Msg::HandoffAck;
+}
+
+bool Session::init_parent()
+{
+    if (!gli_conf_ipc) {
+        return false;
+    }
+
+    m_server = new QLocalServer(this);
+    auto name = QString::fromStdString(ipc::server_name_from_config());
+    QLocalServer::removeServer(name);
+    if (!m_server->listen(name)) {
+        QMessageBox::critical(nullptr, "Error",
+                QString("Unable to start Gargoyle IPC server:\n%1").arg(m_server->errorString()));
+        return false;
+    }
+
+    connect(m_server, &QLocalServer::newConnection, this, &Session::on_new_connection);
+    m_parent = true;
+    return true;
+}
+
+void Session::set_launcher(LaunchGameFn fn)
+{
+    m_launch = std::move(fn);
+}
+
+bool Session::open_game(const QString &game)
+{
+    if (game.isEmpty() || !m_launch) {
+        return false;
+    }
+
+    note_recent_file(&m_settings, game);
+    return m_launch(game.toStdString());
+}
+
+int Session::exec()
+{
+    if (m_windows.empty()) {
+        QTimer::singleShot(30000, this, [this]() {
+            if (m_windows.empty()) {
+                QApplication::quit();
+            }
+        });
+    }
+
+    return QApplication::exec();
+}
+
+void Session::note_window_closed(GameWindow *window)
+{
+    auto it = m_windows.find(window);
+    if (it != m_windows.end()) {
+        it->second.release();
+        m_windows.erase(it);
+        window->deleteLater();
+    }
+    if (m_windows.empty()) {
+        QApplication::quit();
+    }
+}
+
+void Session::adopt_window(std::unique_ptr<GameWindow> window)
+{
+    auto *raw = window.get();
+    m_windows.emplace(raw, std::move(window));
+}
+
+void Session::on_new_connection()
+{
+    while (m_server->hasPendingConnections()) {
+        auto *socket = m_server->nextPendingConnection();
+        auto *pending = new PendingConnection(socket, this);
+        m_pending.push_back(pending);
+        connect(pending, &PendingConnection::finished, this, [this, pending]() {
+            m_pending.erase(std::remove(m_pending.begin(), m_pending.end(), pending), m_pending.end());
+            pending->deleteLater();
+        });
+    }
+}
+
+} // namespace session_detail
+
+bool session_is_parent()
+{
+    return session_detail::Session::instance().is_parent();
+}
+
+bool session_try_handoff(const QString &game)
+{
+    return session_detail::Session::instance().try_handoff(game);
+}
+
+bool session_init_parent()
+{
+    return session_detail::Session::instance().init_parent();
+}
+
+void session_set_launcher(LaunchGameFn fn)
+{
+    session_detail::Session::instance().set_launcher(std::move(fn));
+}
+
+bool session_open_game(const QString &game)
+{
+    return session_detail::Session::instance().open_game(game);
+}
+
+int session_exec()
+{
+    return session_detail::Session::instance().exec();
+}
+
+}
+
+#include "sessionqt.moc"

--- a/garglk/sessionqt.cpp
+++ b/garglk/sessionqt.cpp
@@ -258,9 +258,17 @@ GameWindow::GameWindow(QLocalSocket *socket, QWidget *parent) :
     setCentralWidget(m_view);
     m_socket->setParent(this);
     if (gli_conf_menu_bar) {
-        setup_file_menu(this, m_settings,
+        auto send_edit_key = [this](int key) {
+            send(ipc::Msg::EventKey,
+                    ipc::make_event_key(Qt::ControlModifier, key, {}));
+        };
+        setup_menus(this, m_settings,
                 [](const QString &game) { Session::instance().open_game(game); },
-                [] { Session::instance().quit_all(); });
+                [this] { close(); },
+                [] { Session::instance().quit_all(); },
+                [send_edit_key] { send_edit_key(Qt::Key_X); },
+                [send_edit_key] { send_edit_key(Qt::Key_C); },
+                [send_edit_key] { send_edit_key(Qt::Key_V); });
     } else {
         menuBar()->hide();
     }

--- a/garglk/sessionqt.h
+++ b/garglk/sessionqt.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 by the Gargoyle developers.
+//
+// This file is part of Gargoyle.
+
+#ifndef GARGLK_SESSIONQT_H
+#define GARGLK_SESSIONQT_H
+
+#include <functional>
+#include <string>
+
+#include <QString>
+
+namespace garglk {
+
+// True when this process is the IPC session parent (owns game windows).
+bool session_is_parent();
+
+// If another Gargoyle parent is already running, hand off `game` to it
+// and return true (caller should exit). No-op / false when ipc is off.
+bool session_try_handoff(const QString &game);
+
+// Start the local server. Returns false on failure.
+bool session_init_parent();
+
+// Called by the launcher to open/launch a game via winterp (non-blocking).
+using LaunchGameFn = std::function<bool(const std::string &game)>;
+void session_set_launcher(LaunchGameFn fn);
+
+// Open a game from the parent (File → Open / handoff / initial story).
+bool session_open_game(const QString &game);
+
+// Run the Qt event loop until the last game window closes.
+int session_exec();
+
+}
+
+#endif

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -409,7 +409,7 @@ garglk::Window::Window() :
     });
 
     if (gli_conf_menu_bar) {
-        setup_file_menu(this, m_settings, launch_gargoyle);
+        setup_file_menu(this, m_settings, launch_gargoyle, [] { gli_exit(0); });
     } else {
         menuBar()->hide();
     }

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -110,6 +110,8 @@
 #include "garversion.h"
 #include "glk.h"
 #include "garglk.h"
+#include "ipclientqt.h"
+#include "menubarqt.h"
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #define HAS_QT6
@@ -124,25 +126,6 @@ static const std::unordered_map<FileFilter, std::pair<QString, QString>> filters
     {FileFilter::Text, {"Text files (*.txt)", "txt"}},
     {FileFilter::Data, {"Data files (*.glkdata)", "glkdata"}},
 };
-
-static constexpr int MAX_RECENT_FILES = 10;
-static const char *RECENT_FILES_KEY = "recent/files";
-
-static void add_recent_file(QSettings *settings, const QString &path)
-{
-    if (path.isEmpty()) {
-        return;
-    }
-
-    auto absolute = QFileInfo(path).absoluteFilePath();
-    auto recent = settings->value(RECENT_FILES_KEY).toStringList();
-    recent.removeAll(absolute);
-    recent.prepend(absolute);
-    while (recent.size() > MAX_RECENT_FILES) {
-        recent.removeLast();
-    }
-    settings->setValue(RECENT_FILES_KEY, recent);
-}
 
 static QString find_gargoyle_launcher()
 {
@@ -208,49 +191,6 @@ static bool launch_gargoyle(const QString &game = {})
     return true;
 }
 
-static QString browse_for_game()
-{
-    // Keep in sync with launchqt.cpp's winbrowsefile().
-    struct Filter {
-        QString name;
-        QStringList extensions;
-    };
-
-    const QVector<Filter> game_filters = {
-        {"Adrift", {"taf"}},
-        {"AdvSys", {"dat"}},
-        {"AGT", {"agx", "d$$"}},
-        {"Alan", {"acd", "a3c"}},
-        {"Glulx", {"ulx", "blb", "blorb", "glb", "gblorb"}},
-        {"Hugo", {"hex"}},
-        {"JACL", {"jacl", "j2"}},
-        {"Level 9", {"l9", "sna"}},
-        {"Magnetic Scrolls", {"mag"}},
-        {"TADS", {"gam", "t3"}},
-        {"Z-code", {"z1", "z2", "z3", "z4", "z5", "z6", "z7", "z8", "zlb", "zblorb"}},
-    };
-
-    QStringList mapped_filters;
-    QStringList all_extensions;
-    for (const auto &filter : game_filters) {
-        QStringList exts;
-        for (const auto &ext : filter.extensions) {
-            exts << QString("*.%1").arg(ext);
-        }
-        all_extensions << exts;
-        mapped_filters << QString("%1 Games (%2)").arg(filter.name, exts.join(" "));
-    }
-
-    QString filter_string = QString("All Games (%1);;All Files (*);;%2")
-        .arg(all_extensions.join(" "), mapped_filters.join(";;"));
-
-    QFileDialog::Options options(QFileDialog::HideNameFilterDetails);
-#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-    return QFileDialog::getOpenFileName(window, "Open", "", filter_string, nullptr, options);
-}
-
 static bool refresh_needed = true;
 
 static constexpr int TICK_PERIOD_MILLIS = 10;
@@ -270,20 +210,52 @@ static void handle_input(const QString &input, bool from_paste)
     }
 }
 
+static QTimer *ipc_timer = nullptr;
+static bool ipc_timed_out = false;
+
 void glk_request_timer_events(glui32 ms)
 {
+    if (garglk::ipc_client::active()) {
+        if (ipc_timer == nullptr) {
+            ipc_timer = new QTimer(app);
+            ipc_timer->setTimerType(Qt::TimerType::PreciseTimer);
+            QObject::connect(ipc_timer, &QTimer::timeout, []() {
+                ipc_timed_out = true;
+            });
+        }
+        if (ipc_timer->isActive()) {
+            ipc_timer->stop();
+        }
+        if (ms > static_cast<glui32>(std::numeric_limits<int>::max())) {
+            ms = static_cast<glui32>(std::numeric_limits<int>::max());
+        }
+        if (ms != 0) {
+            ipc_timer->setInterval(static_cast<int>(ms));
+            ipc_timer->start();
+        }
+        return;
+    }
+
     window->start_timer(ms);
 }
 
 void gli_notification_waiting()
 {
+    if (garglk::ipc_client::active()) {
+        QApplication::postEvent(app, new QEvent(QEvent::None));
+        return;
+    }
     QApplication::postEvent(window, new QEvent(QEvent::None));
 }
 
 void garglk::winabort(const std::string &msg)
 {
     std::cerr << "fatal: " << msg << std::endl;
-    QMessageBox::critical(nullptr, "Error", msg.c_str());
+    if (garglk::ipc_client::active()) {
+        garglk::ipc_client::abort_dialog(QString::fromStdString(msg));
+    } else {
+        QMessageBox::critical(nullptr, "Error", msg.c_str());
+    }
     gli_exit(EXIT_FAILURE);
 }
 
@@ -302,6 +274,29 @@ enum class Action { Open, Save };
 
 static std::string winchoosefile(const QString &prompt, FileFilter filter, Action action)
 {
+    if (garglk::ipc_client::active()) {
+        QString dir;
+        if (gli_conf_gamedata_location == GamedataLocation::Dedicated && gli_workfile.has_value()) {
+            auto path = QFileInfo(QString::fromStdString(*gli_workfile));
+            if (!path.fileName().isEmpty()) {
+                QDir basedir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+                QDir savepath = QDir(basedir.filePath("gamedata")).filePath(path.fileName());
+                if (savepath.mkpath(savepath.absolutePath())) {
+                    dir = savepath.absolutePath();
+                }
+            }
+        } else if (gli_conf_gamedata_location == GamedataLocation::Gamedir) {
+            dir = QString::fromStdString(gli_workdir);
+        } else if (gli_conf_gamedata_location == GamedataLocation::Fixed) {
+            dir = QString::fromStdString(gli_conf_gamedata_dir);
+        }
+
+        if (action == Action::Open) {
+            return garglk::ipc_client::open_dialog(prompt, filter, dir);
+        }
+        return garglk::ipc_client::save_dialog(prompt, filter, dir);
+    }
+
     QFileDialog dialog(window, prompt);
 
 #ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
@@ -413,88 +408,16 @@ garglk::Window::Window() :
         m_timed_out = true;
     });
 
-    setup_menu_bar();
-}
-
-void garglk::Window::setup_menu_bar()
-{
-    auto *file_menu = menuBar()->addMenu("&File");
-
-    auto *open_action = file_menu->addAction("&Open…", this, &Window::open_game);
-    open_action->setShortcut(QKeySequence::Open);
-
-    m_recent_menu = file_menu->addMenu("Open &Recent");
-    connect(m_recent_menu, &QMenu::aboutToShow, this, &Window::update_recent_menu);
-    update_recent_menu();
-
-    file_menu->addSeparator();
-
-    auto *settings_action = file_menu->addAction("&Settings", this, [] {
-        gli_edit_config();
-    });
-    // QKeySequence::Preferences is empty on Windows; Ctrl+, matches the
-    // existing key binding in keyPressEvent.
-    auto prefs = QKeySequence::keyBindings(QKeySequence::Preferences);
-    if (prefs.isEmpty()) {
-        settings_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Comma));
+    if (gli_conf_menu_bar) {
+        setup_file_menu(this, m_settings, launch_gargoyle);
     } else {
-        settings_action->setShortcuts(prefs);
+        menuBar()->hide();
     }
 }
 
 void garglk::Window::note_recent_file(const QString &path)
 {
-    add_recent_file(m_settings, path);
-}
-
-void garglk::Window::open_game()
-{
-    auto game = browse_for_game();
-    if (!game.isEmpty()) {
-        launch_gargoyle(game);
-    }
-}
-
-void garglk::Window::open_recent_game()
-{
-    auto *action = qobject_cast<QAction *>(sender());
-    if (action == nullptr) {
-        return;
-    }
-
-    auto game = action->data().toString();
-    if (game.isEmpty()) {
-        return;
-    }
-
-    if (!QFileInfo::exists(game)) {
-        QMessageBox::warning(this, "Warning", QString("File not found:\n%1").arg(game));
-        auto recent = m_settings->value(RECENT_FILES_KEY).toStringList();
-        recent.removeAll(game);
-        m_settings->setValue(RECENT_FILES_KEY, recent);
-        return;
-    }
-
-    launch_gargoyle(game);
-}
-
-void garglk::Window::update_recent_menu()
-{
-    m_recent_menu->clear();
-
-    auto recent = m_settings->value(RECENT_FILES_KEY).toStringList();
-    if (recent.isEmpty()) {
-        auto *empty = m_recent_menu->addAction("No Recent Files");
-        empty->setEnabled(false);
-        return;
-    }
-
-    for (const auto &path : recent) {
-        auto *action = m_recent_menu->addAction(QFileInfo(path).fileName());
-        action->setData(path);
-        action->setToolTip(path);
-        connect(action, &QAction::triggered, this, &Window::open_recent_game);
-    }
+    garglk::note_recent_file(m_settings, path);
 }
 
 void garglk::Window::showEvent(QShowEvent *event)
@@ -1079,17 +1002,44 @@ void wininit()
 
 void winopen()
 {
-    window = new garglk::Window();
-
     // Qt window geometry is in logical pixels, but the metrics here are
     // in physical pixels (see gli_backingscalefactor in wininit()), so
     // scale back down. This is a no-op when the factor is 1.0.
-    window->setMinimumSize(std::round(gli_wmarginx * 2 / gli_backingscalefactor),
-                           std::round(gli_wmarginy * 2 / gli_backingscalefactor));
-
     int defw = std::round((gli_wmarginx * 2 + gli_cellw * gli_cols) / gli_backingscalefactor);
     int defh = std::round((gli_wmarginy * 2 + gli_cellh * gli_rows) / gli_backingscalefactor);
     QSize size(defw, defh);
+
+    bool do_fullscreen = gli_conf_fullscreen;
+    bool do_move = false;
+    QPoint position;
+
+    // Prefer IPC session parent when enabled and available.
+    if (garglk::ipc_client::connect_to_parent()) {
+        unsigned char r = gli_window_color[0];
+        unsigned char g = gli_window_color[1];
+        unsigned char b = gli_window_color[2];
+
+        if (gli_conf_save_window_size) {
+            // Stored sizes aren't available without a local QSettings window;
+            // use defaults. Parent may still restore via its own settings later.
+        }
+
+        garglk::ipc_client::init_window(do_move, 0, 0, size.width(), size.height(),
+                do_fullscreen, r, g, b);
+
+        if (gli_workfile.has_value()) {
+            // Recent files are tracked by the parent session on open.
+        }
+
+        wintitle();
+        return;
+    }
+
+    window = new garglk::Window();
+
+    window->setMinimumSize(std::round(gli_wmarginx * 2 / gli_backingscalefactor),
+                           std::round(gli_wmarginy * 2 / gli_backingscalefactor));
+
     if (gli_conf_save_window_size) {
         auto stored_size = window->settings()->value("window/size");
         if (stored_size.canConvert<QSize>()) {
@@ -1098,14 +1048,14 @@ void winopen()
     }
 
     // Requested size is for the game view; grow the window to fit the
-    // menu bar above it.
-    int menu_h = window->menuBar()->sizeHint().height();
+    // menu bar above it when enabled.
+    int menu_h = gli_conf_menu_bar ? window->menuBar()->sizeHint().height() : 0;
     window->resize(size.width(), size.height() + menu_h);
 
     if (gli_conf_save_window_location) {
-        auto position = window->settings()->value("window/position");
-        if (position.canConvert<QPoint>()) {
-            window->move(position.toPoint());
+        auto stored_position = window->settings()->value("window/position");
+        if (stored_position.canConvert<QPoint>()) {
+            window->move(stored_position.toPoint());
         }
     }
 
@@ -1114,8 +1064,6 @@ void winopen()
     }
 
     wintitle();
-
-    bool do_fullscreen = gli_conf_fullscreen;
 
     if (gli_conf_save_window_location || gli_conf_save_window_size) {
         auto fullscreen = window->settings()->value("window/fullscreen");
@@ -1141,6 +1089,11 @@ void wintitle()
         title = QString("%1 - %2").arg(QString::fromStdString(gli_story_name), QString::fromStdString(gli_program_name));
     } else {
         title = QString::fromStdString(gli_program_name);
+    }
+
+    if (garglk::ipc_client::active()) {
+        garglk::ipc_client::set_title(title);
+        return;
     }
 
     window->setWindowTitle(title);
@@ -1247,7 +1200,27 @@ std::optional<std::string> garglk::winappdir()
 
 bool garglk::winisfullscreen()
 {
+    if (garglk::ipc_client::active()) {
+        return garglk::ipc_client::is_fullscreen();
+    }
     return window->isFullScreen();
+}
+
+static void refresh_display()
+{
+    if (!refresh_needed) {
+        return;
+    }
+
+    if (garglk::ipc_client::active()) {
+        gli_windows_redraw();
+        garglk::ipc_client::set_contents(gli_image_rgb.width(), gli_image_rgb.height(),
+                gli_image_rgb.data(), gli_image_rgb.size());
+        refresh_needed = false;
+        return;
+    }
+
+    window->refresh();
 }
 
 void gli_tick()
@@ -1269,6 +1242,32 @@ void gli_tick()
 void gli_select(event_t *event, bool polled)
 {
     gli_event_clearevent(event);
+
+    if (garglk::ipc_client::active()) {
+        garglk::ipc_client::poll();
+        app->processEvents(QEventLoop::ExcludeUserInputEvents);
+        refresh_display();
+        gli_dispatch_event(event, polled);
+
+        if (!polled) {
+            while (event->type == evtype_None && !ipc_timed_out) {
+                refresh_display();
+                app->processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 50);
+                garglk::ipc_client::poll();
+                refresh_display();
+                gli_dispatch_event(event, polled);
+            }
+        }
+
+        if (event->type == evtype_None && ipc_timed_out) {
+            gli_event_store(evtype_Timer, nullptr, 0, 0);
+            gli_dispatch_event(event, polled);
+            ipc_timed_out = false;
+        }
+
+        process_events.store(false, std::memory_order_relaxed);
+        return;
+    }
 
     app->processEvents();
 

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -18,6 +18,7 @@
 // along with Gargoyle; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+#include <QAction>
 #include <QApplication>
 #include <QChar>
 #include <QClipboard>
@@ -31,9 +32,12 @@
 #include <QFrame>
 #include <QGraphicsView>
 #include <QHBoxLayout>
+#include <QKeySequence>
 #include <QLabel>
 #include <QList>
 #include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
 #include <QMessageBox>
 #include <QMoveEvent>
 #include <QObject>
@@ -51,6 +55,7 @@
 #include <QStringList>
 #include <QTimer>
 #include <QUrl>
+#include <QVector>
 #include <QVBoxLayout>
 #include <QWidget>
 #include <QtGlobal>
@@ -120,8 +125,131 @@ static const std::unordered_map<FileFilter, std::pair<QString, QString>> filters
     {FileFilter::Data, {"Data files (*.glkdata)", "glkdata"}},
 };
 
+static constexpr int MAX_RECENT_FILES = 10;
+static const char *RECENT_FILES_KEY = "recent/files";
+
+static void add_recent_file(QSettings *settings, const QString &path)
+{
+    if (path.isEmpty()) {
+        return;
+    }
+
+    auto absolute = QFileInfo(path).absoluteFilePath();
+    auto recent = settings->value(RECENT_FILES_KEY).toStringList();
+    recent.removeAll(absolute);
+    recent.prepend(absolute);
+    while (recent.size() > MAX_RECENT_FILES) {
+        recent.removeLast();
+    }
+    settings->setValue(RECENT_FILES_KEY, recent);
+}
+
+static QString find_gargoyle_launcher()
+{
+    // Prefer the path recorded by the launcher when it started this
+    // interpreter; that covers non-standard layouts (e.g. build trees).
+    if (auto *env = std::getenv("GARGLK_LAUNCHER"); env != nullptr && env[0] != '\0') {
+        QFileInfo info(QString::fromLocal8Bit(env));
+        if (info.exists() && info.isFile()) {
+            return info.canonicalFilePath();
+        }
+    }
+
+    QDir appdir(QCoreApplication::applicationDirPath());
+#ifdef Q_OS_WIN
+    const QString name = "gargoyle.exe";
+#else
+    const QString name = "gargoyle";
+#endif
+
+    // AppImage/Windows/dev builds keep interpreters next to gargoyle.
+    // Unix installs typically put interpreters in libexec/gargoyle and
+    // the launcher in bin/, one or two levels up. CMake build trees put
+    // the launcher in ../garglk/.
+    const QStringList candidates = {
+        appdir.absoluteFilePath(name),
+        appdir.absoluteFilePath(QString("../%1").arg(name)),
+        appdir.absoluteFilePath(QString("../garglk/%1").arg(name)),
+        appdir.absoluteFilePath(QString("../bin/%1").arg(name)),
+        appdir.absoluteFilePath(QString("../../bin/%1").arg(name)),
+    };
+
+    for (const auto &candidate : candidates) {
+        QFileInfo info(candidate);
+        if (info.exists() && info.isFile()) {
+            return info.canonicalFilePath();
+        }
+    }
+
+    return QStandardPaths::findExecutable("gargoyle");
+}
+
 static QApplication *app;
 static garglk::Window *window;
+
+static bool launch_gargoyle(const QString &game = {})
+{
+    auto launcher = find_gargoyle_launcher();
+    if (launcher.isEmpty()) {
+        QMessageBox::warning(window, "Warning", "Unable to find the Gargoyle launcher.");
+        return false;
+    }
+
+    QStringList args;
+    if (!game.isEmpty()) {
+        args << game;
+    }
+
+    if (!QProcess::startDetached(launcher, args)) {
+        QMessageBox::warning(window, "Warning", "Unable to start Gargoyle.");
+        return false;
+    }
+
+    return true;
+}
+
+static QString browse_for_game()
+{
+    // Keep in sync with launchqt.cpp's winbrowsefile().
+    struct Filter {
+        QString name;
+        QStringList extensions;
+    };
+
+    const QVector<Filter> game_filters = {
+        {"Adrift", {"taf"}},
+        {"AdvSys", {"dat"}},
+        {"AGT", {"agx", "d$$"}},
+        {"Alan", {"acd", "a3c"}},
+        {"Glulx", {"ulx", "blb", "blorb", "glb", "gblorb"}},
+        {"Hugo", {"hex"}},
+        {"JACL", {"jacl", "j2"}},
+        {"Level 9", {"l9", "sna"}},
+        {"Magnetic Scrolls", {"mag"}},
+        {"TADS", {"gam", "t3"}},
+        {"Z-code", {"z1", "z2", "z3", "z4", "z5", "z6", "z7", "z8", "zlb", "zblorb"}},
+    };
+
+    QStringList mapped_filters;
+    QStringList all_extensions;
+    for (const auto &filter : game_filters) {
+        QStringList exts;
+        for (const auto &ext : filter.extensions) {
+            exts << QString("*.%1").arg(ext);
+        }
+        all_extensions << exts;
+        mapped_filters << QString("%1 Games (%2)").arg(filter.name, exts.join(" "));
+    }
+
+    QString filter_string = QString("All Games (%1);;All Files (*);;%2")
+        .arg(all_extensions.join(" "), mapped_filters.join(";;"));
+
+    QFileDialog::Options options(QFileDialog::HideNameFilterDetails);
+#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+    return QFileDialog::getOpenFileName(window, "Open", "", filter_string, nullptr, options);
+}
 
 static bool refresh_needed = true;
 
@@ -278,10 +406,95 @@ garglk::Window::Window() :
     // doesn't really matter anyway.
     m_settings(new QSettings("io.github.garglk", "Gargoyle", this))
 {
+    setCentralWidget(m_view);
+
     m_timer->setTimerType(Qt::TimerType::PreciseTimer);
     connect(m_timer, &QTimer::timeout, this, [&]() {
         m_timed_out = true;
     });
+
+    setup_menu_bar();
+}
+
+void garglk::Window::setup_menu_bar()
+{
+    auto *file_menu = menuBar()->addMenu("&File");
+
+    auto *open_action = file_menu->addAction("&Open…", this, &Window::open_game);
+    open_action->setShortcut(QKeySequence::Open);
+
+    m_recent_menu = file_menu->addMenu("Open &Recent");
+    connect(m_recent_menu, &QMenu::aboutToShow, this, &Window::update_recent_menu);
+    update_recent_menu();
+
+    file_menu->addSeparator();
+
+    auto *settings_action = file_menu->addAction("&Settings", this, [] {
+        gli_edit_config();
+    });
+    // QKeySequence::Preferences is empty on Windows; Ctrl+, matches the
+    // existing key binding in keyPressEvent.
+    auto prefs = QKeySequence::keyBindings(QKeySequence::Preferences);
+    if (prefs.isEmpty()) {
+        settings_action->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_Comma));
+    } else {
+        settings_action->setShortcuts(prefs);
+    }
+}
+
+void garglk::Window::note_recent_file(const QString &path)
+{
+    add_recent_file(m_settings, path);
+}
+
+void garglk::Window::open_game()
+{
+    auto game = browse_for_game();
+    if (!game.isEmpty()) {
+        launch_gargoyle(game);
+    }
+}
+
+void garglk::Window::open_recent_game()
+{
+    auto *action = qobject_cast<QAction *>(sender());
+    if (action == nullptr) {
+        return;
+    }
+
+    auto game = action->data().toString();
+    if (game.isEmpty()) {
+        return;
+    }
+
+    if (!QFileInfo::exists(game)) {
+        QMessageBox::warning(this, "Warning", QString("File not found:\n%1").arg(game));
+        auto recent = m_settings->value(RECENT_FILES_KEY).toStringList();
+        recent.removeAll(game);
+        m_settings->setValue(RECENT_FILES_KEY, recent);
+        return;
+    }
+
+    launch_gargoyle(game);
+}
+
+void garglk::Window::update_recent_menu()
+{
+    m_recent_menu->clear();
+
+    auto recent = m_settings->value(RECENT_FILES_KEY).toStringList();
+    if (recent.isEmpty()) {
+        auto *empty = m_recent_menu->addAction("No Recent Files");
+        empty->setEnabled(false);
+        return;
+    }
+
+    for (const auto &path : recent) {
+        auto *action = m_recent_menu->addAction(QFileInfo(path).fileName());
+        action->setData(path);
+        action->setToolTip(path);
+        connect(action, &QAction::triggered, this, &Window::open_recent_game);
+    }
 }
 
 void garglk::Window::showEvent(QShowEvent *event)
@@ -307,7 +520,7 @@ void garglk::Window::showEvent(QShowEvent *event)
     // window is first shown, by which point the true scale has reliably
     // arrived in practice.
     QTimer::singleShot(50, this, [this]() {
-        updateBufferSize(size());
+        updateBufferSize(m_view->size());
     });
 #endif
 }
@@ -316,7 +529,7 @@ void garglk::Window::showEvent(QShowEvent *event)
 bool garglk::Window::event(QEvent *event)
 {
     if (event->type() == QEvent::DevicePixelRatioChange) {
-        updateBufferSize(size());
+        updateBufferSize(m_view->size());
     }
 
     return QMainWindow::event(event);
@@ -367,9 +580,9 @@ void garglk::Window::resizeEvent(QResizeEvent *event)
 {
     QMainWindow::resizeEvent(event);
 
-    m_view->resize(event->size());
-
-    updateBufferSize(event->size());
+    // Buffer size follows the central view (below the menu bar), not the
+    // full window.
+    updateBufferSize(m_view->size());
 
     event->accept();
 }
@@ -883,13 +1096,21 @@ void winopen()
             size = stored_size.toSize();
         }
     }
-    window->resize(size);
+
+    // Requested size is for the game view; grow the window to fit the
+    // menu bar above it.
+    int menu_h = window->menuBar()->sizeHint().height();
+    window->resize(size.width(), size.height() + menu_h);
 
     if (gli_conf_save_window_location) {
         auto position = window->settings()->value("window/position");
         if (position.canConvert<QPoint>()) {
             window->move(position.toPoint());
         }
+    }
+
+    if (gli_workfile.has_value()) {
+        window->note_recent_file(QString::fromStdString(*gli_workfile));
     }
 
     wintitle();

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -363,7 +363,7 @@ void winclipstore(const std::vector<glui32> &text)
     cliptext = QString::fromUcs4(reinterpret_cast<const char32_t *>(text.data()), text.size());
 }
 
-static void winclipsend(QClipboard::Mode mode)
+static void clipsend(QClipboard::Mode mode)
 {
     if (cliptext.isEmpty()) {
         return;
@@ -374,12 +374,22 @@ static void winclipsend(QClipboard::Mode mode)
     clipboard->setText(cliptext, mode);
 }
 
-static void winclipreceive(QClipboard::Mode mode)
+static void clipreceive(QClipboard::Mode mode)
 {
     QClipboard *clipboard = QGuiApplication::clipboard();
     QString text = clipboard->text(mode);
 
     handle_input(text, true);
+}
+
+void winclipsend()
+{
+    clipsend(QClipboard::Clipboard);
+}
+
+void winclipreceive()
+{
+    clipreceive(QClipboard::Clipboard);
 }
 
 garglk::Window::Window() :
@@ -409,7 +419,19 @@ garglk::Window::Window() :
     });
 
     if (gli_conf_menu_bar) {
-        setup_file_menu(this, m_settings, launch_gargoyle, [] { gli_exit(0); });
+        setup_menus(this, m_settings, launch_gargoyle,
+                [this] { close(); },
+                [] { gli_exit(0); },
+                [] {
+                    gli_store_input_selection();
+                    winclipsend();
+                    gli_delete_input_selection();
+                },
+                [] {
+                    gli_store_input_selection();
+                    winclipsend();
+                },
+                [] { winclipreceive(); });
     } else {
         menuBar()->hide();
     }
@@ -686,9 +708,9 @@ void garglk::View::keyPressEvent(QKeyEvent *event)
     refresh_needed = true;
 
     static const std::map<QKeySequence::StandardKey, std::function<void()>> sequences = {
-        {QKeySequence::Cut,                []{ gli_store_input_selection(); winclipsend(QClipboard::Clipboard); gli_delete_input_selection(); }},
-        {QKeySequence::Copy,               []{ gli_store_input_selection(); winclipsend(QClipboard::Clipboard); }},
-        {QKeySequence::Paste,              []{ winclipreceive(QClipboard::Clipboard); }},
+        {QKeySequence::Cut,                []{ gli_store_input_selection(); winclipsend(); gli_delete_input_selection(); }},
+        {QKeySequence::Copy,               []{ gli_store_input_selection(); winclipsend(); }},
+        {QKeySequence::Paste,              []{ winclipreceive(); }},
         {QKeySequence::MoveToPreviousWord, []{ gli_input_handle_key(keycode_SkipWordLeft); }},
         {QKeySequence::MoveToNextWord,     []{ gli_input_handle_key(keycode_SkipWordRight); }},
         {QKeySequence::SelectPreviousChar, []{ gli_input_handle_key(keycode_SelectLeft); }},
@@ -886,7 +908,7 @@ void garglk::View::mousePressEvent(QMouseEvent *event)
         gli_input_handle_click(std::round(event->pos().x() * dpr), std::round(event->pos().y() * dpr),
                 count_click(event->pos()));
     } else if (event->button() == Qt::MiddleButton) {
-        winclipreceive(QClipboard::Selection);
+        clipreceive(QClipboard::Selection);
     }
 
     event->accept();
@@ -902,7 +924,7 @@ void garglk::View::mouseReleaseEvent(QMouseEvent *event)
     if (event->button() == Qt::LeftButton) {
         gli_copyselect = false;
         unsetCursor();
-        winclipsend(QClipboard::Selection);
+        clipsend(QClipboard::Selection);
     }
 
     event->accept();

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -5,7 +5,6 @@
 #include <QElapsedTimer>
 #include <QKeyEvent>
 #include <QMainWindow>
-#include <QMenu>
 #include <QMouseEvent>
 #include <QMoveEvent>
 #include <QPaintEvent>
@@ -83,15 +82,9 @@ private:
     // event(), see the comments there for why a second call is needed.
     void updateBufferSize(const QSize &logicalSize);
 
-    void setup_menu_bar();
-    void open_game();
-    void open_recent_game();
-    void update_recent_menu();
-
     View *const m_view;
     QTimer *const m_timer;
     QSettings *const m_settings;
-    QMenu *m_recent_menu = nullptr;
     bool m_timed_out = false;
 };
 

--- a/garglk/sysqt.h
+++ b/garglk/sysqt.h
@@ -5,6 +5,7 @@
 #include <QElapsedTimer>
 #include <QKeyEvent>
 #include <QMainWindow>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QMoveEvent>
 #include <QPaintEvent>
@@ -12,6 +13,7 @@
 #include <QResizeEvent>
 #include <QSettings>
 #include <QShowEvent>
+#include <QString>
 #include <QTimer>
 #include <QWheelEvent>
 #include <QWidget>
@@ -62,7 +64,8 @@ public:
     bool timed_out() const { return m_timed_out; }
     void reset_timeout() { m_timed_out = false; }
 
-    const QSettings *settings() { return m_settings; }
+    const QSettings *settings() const { return m_settings; }
+    void note_recent_file(const QString &path);
 
 protected:
     void showEvent(QShowEvent *) override;
@@ -80,9 +83,15 @@ private:
     // event(), see the comments there for why a second call is needed.
     void updateBufferSize(const QSize &logicalSize);
 
+    void setup_menu_bar();
+    void open_game();
+    void open_recent_game();
+    void update_recent_menu();
+
     View *const m_view;
     QTimer *const m_timer;
     QSettings *const m_settings;
+    QMenu *m_recent_menu = nullptr;
     bool m_timed_out = false;
 };
 


### PR DESCRIPTION
* Fixes #1003
* Fixes #1006 

It's kinda wild to fix #1006 and #1003 in the same PR, but that's kinda what's needed to implement a basic "Open" menu.

There are two new `garglk.ini` boolean settings, `menu_bar` and `ipc`. `menu_bar` enables/disables the menu bar UI; `ipc` enables/disables the IPC system.

If you approve this PR, hopefully other menu items will be possible without such major refactorings.

EDIT: I did all of my manual testing for this branch on QT 6, on Windows 11 aarch64 and Ubuntu 24 LTS ARM, in VMs on an Apple Silicon Mac.

<img width="520" height="590" alt="image" src="https://github.com/user-attachments/assets/1ba6c02a-41df-467a-aeea-fa9d61c05021" />

