### PR TITLE
Add a Dockerfile for cross-compiling MinGW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM amd64/ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq && apt-get install -y -qq \
+    build-essential cmake dos2unix git libarchive-tools \
+    nsis p7zip-full pkg-config unzip wget zip ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG ARCH=x86_64
+ARG UBUNTU=24.04
+ARG LLVM_MINGW=20260616
+ARG LLVM_MINGW_HOST=msvcrt-ubuntu-22.04-x86_64
+ARG ASSET_RELEASE=mingw-llvm-24.04
+
+RUN mkdir -p /usr/llvm-mingw \
+ && wget -q https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW}/llvm-mingw-${LLVM_MINGW}-${LLVM_MINGW_HOST}.tar.xz \
+ && bsdtar --strip-components 1 -x -f llvm-mingw-${LLVM_MINGW}-${LLVM_MINGW_HOST}.tar.xz -C /usr/llvm-mingw \
+ && rm llvm-mingw-${LLVM_MINGW}-${LLVM_MINGW_HOST}.tar.xz \
+ && rm -rf /usr/llvm-mingw/${ARCH}-w64-mingw32/include \
+ && cp -a /usr/llvm-mingw/generic-w64-mingw32/include /usr/llvm-mingw/${ARCH}-w64-mingw32/ \
+ && assets=https://github.com/garglk/assets/releases/download/${ASSET_RELEASE} \
+ && wget -q ${assets}/mingw-llvm-${ARCH}-${UBUNTU}.tar.xz \
+ && bsdtar xf mingw-llvm-${ARCH}-${UBUNTU}.tar.xz -C /usr/llvm-mingw \
+ && rm mingw-llvm-${ARCH}-${UBUNTU}.tar.xz \
+ && wget -q ${assets}/mingw-llvm-host-qt6-${UBUNTU}.tar.xz \
+ && bsdtar xf mingw-llvm-host-qt6-${UBUNTU}.tar.xz -C /usr/llvm-mingw \
+ && rm mingw-llvm-host-qt6-${UBUNTU}.tar.xz \
+ && mkdir NSIS && cd NSIS \
+ && wget -q https://nsis.sourceforge.io/mediawiki/images/7/78/FontName-0.7.zip \
+ && unzip -q FontName-0.7.zip \
+ && 7z x -bb3 FontName-0.7.exe \
+ && mkdir -p /usr/share/nsis/Include /usr/share/nsis/Plugins/x86-ansi \
+ && for inc in Include/*; do iconv -f CP1251 -t UTF8 "${inc}" -o "/usr/share/nsis/Include/$(basename "${inc}")"; done \
+ && cp Plugins/FontName.dll /usr/share/nsis/Plugins/x86-ansi \
+ && cd .. && rm -rf NSIS
+
+WORKDIR /src

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -424,6 +424,27 @@ Releases are created with the `windows.sh` script, which builds Gargoyle with
 MinGW and then creates an installer via the `install.nsi` file. This uses the
 Nullsoft Scriptable Install System, which is available for Linux.
 
+### Cross-compiling the MinGW build with Docker
+
+The `gargoyle_docker_mingw.sh` script cross-compiles Gargoyle for Windows using
+the provided `Dockerfile` (LLVM MinGW and Qt 6 dependencies from the
+[garglk/assets](https://github.com/garglk/assets) releases).
+
+The llvm-mingw toolchain is x86_64-hosted, so the image is always built for
+`linux/amd64`, including on ARM/Apple Silicon hosts.
+
+x86_64 is built by default:
+
+    $ ./gargoyle_docker_mingw.sh
+
+Other architectures are selected with `-a` (`i686`, `x86_64`, `aarch64`, or
+`armv7`):
+
+    $ ./gargoyle_docker_mingw.sh -a aarch64
+
+This writes `gargoyle-<version>-windows-<arch>.zip` in the repository root. For
+`i686` and `x86_64`, an NSIS installer (`.exe`) is also produced.
+
 ### Clang on Windows
 
 Support for building Gargoyle on Windows using Clang for Windows is currently

--- a/gargoyle_docker_mingw.sh
+++ b/gargoyle_docker_mingw.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+# Cross compile Gargoyle for Windows via Docker using the provided
+# Dockerfile (LLVM MinGW + Qt 6 assets). Requires Docker.
+#
+# The llvm-mingw toolchain is x86_64-hosted, so the image is always built
+# for linux/amd64 (including on Apple Silicon hosts).
+#
+# x86_64 is built by default. To select another architecture, use the -a
+# option. Valid values:
+#
+# i686
+# x86_64
+# aarch64
+# armv7
+
+fatal() {
+    echo "${@}" >&2
+    exit 1
+}
+
+GARGOYLE_ARCH="x86_64"
+
+usage="Usage: $0 [-a i686|x86_64|aarch64|armv7]"
+
+while getopts "a:" o
+do
+    case "${o}" in
+        a)
+            GARGOYLE_ARCH="${OPTARG}"
+            ;;
+        *)
+            fatal "${usage}"
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+[[ $# -eq 0 ]] || fatal "${usage}"
+
+case "${GARGOYLE_ARCH}" in
+    i686|x86_64|aarch64|armv7)
+        ;;
+    *)
+        fatal "Unsupported arch: ${GARGOYLE_ARCH}"
+        ;;
+esac
+
+command -v docker >/dev/null || fatal "Docker is required but was not found in PATH"
+
+root="$(cd "$(dirname "$0")" && pwd)"
+cd "${root}"
+
+image="garglk-mingw-${GARGOYLE_ARCH}"
+
+# The llvm-mingw toolchain is x86_64-hosted, so the image is always built for
+# `linux/amd64`, including on ARM/Apple Silicon hosts.
+
+docker build --platform=linux/amd64 --build-arg ARCH="${GARGOYLE_ARCH}" -t "${image}" .
+docker run --rm --platform=linux/amd64 -v "${root}:/src" -w /src "${image}" \
+    bash -lc "./windows.sh -a ${GARGOYLE_ARCH} -c && ./package-windows.sh ${GARGOYLE_ARCH}"


### PR DESCRIPTION
With this, you can `./gargoyle_docker_mingw.sh` with nothing pre-installed but Docker itself.