### PR TITLE
Restore window, more and caret colors in glk_stylehint_clear

### DIFF
--- a/garglk/style.cpp
+++ b/garglk/style.cpp
@@ -145,6 +145,22 @@ void glk_stylehint_clear(glui32 wintype, glui32 styl, glui32 hint)
             style.justification = def.justification;
             break;
         }
+
+        // glk_stylehint_set() takes the window, more prompt and caret colors
+        // along with Normal's; clearing the hint has to hand them back, or
+        // they keep colors that no style asks for any more.
+        if (wintype == wintype_TextBuffer &&
+                styl == style_Normal &&
+                hint == stylehint_BackColor) {
+            gli_window_color = gli_window_save;
+        }
+
+        if (wintype == wintype_TextBuffer &&
+                styl == style_Normal &&
+                hint == stylehint_TextColor) {
+            gli_more_color = gli_more_save;
+            gli_caret_color = gli_caret_save;
+        }
     } catch (const std::out_of_range &) {
     }
 }


### PR DESCRIPTION
EDIT: Perhaps it will be clearer if I copy the text from #1007 here.

There is a feature of Scarier (possibly not the version currently in the garglk repo, but at least the one [here](https://github.com/angstsmurf/spatterlight/tree/master/terps/scarier)) that won't work with the way Gargoyle currently handles glk_stylehint_clear(): changing the text background colour twice.

This is demonstrated by the game [The Dead Man](https://ifdb.org/viewgame?id=9m7iq18gugcnkb5c), which starts out with the standard Adrift green text on black, then switches to black on white (after you type Z about 15 times), then back to green on black. That currently leaves the window background the wrong colour,

My AI claims this is a Gargoyle bug. Let me know what you think.

---

`glk_stylehint_set()` does more than fill in the style table: for a text
buffer's `style_Normal` it also assigns three globals —

```c
if (wintype == wintype_TextBuffer && styl == style_Normal && hint == stylehint_BackColor) {
    gli_window_color = style.bg;
}
if (wintype == wintype_TextBuffer && styl == style_Normal && hint == stylehint_TextColor) {
    gli_more_color = style.fg;
    gli_caret_color = style.fg;
}
```

`glk_stylehint_clear()` puts `style.fg` / `style.bg` back to the defaults but
leaves those three holding the colors of the hint that was just withdrawn.

That matters because `gli_window_color` is not merely cosmetic: it is what
`gli_windows_redraw()` clears the frame to, and it is the initializer for a
newly created window's `bgcolor` (`garglk.h`). So a program that sets a Normal
background hint, opens windows, then clears the hint and opens windows again
gets windows whose background is still the old hint's color, while every style
in them is back to the theme:

```c
glk_stylehint_set(wintype_TextBuffer, style_Normal, stylehint_BackColor, 0x000000);
win = glk_window_open(...);   // black background, as asked

glk_stylehint_clear(wintype_TextBuffer, style_Normal, stylehint_BackColor);
glk_window_close(glk_window_get_root(), NULL);
win = glk_window_open(...);   // styles are the theme's again, but the window
                              // background is still black
```

On screen that reads as theme-colored boxes of text on a black field, plus
margins painted in the withdrawn color. `gli_more_color` and `gli_caret_color`
likewise keep a foreground no style asks for any more.

This patch mirrors the `set` side effects in `clear`, under the same guards
(text buffer, `style_Normal`). It restores from `gli_window_save`,
`gli_more_save` and `gli_caret_save` rather than from `def.bg` / `def.fg`,
because `windowcolor`, `morecolor` and `caretcolor` are their own ini and theme
keys and need not equal the Normal style's colors — those `*_save` values are
exactly what `gli_set_zcolors()` restores when a terp names `zcolor_Default`.

Found while running the scarier interpreter (merged in cfe2269d) on macOS.
Scarier publishes an ADRIFT game's palette as `style_Normal` Text/BackColor
stylehints and rebuilds the window tree so open windows snapshot them; its
`glk colour off` command clears the hints and rebuilds. Before this patch the
rebuilt tree came up with black window backgrounds behind theme-colored text;
after it, the theme is restored cleanly. Verified with [Alien Diver](https://www.adrift.co/cgi/download.cgi?1576) (ADRIFT 5,
side pane + map) and [Shadowpeak](https://www.adrift.co/cgi/download.cgi?1142) (ADRIFT 4).
