### PR TITLE
Support loading of X11 fonts via XLFDs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,6 +101,14 @@ In addition, Gargoyle supports the following options:
   configuration directory. Defaults to false. Available only on non-Apple Unix
   platforms.
 
+- `WITH_X11_FONTS`: If true (the default), support naming fonts by X Logical
+  Font Description, as with `monoxfont` in `garglk.ini`. This reads `fonts.dir`
+  out of font directories and needs no X server, but a system with no X11 fonts
+  has no use for it. `X11_FONT_DIR` sets the directory tree scanned for them
+  (`/usr/share/fonts` by default), and `X11_FS_CONFIG` the X font server
+  configuration read for a font catalogue (`/etc/X11/fs/config`). Available only
+  on non-Apple Unix platforms.
+
 - `WITH_KDE`: If true, KDE Frameworks will be used.
 
 - `WITH_TTS`: Takes one of four values: "ON", "OFF", "AUTO", or "DYNAMIC".

--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -9,6 +9,7 @@ option(WITH_BUNDLED_FMT "Use Gargoyle's bundled fmt library instead of the syste
 
 if(UNIX AND NOT APPLE)
     option(WITH_FREEDESKTOP "Install freedesktop.org application, icon, and MIME files" ON)
+    option(WITH_X11_FONTS "Support naming fonts by X Logical Font Description" ON)
     set(GARGLKINI "${CMAKE_INSTALL_FULL_SYSCONFDIR}/garglk.ini")
     if(NOT APPIMAGE)
         option(INSTALL_GARGLKINI "Install an example config file to ${GARGLKINI}" OFF)
@@ -421,6 +422,16 @@ elseif(UNIX)
     pkg_check_modules(FONTCONFIG REQUIRED IMPORTED_TARGET fontconfig)
     target_sources(garglk-common PRIVATE fontfc.cpp)
     target_link_libraries(garglk-common PRIVATE PkgConfig::FONTCONFIG)
+
+    if(WITH_X11_FONTS)
+        set(X11_FONT_DIR "/usr/share/fonts" CACHE STRING "Directory tree to scan for X11 fonts (fonts.dir)")
+        set(X11_FS_CONFIG "/etc/X11/fs/config" CACHE STRING "X font server config to read a font catalogue from")
+        target_sources(garglk-common PRIVATE fontx11.cpp)
+        target_compile_definitions(garglk-common PRIVATE
+            GARGLK_CONFIG_X11FONTS
+            X11_FONT_DIR="${X11_FONT_DIR}"
+            X11_FS_CONFIG="${X11_FS_CONFIG}")
+    endif()
 elseif(WIN32)
     target_sources(garglk-common PRIVATE fontwin.cpp)
     target_link_libraries(garglk-common PRIVATE winmm shlwapi)

--- a/garglk/config.cpp
+++ b/garglk/config.cpp
@@ -157,6 +157,8 @@ double gli_zoom = 1.0;
 FontFiles gli_conf_prop, gli_conf_mono;
 
 std::string gli_conf_monofont = DEFAULT_MONO_FONT;
+std::optional<std::string> gli_conf_propxfont;
+std::optional<std::string> gli_conf_monoxfont;
 std::string gli_conf_propfont = DEFAULT_PROP_FONT;
 double gli_conf_monosize = 12.6; // good size for Gargoyle Mono
 double gli_conf_propsize = 14.7; // good size for Gargoyle Serif
@@ -707,6 +709,12 @@ static void readoneconfig(const std::string &fname, const std::string &argv0, co
                 gli_conf_prop.z.override = arg;
             } else if (cmd == "propfont") {
                 gli_conf_propfont = arg;
+            } else if (cmd == "monoxfont" || cmd == "propxfont") {
+#ifdef GARGLK_CONFIG_X11FONTS
+                (cmd[0] == 'm' ? gli_conf_monoxfont : gli_conf_propxfont) = arg;
+#else
+                throw ConfigError("X11 fonts are not supported on this platform");
+#endif
             } else if (cmd == "leading") {
                 gli_leading = config_atleast(parse_int(arg), 1);
             } else if (cmd == "baseline") {

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -32,6 +32,7 @@
 
 #include "format.h"
 
+#include "font.h"
 #include "glk.h"
 #include "garglk.h"
 
@@ -57,8 +58,6 @@ using namespace std::literals;
 #define mul255(a, b) ((static_cast<short>(a) * (b) + 127) / 255)
 #define mulhigh(a, b) ((static_cast<int>(a) * (b) + (1 << (GAMMA_BITS - 1)) - 1) / GAMMA_MAX)
 #define grayscale(r, g, b) ((30 * (r) + 59 * (g) + 11 * (b)) / 100)
-
-static std::string convert_ft_error(FT_Error err, const std::string &basemsg);
 
 namespace {
 
@@ -88,7 +87,7 @@ public:
     public:
         LoadError(FT_Error err, std::string filename, const std::string &basemsg) :
             m_filename(std::move(filename)),
-            m_what(convert_ft_error(err, basemsg))
+            m_what(garglk::convert_ft_error(err, basemsg))
         {
         }
 
@@ -172,24 +171,6 @@ bool garglk::set_lcdfilter(const std::string &filter)
 //
 // Font loading
 //
-
-static std::string convert_ft_error(FT_Error err, const std::string &basemsg)
-{
-    // FT_Error_String() was introduced in FreeType 2.10.0.
-#if FREETYPE_MAJOR == 2 && FREETYPE_MINOR < 10
-    const char *errstr = nullptr;
-#else
-    // If FreeType was not built with FT_CONFIG_OPTION_ERROR_STRINGS,
-    // this will always be null.
-    const char *errstr = FT_Error_String(err);
-#endif
-
-    if (errstr == nullptr) {
-        return Format("{} (error code {})", basemsg, err);
-    } else {
-        return Format("{}: {}", basemsg, errstr);
-    }
-}
 
 namespace {
 
@@ -310,7 +291,7 @@ FontEntry Font::getglyph(glui32 cid)
 
         err = FT_Load_Glyph(m_face.get(), gid, load_flags);
         if (err != 0) {
-            throw std::runtime_error(convert_ft_error(err, "FT_Load_Glyph"));
+            throw std::runtime_error(garglk::convert_ft_error(err, "FT_Load_Glyph"));
         }
 
         // A bitmap-only font ignores FT_LOAD_NO_BITMAP, so this can be a
@@ -340,7 +321,7 @@ FontEntry Font::getglyph(glui32 cid)
         }
 
         if (err != 0) {
-            throw std::runtime_error(convert_ft_error(err, "FT_Render_Glyph"));
+            throw std::runtime_error(garglk::convert_ft_error(err, "FT_Render_Glyph"));
         }
 
         const FT_Bitmap *bitmap = &m_face->glyph->bitmap;
@@ -352,7 +333,7 @@ FontEntry Font::getglyph(glui32 cid)
         if (bitmap->pixel_mode != FT_PIXEL_MODE_GRAY && bitmap->pixel_mode != FT_PIXEL_MODE_LCD) {
             err = FT_Bitmap_Convert(ftlib, bitmap, converted.get(), 1);
             if (err != 0) {
-                throw std::runtime_error(convert_ft_error(err, "FT_Bitmap_Convert"));
+                throw std::runtime_error(garglk::convert_ft_error(err, "FT_Bitmap_Convert"));
             }
 
             bitmap = converted.get();
@@ -571,7 +552,7 @@ void gli_initialize_fonts()
 
     err = FT_Init_FreeType(&ftlib);
     if (err != 0) {
-        garglk::winabort(convert_ft_error(err, "Unable to initialize FreeType"));
+        garglk::winabort(garglk::convert_ft_error(err, "Unable to initialize FreeType"));
     }
 
     std::vector<std::string> problem_fonts;
@@ -603,10 +584,54 @@ void gli_initialize_fonts()
     // "built-in/fallback fonts", but with existing configs out there,
     // it's not meant to be.
     fontload();
-    if (!garglk::fontreplace(gli_conf_monofont, FontType::Monospace) && gli_conf_monofont != DEFAULT_MONO_FONT) {
+
+    bool mono_found = false;
+    bool prop_found = false;
+
+#ifdef GARGLK_CONFIG_X11FONTS
+    // monoxfont and propxfont use XLFD names instead of fontconfig.
+    if (gli_conf_monoxfont.has_value() || gli_conf_propxfont.has_value()) {
+        if (!garglk::x11_fonts_available()) {
+            problem_fonts.emplace_back("No X11 fonts were found on this system, so monoxfont and propxfont can't be used.");
+        }
+    }
+
+    auto use_xfont = [&problem_fonts](const std::string &xlfd, FontType type) {
+        const char *what = type == FontType::Monospace ? "monospace" : "proportional";
+        const char *setting = type == FontType::Monospace ? "monofont" : "propfont";
+
+        auto result = garglk::fontreplace_x11(xlfd, type);
+        switch (result.status) {
+        case garglk::XFontResult::Status::Loaded:
+            return true;
+        case garglk::XFontResult::Status::NoMatch:
+            problem_fonts.push_back(Format("No X11 {} font matches \"{}\", falling back to {}.", what, xlfd, setting));
+            break;
+        case garglk::XFontResult::Status::Unusable:
+            problem_fonts.push_back(Format("X11 {} font \"{}\" can't be loaded ({}), falling back to {}.", what, xlfd, result.reason, setting));
+            break;
+        }
+
+        return false;
+    };
+
+    if (gli_conf_monoxfont.has_value()) {
+        mono_found = use_xfont(*gli_conf_monoxfont, FontType::Monospace);
+    }
+
+    if (gli_conf_propxfont.has_value()) {
+        prop_found = use_xfont(*gli_conf_propxfont, FontType::Proportional);
+    }
+#endif
+
+    if (!mono_found &&
+        !garglk::fontreplace(gli_conf_monofont, FontType::Monospace) && gli_conf_monofont != DEFAULT_MONO_FONT)
+    {
         problem_fonts.push_back(Format("Unable to find monospace font \"{}\", using fallback.", gli_conf_monofont));
     }
-    if (!garglk::fontreplace(gli_conf_propfont, FontType::Proportional) && gli_conf_propfont != DEFAULT_PROP_FONT) {
+    if (!prop_found &&
+        !garglk::fontreplace(gli_conf_propfont, FontType::Proportional) && gli_conf_propfont != DEFAULT_PROP_FONT)
+    {
         problem_fonts.push_back(Format("Unable to find proportional font \"{}\", using fallback.", gli_conf_propfont));
     }
     fontunload();
@@ -788,7 +813,7 @@ int Font::charkern(glui32 c0, glui32 c1)
 
     err = FT_Get_Kerning(m_face.get(), g0, g1, FT_KERNING_UNFITTED, &v);
     if (err != 0) {
-        throw std::runtime_error(convert_ft_error(err, "FT_Get_Kerning"));
+        throw std::runtime_error(garglk::convert_ft_error(err, "FT_Get_Kerning"));
     }
 
     int value = (v.x * GLI_SUBPIX) / 64.0;

--- a/garglk/font.h
+++ b/garglk/font.h
@@ -5,7 +5,34 @@
 #include <optional>
 #include <unordered_map>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+#include "format.h"
+
 #include "garglk.h"
+
+namespace garglk {
+
+inline std::string convert_ft_error(FT_Error err, const std::string &basemsg)
+{
+    // FT_Error_String() was introduced in FreeType 2.10.0.
+#if FREETYPE_MAJOR == 2 && FREETYPE_MINOR < 10
+    const char *errstr = nullptr;
+#else
+    // If FreeType was not built with FT_CONFIG_OPTION_ERROR_STRINGS,
+    // this will always be null.
+    const char *errstr = FT_Error_String(err);
+#endif
+
+    if (errstr == nullptr) {
+        return Format("{} (error code {})", basemsg, err);
+    } else {
+        return Format("{}: {}", basemsg, errstr);
+    }
+}
+
+}
 
 class FontFiller {
 public:

--- a/garglk/fontx11.cpp
+++ b/garglk/fontx11.cpp
@@ -1,0 +1,565 @@
+// Copyright (C) 2026 by Chris Spiegel.
+//
+// This file is part of Gargoyle.
+//
+// Gargoyle is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// Gargoyle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Gargoyle; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+// Look fonts up by X Logical Font Description, e.g.
+//
+//     -misc-fixed-medium-r-normal--14-130-75-75-c-70-iso8859-1
+//
+// This reads fonts.dir and fonts.alias directly, so no X server is needed.
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
+#include "format.h"
+
+#include "font.h"
+#include "glk.h"
+#include "garglk.h"
+
+namespace {
+
+// An XLFD is 14 fields, each introduced by a hyphen:
+//
+// -foundry-family-weight-slant-setwidth-addstyle-pixelsize-pointsize-resx-resy-spacing-avgwidth-registry-encoding
+constexpr std::size_t XLFD_FIELDS = 14;
+constexpr std::size_t XLFD_WEIGHT = 2;
+constexpr std::size_t XLFD_SLANT = 3;
+constexpr std::size_t XLFD_PIXELSIZE = 6;
+constexpr std::size_t XLFD_AVGWIDTH = 11;
+constexpr std::size_t XLFD_REGISTRY = 12;
+
+using XlfdFields = std::array<std::string, XLFD_FIELDS>;
+
+struct XFont {
+    // Keep both forms: matching uses the full name; ranking uses its fields.
+    std::string xlfd;
+    XlfdFields fields;
+    // Bitmap size from the XLFD.
+    int size;
+    std::string path;
+    // Position in the font path, including order within each directory.
+    std::size_t order;
+};
+
+std::vector<XFont> xfonts;
+std::vector<std::pair<std::string, std::string>> xaliases;
+
+std::string trim(const std::string &s)
+{
+    auto start = s.find_first_not_of(" \t\r");
+    if (start == std::string::npos) {
+        return "";
+    }
+
+    return s.substr(start, s.find_last_not_of(" \t\r") - start + 1);
+}
+
+// XLFD globs are case-insensitive and may span fields.
+bool xlfd_match(const std::string &pattern, const std::string &name)
+{
+    std::size_t p = 0, n = 0, star = std::string::npos, retry = 0;
+
+    while (n < name.size()) {
+        if (p < pattern.size() && (pattern[p] == '?' || pattern[p] == name[n])) {
+            p++;
+            n++;
+        } else if (p < pattern.size() && pattern[p] == '*') {
+            star = p++;
+            retry = n;
+        } else if (star != std::string::npos) {
+            p = star + 1;
+            n = ++retry;
+        } else {
+            return false;
+        }
+    }
+
+    while (p < pattern.size() && pattern[p] == '*') {
+        p++;
+    }
+
+    return p == pattern.size();
+}
+
+std::optional<XlfdFields> xlfd_fields(const std::string &xlfd)
+{
+    if (xlfd.empty() || xlfd[0] != '-') {
+        return std::nullopt;
+    }
+
+    XlfdFields fields;
+    std::size_t count = 0;
+    std::size_t start = 1;
+    for (std::size_t i = 1; i <= xlfd.size(); i++) {
+        if (i == xlfd.size() || xlfd[i] == '-') {
+            if (count == XLFD_FIELDS) {
+                return std::nullopt;
+            }
+
+            fields[count++] = xlfd.substr(start, i - start);
+            start = i + 1;
+        }
+    }
+
+    if (count != XLFD_FIELDS) {
+        return std::nullopt;
+    }
+
+    return fields;
+}
+
+// A zero pixel size denotes a scalable font.
+std::optional<int> pixelsize(const XlfdFields &fields)
+{
+    try {
+        int size = std::stoi(fields[XLFD_PIXELSIZE]);
+        if (size > 0) {
+            return size;
+        }
+    } catch (const std::exception &) {
+    }
+
+    return std::nullopt;
+}
+
+std::string xlfd_join(const XlfdFields &fields)
+{
+    std::string xlfd;
+    for (const auto &field : fields) {
+        xlfd += "-" + field;
+    }
+
+    return xlfd;
+}
+
+// Sort the results to make lookup order stable.
+std::vector<std::string> directories_under(const std::string &root)
+{
+    namespace fs = std::filesystem;
+
+    std::vector<std::string> found;
+    std::error_code ec;
+
+    fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, ec);
+    for (fs::recursive_directory_iterator end; !ec && it != end; it.increment(ec)) {
+        if (it->path().filename() == "fonts.dir") {
+            found.push_back(it->path().parent_path().string());
+        }
+    }
+
+    std::sort(found.begin(), found.end());
+
+    return found;
+}
+
+// Names and aliases may occur in more than one directory, so search order
+// matters. Start with the font server catalogue, then user and system fonts.
+// Reading the files directly keeps lookup independent of an X display.
+std::vector<std::string> font_directories()
+{
+    std::vector<std::string> dirs;
+
+    std::ifstream f(X11_FS_CONFIG);
+    std::string line;
+    std::string catalogue;
+    while (std::getline(f, line)) {
+        line = trim(line);
+        if (catalogue.empty()) {
+            if (line.compare(0, 9, "catalogue") != 0) {
+                continue;
+            }
+
+            auto equals = line.find('=');
+            if (equals == std::string::npos) {
+                continue;
+            }
+
+            catalogue = trim(line.substr(equals + 1));
+        } else {
+            catalogue += line;
+        }
+
+        // A trailing comma continues the catalogue on the next line.
+        if (catalogue.empty() || catalogue.back() != ',') {
+            break;
+        }
+    }
+
+    std::size_t start = 0;
+    while (start <= catalogue.size() && !catalogue.empty()) {
+        auto comma = catalogue.find(',', start);
+        auto dir = trim(catalogue.substr(start, comma - start));
+
+        // Font path entries may be decorated, as in "/usr/share/fonts:unscaled".
+        auto colon = dir.find(':');
+        if (colon != std::string::npos) {
+            dir = dir.substr(0, colon);
+        }
+
+        while (dir.size() > 1 && dir.back() == '/') {
+            dir.pop_back();
+        }
+
+        if (!dir.empty() && dir[0] == '/') {
+            dirs.push_back(dir);
+        }
+
+        if (comma == std::string::npos) {
+            break;
+        }
+
+        start = comma + 1;
+    }
+
+    std::vector<std::string> roots;
+
+    const char *home = std::getenv("HOME");
+    if (home != nullptr) {
+        const char *xdg = std::getenv("XDG_DATA_HOME");
+        roots.push_back(Format("{}/.fonts", home));
+        roots.push_back(xdg != nullptr ? Format("{}/fonts", xdg)
+                                       : Format("{}/.local/share/fonts", home));
+    }
+
+    roots.emplace_back(X11_FONT_DIR);
+
+    for (const auto &root : roots) {
+        auto found = directories_under(root);
+        dirs.insert(dirs.end(), found.begin(), found.end());
+    }
+
+    std::vector<std::string> unique;
+    for (const auto &dir : dirs) {
+        if (std::find(unique.begin(), unique.end(), dir) == unique.end()) {
+            unique.push_back(dir);
+        }
+    }
+
+    return unique;
+}
+
+// XLFDs may contain spaces, so the second field runs to end of line. Either
+// field may be quoted, and backslashes escape the following character.
+std::optional<std::string> read_field(const std::string &line, std::size_t &pos, bool to_end)
+{
+    while (pos < line.size() && (line[pos] == ' ' || line[pos] == '\t')) {
+        pos++;
+    }
+
+    if (pos == line.size()) {
+        return std::nullopt;
+    }
+
+    bool quoted = line[pos] == '"';
+    if (quoted) {
+        pos++;
+    }
+
+    std::string field;
+    for (; pos < line.size(); pos++) {
+        if (line[pos] == '\\' && pos + 1 < line.size()) {
+            field.push_back(line[++pos]);
+        } else if (quoted) {
+            if (line[pos] == '"') {
+                pos++;
+                break;
+            }
+
+            field.push_back(line[pos]);
+        } else if (!to_end && (line[pos] == ' ' || line[pos] == '\t')) {
+            break;
+        } else {
+            field.push_back(line[pos]);
+        }
+    }
+
+    field = trim(field);
+    if (field.empty()) {
+        return std::nullopt;
+    }
+
+    return field;
+}
+
+// Parse a name/XLFD pair, ignoring blank, comment, and malformed lines.
+std::optional<std::pair<std::string, std::string>> split_entry(const std::string &line)
+{
+    auto entry = trim(line);
+    if (entry.empty() || entry[0] == '!') {
+        return std::nullopt;
+    }
+
+    std::size_t pos = 0;
+    auto name = read_field(entry, pos, false);
+    auto xlfd = read_field(entry, pos, true);
+
+    if (!name.has_value() || !xlfd.has_value()) {
+        return std::nullopt;
+    }
+
+    return std::pair(*name, garglk::downcase(*xlfd));
+}
+
+void load_directory(const std::string &dir)
+{
+    std::ifstream fontsdir(dir + "/fonts.dir");
+    std::string line;
+
+    // The first line is a count of the entries that follow.
+    if (std::getline(fontsdir, line)) {
+        while (std::getline(fontsdir, line)) {
+            auto entry = split_entry(line);
+            if (!entry.has_value()) {
+                continue;
+            }
+
+            const auto &[file, xlfd] = *entry;
+
+            auto fields = xlfd_fields(xlfd);
+            if (!fields.has_value()) {
+                continue;
+            }
+
+            // XLFD lookup is for bitmap fonts; fontconfig handles scalable fonts.
+            auto size = pixelsize(*fields);
+            if (size.has_value()) {
+                xfonts.push_back({xlfd, *fields, *size, Format("{}/{}", dir, file), xfonts.size()});
+            }
+        }
+    }
+
+    std::ifstream fontsalias(dir + "/fonts.alias");
+    while (std::getline(fontsalias, line)) {
+        auto entry = split_entry(line);
+        if (entry.has_value()) {
+            const auto &[alias, xlfd] = *entry;
+            xaliases.emplace_back(garglk::downcase(alias), xlfd);
+        }
+    }
+}
+
+void load_fonts()
+{
+    static bool loaded = false;
+
+    if (loaded) {
+        return;
+    }
+
+    loaded = true;
+
+    for (const auto &dir : font_directories()) {
+        load_directory(dir);
+    }
+}
+
+// Prefer encodings FreeType exposes through a Unicode charmap. Broad patterns
+// may otherwise select a JIS font before a usable Latin one.
+int encoding_rank(const XlfdFields &fields)
+{
+    if (fields[XLFD_REGISTRY] == "iso10646") {
+        return 0;
+    } else if (fields[XLFD_REGISTRY] == "iso8859") {
+        return 1;
+    } else {
+        return 2;
+    }
+}
+
+// Reject unusable matches before their bitmap size can affect fallback text.
+std::optional<std::string> font_is_unusable(const XFont &xfont, FontType type)
+{
+    FT_Library ftlib;
+    FT_Error err = FT_Init_FreeType(&ftlib);
+    if (err != 0) {
+        return garglk::convert_ft_error(err, "FT_Init_FreeType");
+    }
+
+    std::optional<std::string> reason;
+    FT_Face face;
+
+    err = FT_New_Face(ftlib, xfont.path.c_str(), 0, &face);
+    if (err != 0) {
+        reason = garglk::convert_ft_error(err, "FT_New_Face");
+    } else {
+        double aspect = type == FontType::Monospace ? gli_conf_monoaspect : gli_conf_propaspect;
+        err = FT_Set_Char_Size(face, xfont.size * aspect * 64, xfont.size * 64, 72, 72);
+        if (err != 0) {
+            reason = garglk::convert_ft_error(err, "FT_Set_Char_Size");
+        } else {
+            err = FT_Select_Charmap(face, FT_ENCODING_UNICODE);
+            if (err != 0) {
+                reason = garglk::convert_ft_error(err, "FT_Select_Charmap");
+            }
+        }
+
+        FT_Done_Face(face);
+    }
+
+    FT_Done_FreeType(ftlib);
+
+    return reason;
+}
+
+// Distinguish no match from matches that FreeType could not load.
+struct Lookup {
+    const XFont *font = nullptr;
+    bool matched = false;
+    std::string reason;
+};
+
+Lookup find_xfont(const std::string &name, FontType type)
+{
+    auto pattern = garglk::downcase(trim(name));
+
+    // Aliases may chain or resolve to patterns.
+    for (int hop = 0; hop < 5; hop++) {
+        auto alias = std::find_if(xaliases.begin(), xaliases.end(), [&pattern](const auto &entry) {
+            return entry.first == pattern;
+        });
+
+        if (alias == xaliases.end()) {
+            break;
+        }
+
+        pattern = alias->second;
+    }
+
+    // Prefer usable encodings, then preserve font-path order.
+    auto rank = [](const XFont *xfont) {
+        return std::pair(encoding_rank(xfont->fields), xfont->order);
+    };
+
+    std::vector<const XFont *> matches;
+    for (const auto &xfont : xfonts) {
+        if (xlfd_match(pattern, xfont.xlfd)) {
+            matches.push_back(&xfont);
+        }
+    }
+
+    std::sort(matches.begin(), matches.end(), [&rank](const XFont *a, const XFont *b) {
+        return rank(a) < rank(b);
+    });
+
+    Lookup lookup;
+    lookup.matched = !matches.empty();
+
+    for (const auto *match : matches) {
+        auto unusable = font_is_unusable(*match, type);
+        if (!unusable.has_value()) {
+            lookup.font = match;
+            break;
+        }
+
+        // Report the best-ranked failure.
+        if (lookup.reason.empty()) {
+            lookup.reason = *unusable;
+        }
+    }
+
+    return lookup;
+}
+
+// Ask for the same font in another weight or slant. The average width is
+// wildcarded because a bold face is often wider than its regular.
+std::optional<XFont> find_styled(XlfdFields fields, const std::string &weight, const std::string &slant, FontType type)
+{
+    fields[XLFD_WEIGHT] = weight;
+    fields[XLFD_SLANT] = slant;
+    fields[XLFD_AVGWIDTH] = "*";
+
+    auto lookup = find_xfont(xlfd_join(fields), type);
+    if (lookup.font == nullptr) {
+        return std::nullopt;
+    }
+
+    return *lookup.font;
+}
+
+}
+
+bool garglk::x11_fonts_available()
+{
+    load_fonts();
+
+    return !xfonts.empty();
+}
+
+garglk::XFontResult garglk::fontreplace_x11(const std::string &xlfd, FontType type)
+{
+    load_fonts();
+
+    auto lookup = find_xfont(xlfd, type);
+    if (lookup.font == nullptr) {
+        if (lookup.matched) {
+            return {XFontResult::Status::Unusable, lookup.reason};
+        }
+
+        return {XFontResult::Status::NoMatch, ""};
+    }
+
+    const XFont &regular = *lookup.font;
+
+    const auto &regular_weight = regular.fields[XLFD_WEIGHT];
+
+    FontFiller filler(type);
+
+    filler.add(FontFiller::Style::Regular, regular.path);
+
+    auto styled = [&regular, type](const std::string &weight, const std::vector<std::string> &slants) -> std::optional<std::string> {
+        for (const auto &slant : slants) {
+            auto found = find_styled(regular.fields, weight, slant, type);
+            if (found.has_value() && found->path != regular.path) {
+                return found->path;
+            }
+        }
+
+        return std::nullopt;
+    };
+
+    // "i" is a true italic and "o" an oblique; X fonts use both.
+    std::vector<std::string> upright = {"r"};
+    std::vector<std::string> italic = {"i", "o"};
+
+    filler.add(FontFiller::Style::Bold, styled("bold", upright));
+    filler.add(FontFiller::Style::Italic, styled(regular_weight, italic));
+    filler.add(FontFiller::Style::BoldItalic, styled("bold", italic));
+
+    if (!filler.fill()) {
+        return {XFontResult::Status::Unusable, ""};
+    }
+
+    // Bitmap font size comes from the XLFD, not monosize or propsize.
+    if (type == FontType::Monospace) {
+        gli_conf_monosize = regular.size;
+    } else {
+        gli_conf_propsize = regular.size;
+    }
+
+    return {XFontResult::Status::Loaded, ""};
+}

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -175,6 +175,17 @@ void show_game_info(const GameInfo &info, bool show_once);
 std::optional<GameInfo> get_game_info(std::string filename);
 std::string downcase(const std::string &string);
 bool fontreplace(const std::string &font, FontType type);
+
+// The reason is set only when matching fonts cannot be loaded.
+struct XFontResult {
+    enum class Status { Loaded, NoMatch, Unusable };
+
+    Status status;
+    std::string reason;
+};
+
+XFontResult fontreplace_x11(const std::string &xlfd, FontType type);
+bool x11_fonts_available();
 std::vector<ConfigFile> configs(const std::optional<std::string> &gamepath);
 void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, const std::function<void(const std::string &cmd, const std::string &arg, int lineno)> &callback);
 std::string user_config();
@@ -668,6 +679,8 @@ extern std::string gli_conf_propfont;
 extern FontFiles gli_conf_prop;
 extern std::string gli_conf_monofont;
 extern FontFiles gli_conf_mono;
+extern std::optional<std::string> gli_conf_propxfont;
+extern std::optional<std::string> gli_conf_monoxfont;
 
 extern double gli_conf_gamma;
 extern double gli_conf_propsize;

--- a/garglk/garglk.ini
+++ b/garglk/garglk.ini
@@ -208,6 +208,29 @@ monosize      12.6
 propfont      Gargoyle Serif
 propsize      14.7
 
+# On non-Apple Unix, monoxfont and propxfont accept X Logical Font Descriptions
+# (XLFDs). Gargoyle reads fonts.dir and fonts.alias directly; no X server is
+# needed. It searches the font server catalogue first, then user font
+# directories, then the system font tree selected at build time.
+#
+# Wildcards and aliases are accepted:
+#
+# monoxfont   -misc-fixed-medium-r-normal--14-130-75-75-c-70-iso10646-1
+# monoxfont   -*-fixed-medium-r-normal--14-*
+# monoxfont   9x15
+#
+# Gargoyle looks for matching bold and italic faces and synthesizes any missing
+# styles.
+#
+# XLFD lookup uses only bitmap fonts. Their size comes from the XLFD, so these
+# settings ignore monosize, propsize, and zoom. Use monofont and propfont for
+# scalable fonts.
+#
+# If an XLFD font cannot be used, Gargoyle falls back to monofont or propfont.
+
+# monoxfont   -misc-fixed-medium-r-normal--14-130-75-75-c-70-iso10646-1
+# propxfont   -adobe-helvetica-medium-r-normal--14-140-75-75-p-77-iso8859-1
+
 wmarginx      20              # space around the window frame
 wmarginy      20
 wpaddingx     0               # space between windows


### PR DESCRIPTION
monoxfont and propxfont name a font the way X11 named them before fontconfig existed:

    monoxfont -misc-fixed-medium-r-normal--14-130-75-75-c-70-iso10646-1

This does not require an X server, but does require bitmap fonts (e.g. PCF). There is probably no real use-case for these fonts but it became impossible NOT to support them now that anti-aliasing can be turned off and bitmap strikes can be used.

While it doesn't use an X server to load fonts, this is still gated to non-Mac Unix, mainly because that's where X fonts will likely have a fighting chance of existing and, maybe more importantly, probably the only place where the handful of people who might even THINK about using this feature still inhabit.