### PR TITLE
On Windows, put executables/DLLs in the build directory

### DIFF
--- a/.github/workflows/windows-clang.yml
+++ b/.github/workflows/windows-clang.yml
@@ -69,12 +69,10 @@ jobs:
       - name: Assemble results
         run: |
           mkdir gargoyle-staging
-          cp cmake-build\garglk\gargoyle.exe gargoyle-staging
-          cp cmake-build\garglk\*.dll gargoyle-staging
+          cp cmake-build\*.exe gargoyle-staging
+          cp cmake-build\*.dll gargoyle-staging
           cp cmake-build\*.ttf gargoyle-staging
           cp cmake-build\*.otf gargoyle-staging
-          cp cmake-build\terps\*.exe gargoyle-staging
-          cp cmake-build\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe gargoyle-staging
 
       - name: Deploy Qt files
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,16 @@ option(WITH_BABEL "Display Treaty of Babel-derived author and title if possible"
 option(APPIMAGE "Tweak some settings to aid in AppImage building" OFF)
 option(DIST_INSTALL "Install to ${PROJECT_SOURCE_DIR}/build/dist for packaging" OFF)
 
+# Windows has no rpath, and no separate interpreter directory: the
+# launcher looks for interpreters next to itself, and both it and they
+# need libgarglk alongside as well. Put all runtime output in a single
+# directory so the build tree can be run in place, without installing.
+# Multi-config generators append a per-configuration subdirectory to
+# this, so Debug and Release still don't collide.
+if(WIN32 AND NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+endif()
+
 if(MSVC)
     # MSVC defaults to the equivalent of "-fvisibility=hidden", which the code is not set up to support.
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -436,6 +436,17 @@ Invoke cmake as follows (adjust Qt and vcpkg paths accordingly):
 cmake -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_LINKER=lld-link -DINTERFACE=QT -DCMAKE_PREFIX_PATH=D:/Qt/6.5.2/msvc2019_64 -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake -DSOUND=QT ..
 ```
 
+Windows builds place `gargoyle.exe`, `garglk.dll`, and the interpreters all
+together in the build directory, so the build tree can be run in place. To copy
+the Qt runtime in alongside them, run:
+
+```
+ninja deployqt
+```
+
+This only needs doing once per build directory. `gargoyle.exe` can then be
+started directly from there, without installing anything.
+
 Building an installer from this configuration is not yet supported.
 
 ## Building on Haiku

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -440,6 +440,32 @@ target_link_libraries(garglk PUBLIC garglk-common)
 add_library(garglk-gpl2)
 target_link_libraries(garglk-gpl2 PUBLIC garglk-common)
 
+# Running out of the build directory on Windows also needs the Qt DLLs
+# there. windeployqt copies them in, but only needs to be run once per
+# build directory, so provide it as a target to invoke by hand ("ninja
+# deployqt") instead of paying for it on every relink. Cross-compiled
+# builds don't get this: windeployqt is a Windows program, and the
+# cross-compiling scripts deploy Qt themselves.
+if(WIN32 AND CMAKE_HOST_WIN32 AND INTERFACE STREQUAL "QT")
+    if(TARGET Qt${QT_VERSION}::windeployqt)
+        set(GARGLK_WINDEPLOYQT "Qt${QT_VERSION}::windeployqt")
+    else()
+        find_program(GARGLK_WINDEPLOYQT windeployqt
+            HINTS "${QT${QT_VERSION}_INSTALL_PREFIX}/${QT${QT_VERSION}_INSTALL_BINS}")
+    endif()
+
+    if(GARGLK_WINDEPLOYQT)
+        add_custom_target(deployqt
+            COMMAND "${GARGLK_WINDEPLOYQT}" --no-compiler-runtime "$<TARGET_FILE:garglk>"
+            COMMENT "Deploying the Qt runtime next to garglk.dll"
+            VERBATIM
+        )
+        add_dependencies(deployqt garglk)
+    else()
+        message(STATUS "windeployqt not found; the \"deployqt\" target is unavailable")
+    endif()
+endif()
+
 target_include_directories(garglk-common PRIVATE ../support/xbrz)
 target_link_libraries(garglk PRIVATE xbrz)
 target_link_libraries(garglk-gpl2 PRIVATE xbrz-null)

--- a/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
+++ b/terps/frankendrift/FrankenDrift.GlkRunner/FrankenDrift.GlkRunner.Gargoyle/CMakeLists.txt
@@ -77,6 +77,17 @@ add_custom_command(TARGET frankendrift
     COMMAND ${CMAKE_COMMAND} -E rm "${CMAKE_CURRENT_SOURCE_DIR}/${GARGLK_FRANKEN_DYLIB_NAME}"
 )
 
+# dotnet publishes into this directory, not to a CMake target output
+# directory, so on Windows copy the result next to the rest of the
+# runtime output, where the launcher looks for interpreters.
+if(WIN32)
+    add_custom_command(TARGET frankendrift
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_BINARY_DIR}/FrankenDrift.GlkRunner.Gargoyle${GARGLK_FRANKEN_EXT}"
+            "$<TARGET_FILE_DIR:garglk>"
+    )
+endif()
 
 add_dependencies(frankendrift garglk)
 

--- a/winbuildrelease.ps1
+++ b/winbuildrelease.ps1
@@ -69,19 +69,11 @@ mkdir $stagedir
 Copy-Item "$builddir\*.ttf" "$stagedir"
 Copy-Item "$builddir\*.otf" "$stagedir"
 Copy-Item "$builddir\*.exe" "$stagedir"
-Copy-Item "$builddir\garglk\gargoyle.exe" "$stagedir"
-Copy-Item "$builddir\garglk\*.dll" "$stagedir"
-Copy-Item "$builddir\terps\*.exe" "$stagedir"
-Copy-Item "$builddir\terps\tads\*.exe" "$stagedir"
+Copy-Item "$builddir\*.dll" "$stagedir"
 if ($withPdbs) {
-    Copy-Item "$builddir\garglk\*.pdb" "$stagedir"
-    Copy-Item "$builddir\terps\*.pdb" "$stagedir"
-    Copy-Item "$builddir\terps\tads\*.pdb" "$stagedir"
-}
-
-if ($withFrankendrift) {
-    Copy-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\FrankenDrift.GlkRunner.Gargoyle.exe" "$stagedir"
-    if ($withPdbs) {
+    Copy-Item "$builddir\*.pdb" "$stagedir"
+    if ($withFrankendrift) {
+        # NativeAOT writes its PDB next to the project, not to the build root.
         Copy-Item "$builddir\terps\frankendrift\FrankenDrift.GlkRunner\FrankenDrift.GlkRunner.Gargoyle\*.pdb" "$stagedir"
     }
 }


### PR DESCRIPTION
This allows Windows builds to be run directly from the build directory. It also adds a "deployqt" target so that external DLLs are pulled in. This is a separate step rather than part of the build so that it doesn't run each build, which would slow things down.