### PR TITLE
Allow gamedata_location to name a fixed directory

### DIFF
--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -306,6 +306,7 @@ bool gli_conf_safeclicks = false;
 bool gli_conf_per_game_config = true;
 
 GamedataLocation gli_conf_gamedata_location = GamedataLocation::Default;
+std::string gli_conf_gamedata_dir;
 
 Scaler gli_conf_scaler = Scaler::None;
 
@@ -625,6 +626,26 @@ constexpr const T &config_atleast(const T &value, const T &min)
     return value;
 }
 
+// gamedata_location is a bit odd in that it takes fixed atoms/strings,
+// but _also_ can be given an absolute path to a directory. As long as
+// the normal atoms never contain a directory separator, they won't
+// clash, even if it does feel sloppy. This function checks whether a
+// value is an absolute path and thus a candidate for a "fixed" location.
+static bool is_gamedata_path(const std::string &path)
+{
+    // libstdc++ (at least with gcc 14) doesn't parse UNC paths: both
+    // \\server\share and //server/share are _not_ considered absolute.
+    // These should be absolute (libc++ and MSVC both get this right),
+    // so for libstdc++, short-circuit and do a simple check here.
+#if defined(_WIN32) && defined(__GLIBCXX__)
+    if (path.rfind("\\\\", 0) == 0 || path.rfind("//", 0) == 0) {
+        return true;
+    }
+#endif
+
+    return std::filesystem::path(path).is_absolute();
+}
+
 static void readoneconfig(const std::string &fname, const std::string &argv0, const std::optional<std::string> &gamefile)
 {
     std::vector<std::string> matches = {argv0};
@@ -914,8 +935,11 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                     gli_conf_gamedata_location = GamedataLocation::Dedicated;
                 } else if (arg == "gamedir") {
                     gli_conf_gamedata_location = GamedataLocation::Gamedir;
+                } else if (is_gamedata_path(arg)) {
+                    gli_conf_gamedata_location = GamedataLocation::Fixed;
+                    gli_conf_gamedata_dir = arg;
                 } else {
-                    throw ConfigError(Format("unknown gamedata location: {}", arg));
+                    throw ConfigError(Format("unknown gamedata location: {} (must be default, dedicated, gamedir, or an absolute path)", arg));
                 }
             } else if (cmd == "game_info") {
                 if (arg == "never") {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -688,9 +688,13 @@ enum class GamedataLocation {
     Default,
     Dedicated,
     Gamedir,
+    Fixed,
 };
 
 extern GamedataLocation gli_conf_gamedata_location;
+
+// Only meaningful when gli_conf_gamedata_location is Fixed.
+extern std::string gli_conf_gamedata_dir;
 
 enum class Scaler {
     None,

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -183,6 +183,8 @@ wait_on_quit 1
 #
 # With "gamedir", the directory containing the currently-running game is
 # used.
+#
+# With an existing absolute path, that directory is used for every game.
 gamedata_location default
 
 # When opening a game that has supported metadata (a description and/or

--- a/garglk/sysmac.mm
+++ b/garglk/sysmac.mm
@@ -186,6 +186,8 @@ static NSString *get_savedir(FileFilter filter)
         return [NSString stringWithUTF8String: gli_workfile->c_str()];
     } else if (gli_conf_gamedata_location == GamedataLocation::Gamedir) {
         return [NSString stringWithUTF8String: gli_workdir.c_str()];
+    } else if (gli_conf_gamedata_location == GamedataLocation::Fixed) {
+        return [NSString stringWithUTF8String: gli_conf_gamedata_dir.c_str()];
     }
 
     return nil;

--- a/garglk/sysqt.cpp
+++ b/garglk/sysqt.cpp
@@ -191,6 +191,8 @@ static std::string winchoosefile(const QString &prompt, FileFilter filter, Actio
         }
     } else if (gli_conf_gamedata_location == GamedataLocation::Gamedir) {
         dialog.setDirectory(QString::fromStdString(gli_workdir));
+    } else if (gli_conf_gamedata_location == GamedataLocation::Fixed) {
+        dialog.setDirectory(QString::fromStdString(gli_conf_gamedata_dir));
     }
 
     if (action == Action::Open) {


### PR DESCRIPTION
In addition to the existing "default", "gamedata", and "dedicated", a fixed directory can be used. It must be provided as an absolute path. This mixing of atoms & paths is a bit unclean, but there's no perfect solution.