### PR TITLE
Improve Windows build

### DIFF
--- a/.github/workflows/windows-clang.yml
+++ b/.github/workflows/windows-clang.yml
@@ -69,12 +69,11 @@ jobs:
       - name: Assemble results
         run: |
           mkdir gargoyle-staging
-          cp cmake-build\garglk\gargoyle.exe gargoyle-staging
-          cp cmake-build\garglk\*.dll gargoyle-staging
+          # Native Windows builds colocate runtimes in the CMake build directory root.
+          cp cmake-build\*.exe gargoyle-staging
+          cp cmake-build\*.dll gargoyle-staging
           cp cmake-build\*.ttf gargoyle-staging
           cp cmake-build\*.otf gargoyle-staging
-          cp cmake-build\terps\*.exe gargoyle-staging
-          cp cmake-build\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe gargoyle-staging
 
       - name: Deploy Qt files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 /Gargoyle.app
 /build*
+/cmake-build/
+/aqtinstall.log
 /*.dmg
 /*.zip
 /*.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,16 @@ option(WITH_BABEL "Display Treaty of Babel-derived author and title if possible"
 option(APPIMAGE "Tweak some settings to aid in AppImage building" OFF)
 option(DIST_INSTALL "Install to ${PROJECT_SOURCE_DIR}/build/dist for packaging" OFF)
 
+# On Windows, put the launcher, libgarglk DLLs, and interpreters in the
+# build directory root so the tree is runnable without PATH gymnastics
+# or GARGLK_INTERPRETER_DIR (the launcher searches next to gargoyle.exe).
+if(WIN32)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+    foreach(_garglk_cfg DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${_garglk_cfg} "${CMAKE_BINARY_DIR}")
+    endforeach()
+endif()
+
 if(MSVC)
     # MSVC defaults to the equivalent of "-fvisibility=hidden", which the code is not set up to support.
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -425,11 +425,21 @@ needed):
 vcpkg install freetype sndfile mpg123 libopenmpt libjpeg-turbo --triplet x64-windows
 ```
 
-Invoke cmake as follows (adjust Qt and vcpkg paths accordingly):
+Configure from an empty build directory (adjust Qt and vcpkg paths accordingly):
 
 ```
 cmake -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_LINKER=lld-link -DINTERFACE=QT -DCMAKE_PREFIX_PATH=D:/Qt/6.5.2/msvc2019_64 -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DSOUND=QT ..
 ```
+
+Then build:
+
+```
+ninja
+```
+
+On Windows, this places `gargoyle.exe`, `garglk.dll`, the interpreters, and
+(via a `windeployqt` post-build step) the Qt runtime into the CMake build
+directory root. You can run `gargoyle.exe` from that directory directly.
 
 Building an installer from this configuration is not yet supported.
 

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -437,6 +437,35 @@ target_link_libraries(garglk PUBLIC garglk-common)
 add_library(garglk-gpl2)
 target_link_libraries(garglk-gpl2 PUBLIC garglk-common)
 
+# Native Windows builds: deploy Qt next to garglk.dll so the colocated
+# build-tree binaries are double-clickable. Cross-builds (MinGW on Linux)
+# assemble a dist tree separately via windows.sh / package-windows.sh.
+if(WIN32 AND CMAKE_HOST_WIN32 AND INTERFACE STREQUAL "QT")
+    find_program(GARGLK_WINDEPLOYQT
+        NAMES windeployqt${QT_VERSION} windeployqt
+        HINTS
+            "${Qt${QT_VERSION}_DIR}/../../../bin"
+            "${CMAKE_PREFIX_PATH}"
+            "${CMAKE_PREFIX_PATH}/bin"
+    )
+    if(GARGLK_WINDEPLOYQT)
+        add_custom_command(TARGET garglk POST_BUILD
+            COMMAND "${GARGLK_WINDEPLOYQT}"
+                --no-compiler-runtime
+                --no-system-d3d-compiler
+                --no-system-dxc-compiler
+                --no-opengl-sw
+                --exclude-plugins ffmpegmediaplugin,qopensslbackend,qpdf
+                --skip-plugin-types iconengines,imageformats,tls
+                "$<TARGET_FILE:garglk>"
+            COMMENT "Deploying Qt runtime next to garglk.dll"
+            VERBATIM
+        )
+    else()
+        message(WARNING "windeployqt not found; the Windows build tree may not run without Qt on PATH")
+    endif()
+endif()
+
 target_include_directories(garglk-common PRIVATE ../support/xbrz)
 target_link_libraries(garglk PRIVATE xbrz)
 target_link_libraries(garglk-gpl2 PRIVATE xbrz-null)

--- a/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
+++ b/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
@@ -77,6 +77,15 @@ add_custom_command(TARGET frankendrift
     COMMAND ${CMAKE_COMMAND} -E rm "${CMAKE_CURRENT_SOURCE_DIR}/${GARGLK_FRANKEN_DYLIB_NAME}"
 )
 
+# On Windows the CMake build colocates runtimes in CMAKE_BINARY_DIR so the
+# launcher can find interpreters next to itself.
+if(WIN32)
+    add_custom_command(TARGET frankendrift POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_BINARY_DIR}/FrankenDrift.GlkRunner.Gargoyle${GARGLK_FRANKEN_EXT}"
+            "${CMAKE_BINARY_DIR}/FrankenDrift.GlkRunner.Gargoyle${GARGLK_FRANKEN_EXT}"
+    )
+endif()
 
 add_dependencies(frankendrift garglk)
 

--- a/winbuildrelease.ps1
+++ b/winbuildrelease.ps1
@@ -68,26 +68,15 @@ if (Test-Path "$stagedir") {
 mkdir $stagedir
 Copy-Item "$builddir\*.ttf" "$stagedir"
 Copy-Item "$builddir\*.otf" "$stagedir"
+# Native Windows builds colocate runtimes in the CMake build directory root.
 Copy-Item "$builddir\*.exe" "$stagedir"
-Copy-Item "$builddir\garglk\gargoyle.exe" "$stagedir"
-Copy-Item "$builddir\garglk\*.dll" "$stagedir"
-Copy-Item "$builddir\terps\*.exe" "$stagedir"
-Copy-Item "$builddir\terps\tads\*.exe" "$stagedir"
+Copy-Item "$builddir\*.dll" "$stagedir"
 if ($withPdbs) {
-    Copy-Item "$builddir\garglk\*.pdb" "$stagedir"
-    Copy-Item "$builddir\terps\*.pdb" "$stagedir"
-    Copy-Item "$builddir\terps\tads\*.pdb" "$stagedir"
-}
-
-if ($withFrankendrift) {
-    Copy-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe" "$stagedir"
-    if ($withPdbs) {
-        Copy-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.pdb" "$stagedir"
-    }
+    Copy-Item "$builddir\*.pdb" "$stagedir"
 }
 
 Set-Location "$stagedir"
-$deployArgs = @("--no-opengl-sw","--no-compiler-runtime","--no-system-d3d-compiler","--no-system-dxc-compiler","--no-pdf","--exclude-plugins","ffmpegmediaplugin,qopensslbackend","--skip-plugin-types","iconengines,imageformats,tls")
+$deployArgs = @("--no-opengl-sw","--no-compiler-runtime","--no-system-d3d-compiler","--no-system-dxc-compiler","--exclude-plugins","ffmpegmediaplugin,qopensslbackend,qpdf","--skip-plugin-types","iconengines,imageformats,tls")
 if ($withPdbs) {
     $deployArgs += "--pdb"
 }


### PR DESCRIPTION
When building on Windows, copy executables and DLLs directly into cmake-build, so you can double-click on `gargoyle.exe` to test.