### PR TITLE
Clean up how directory handling is done on Windows

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -345,7 +345,6 @@ static void parsecolor(const std::string &str, Color &rgb)
 //        $HOME/.garglkrc (Unix only)
 //        <user settings directory>/Gargoyle (Haiku only)
 //        %APPDATA%/Gargoyle/garglk.ini (Windows only)
-//        <current directory>/garglk.ini (Windows only)
 //        $HOME/garglk.ini (macOS only)
 // 4. $GARGLK_RESOURCES/garglk.ini (macOS only)
 // 5. /etc/garglk.ini (or other location set at build time, Unix only)
@@ -373,17 +372,11 @@ std::vector<garglk::ConfigFile> garglk::configs(const std::optional<std::string>
         configs.emplace_back(Format("{}/Gargoyle", settings_dir), ConfigFile::Type::User);
     }
 #elif defined(_WIN32)
-    // $APPDATA/Gargoyle/garglk.ini (Windows only). This has a higher
-    // priority than $PWD/garglk.ini since it's a more "proper" location.
+    // $APPDATA/Gargoyle/garglk.ini (Windows only).
     const char *appdata = std::getenv("APPDATA");
     if (appdata != nullptr) {
         configs.emplace_back(Format("{}/Gargoyle/garglk.ini", appdata), ConfigFile::Type::User);
     }
-
-    // current directory .ini
-    // Historically this has been the location of garglk.ini on Windows,
-    // so treat it as a user config there.
-    configs.emplace_back("garglk.ini", ConfigFile::Type::User);
 #else
 
     const char *home = std::getenv("HOME");

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -168,23 +168,21 @@ scaler none
 # rather that Gargoyle quit immediately, set this to 0.
 wait_on_quit 1
 
-# By default, Gargoyle will allow the native file picker (Qt or MacOS)
-# to choose which directory to open in when saving and loading files,
-# including save games, transcripts, and generic data files. This may
-# not be the most desirable location. You can instead choose to save
-# either in a centralized save directory or the directory containing the
-# currently-running game.
+# Controls which directory the file dialogs for save games, transcripts,
+# and generic data files open in.
 #
-# If a centralized location is requested, a dedicated directory for each
-# game is created. This will be something like:
+# With "default", Gargoyle doesn't request a directory at all, and the
+# file picker opens wherever it would by default.
+#
+# With "dedicated", a dedicated directory for each game is created and
+# used. This will be something like:
 #
 # $HOME/.local/share/gargoyle/gamedata/zork1.z3/ (Unix)
 # %APPDATA%\Gargoyle\gamedata\zork1.z3\ (Windows)
 # $HOME/Library/Application Support/Gargoyle/gamedata/zork1.z3/ (Mac)
 #
-# To use the default, set this to "default". For a dedicated centralized
-# location, use "dedicated". For the game's containing directory, use
-# "gamedir".
+# With "gamedir", the directory containing the currently-running game is
+# used.
 gamedata_location default
 
 # When opening a game that has supported metadata (a description and/or

--- a/garglk/launchqt.cpp
+++ b/garglk/launchqt.cpp
@@ -37,10 +37,12 @@
 #include <QDir>
 #include <QFile>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QList>
 #include <QMessageBox>
 #include <QProcess>
 #include <QPushButton>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QVector>
@@ -314,6 +316,26 @@ int main(int argc, char **argv)
     garglk::theme::init();
 
     auto story = parse_args(app);
+
+#ifdef _WIN32
+    // Resolve the story path while the working directory it might be
+    // relative to is still current.
+    if (!story.isEmpty()) {
+        story = QFileInfo(story).absoluteFilePath();
+    }
+
+    // On Windows, when started from the start menu, Gargoyle's CWD is
+    // set to the install directory. That means that default file
+    // dialogs open there, which is not a useful location. If the CWD is
+    // in fact there, change dir to the desktop. If the CWD is anywhere
+    // else, assume it's the user's doing and leave it alone.
+    if (QDir::currentPath() == QCoreApplication::applicationDirPath()) {
+        auto desktop = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+        if (!desktop.isEmpty()) {
+            QDir::setCurrent(desktop);
+        }
+    }
+#endif
 
     if (story.isEmpty()) {
         story = winbrowsefile();

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -174,13 +174,11 @@ enum class Action { Open, Save };
 
 static std::string winchoosefile(const QString &prompt, FileFilter filter, Action action)
 {
-    QString filename;
-    QFileDialog::Options options;
-#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
+    QFileDialog dialog(window, prompt);
 
-    QString dir = "";
+#ifdef GARGLK_CONFIG_NO_NATIVE_FILE_DIALOGS
+    dialog.setOption(QFileDialog::DontUseNativeDialog);
+#endif
 
     if (gli_conf_gamedata_location == GamedataLocation::Dedicated && gli_workfile.has_value()) {
         auto path = QFileInfo(QString::fromStdString(*gli_workfile));
@@ -188,22 +186,26 @@ static std::string winchoosefile(const QString &prompt, FileFilter filter, Actio
             QDir basedir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
             QDir savepath = QDir(basedir.filePath("gamedata")).filePath(path.fileName());
             if (savepath.mkpath(savepath.absolutePath())) {
-                dir = savepath.absolutePath();
+                dialog.setDirectory(savepath.absolutePath());
             }
         }
     } else if (gli_conf_gamedata_location == GamedataLocation::Gamedir) {
-        dir = QString::fromStdString(gli_workdir);
+        dialog.setDirectory(QString::fromStdString(gli_workdir));
     }
 
     if (action == Action::Open) {
-        QString filterstring = QString("%1;;All files (*)").arg(filters.at(filter).first);
-        filename = QFileDialog::getOpenFileName(window, prompt, dir, filterstring, nullptr, options);
+        dialog.setAcceptMode(QFileDialog::AcceptOpen);
+        dialog.setFileMode(QFileDialog::ExistingFile);
+        dialog.setNameFilters({filters.at(filter).first, "All files (*)"});
     } else {
-        if (dir == "") {
-            dir += ".";
-        }
-        dir += QString("/Untitled.%1").arg(filters.at(filter).second);
-        filename = QFileDialog::getSaveFileName(window, prompt, dir, filters.at(filter).first, nullptr, options);
+        dialog.setAcceptMode(QFileDialog::AcceptSave);
+        dialog.setNameFilter(filters.at(filter).first);
+        dialog.selectFile(QString("Untitled.%1").arg(filters.at(filter).second));
+    }
+
+    QString filename;
+    if (dialog.exec() == QDialog::Accepted) {
+        filename = dialog.selectedFiles().value(0);
     }
 
     // toStdString() converts to UTF-8, which is not used by Windows (at

--- a/installer.nsi
+++ b/installer.nsi
@@ -99,6 +99,14 @@ Section "DoInstall"
 
     WriteUninstaller "uninstall.exe"
 
+    ; CreateShortCut takes the shortcut's working directory from $OUTDIR,
+    ; which is still plugins\platforms from the SetOutPath above. Reset
+    ; it so that a Gargoyle started from the Start Menu gets the
+    ; installation directory as its working directory: that is the one
+    ; value it can recognize as "nobody chose this", which is what lets
+    ; it relocate to somewhere useful before opening a file dialog.
+    SetOutPath $INSTDIR
+
     !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
 	CreateDirectory "$SMPROGRAMS\$SMFOLDER"
 	CreateShortCut "$SMPROGRAMS\$SMFOLDER\Gargoyle.lnk" "$INSTDIR\gargoyle.exe" "" "$INSTDIR\gargoyle.exe" 0


### PR DESCRIPTION
When launched from the start menu (if the installer was used), Gargoyle's CWD is in a useless location (inside of C:\Program Files). It was even worse before (in Qt's plugins dir), but this change just puts it in Gargoyle's install directory.

However, that means we can detect whether Gargoyle is in its "default" location, and move things around accordingly: we go to the desktop in that case. This at least gives the user a writable location for save files.