### PR TITLE
Implement Dannii's CSS Basic Glk extension

### DIFF
--- a/garglk/CMakeLists.txt
+++ b/garglk/CMakeLists.txt
@@ -109,7 +109,7 @@ else()
     set(IMGLOAD imgload-system.cpp)
 endif()
 
-add_library(garglk-common OBJECT babeldata.cpp style.cpp config.cpp draw.cpp event.cpp
+add_library(garglk-common OBJECT babeldata.cpp style.cpp config.cpp cssbasic.cpp draw.cpp event.cpp
     garglk.cpp imgload.cpp ${IMGLOAD} imgscale.cpp theme.cpp winblank.cpp window.cpp
     wingfx.cpp wingrid.cpp winmask.cpp winpair.cpp wintext.cpp zbleep.cpp
     ${GARGLKINI_CXX} ${THEME_DARK_CXX} ${THEME_LIGHT_CXX}

--- a/garglk/cheapglk/cggestal.cpp
+++ b/garglk/cheapglk/cggestal.cpp
@@ -204,6 +204,11 @@ glui32 glk_gestalt_ext(glui32 id, glui32 val, glui32 *arr,
             return TRUE;
 #endif
 
+#ifdef GLK_MODULE_CSS_BASIC
+        case gestalt_CSSBasic:
+            return TRUE;
+#endif
+
         default:
             return 0;
 

--- a/garglk/cheapglk/cgstream.cpp
+++ b/garglk/cheapglk/cgstream.cpp
@@ -1831,6 +1831,7 @@ static void gli_set_style(stream_t *str, glui32 val)
     switch (str->type) {
     case strtype_Window:
         str->win->attr.style = val;
+        gli_css_refresh_window_attr(str->win);
         if (str->win->echostr != nullptr) {
             gli_set_style(str->win->echostr, val);
         }

--- a/garglk/cheapglk/gi_dispa.c
+++ b/garglk/cheapglk/gi_dispa.c
@@ -67,6 +67,9 @@ static gidispatch_intconst_t intconstant_table[] = {
     { "gestalt_DateTime", (20) },
     { "gestalt_DrawImage", (7) },
     { "gestalt_DrawImageScale", (24) },
+#ifdef GLK_MODULE_CSS_BASIC
+    { "gestalt_CSSBasic", (0x1110) },
+#endif
 #ifdef GARGLK
     { "gestalt_GarglkText", (0x1100) },
 #endif
@@ -343,6 +346,21 @@ static gidispatch_function_t function_table[] = {
     { 0x1102, garglk_set_reversevideo, "garglk_set_reversevideo" },
     { 0x1103, garglk_set_reversevideo_stream, "garglk_set_reversevideo_stream" },
 #endif /* GLK_MODULE_GARGLKTEXT */
+#ifdef GLK_MODULE_CSS_BASIC
+    { 0x1110, glk_css_hint_set, "css_hint_set" },
+    { 0x1111, glk_css_hint_set_num, "css_hint_set_num" },
+    { 0x1112, glk_css_hint_clear, "css_hint_clear" },
+    { 0x1113, glk_css_hint_selector_set, "css_hint_selector_set" },
+    { 0x1114, glk_css_hint_selector_set_num, "css_hint_selector_set_num" },
+    { 0x1115, glk_css_hint_selector_clear, "css_hint_selector_clear" },
+    { 0x1116, glk_css_inline_set, "css_inline_set" },
+    { 0x1117, glk_css_inline_set_num, "css_inline_set_num" },
+    { 0x1118, glk_css_inline_clear, "css_inline_clear" },
+    { 0x1119, glk_css_hint_clear_all_by_style, "css_hint_clear_all_by_style" },
+    { 0x111A, glk_css_hint_clear_all_by_selector, "css_hint_clear_all_by_selector" },
+    { 0x111B, glk_css_hint_clear_all_by_window, "css_hint_clear_all_by_window" },
+    { 0x111C, glk_css_hint_clear_all_inline, "css_hint_clear_all_inline" },
+#endif /* GLK_MODULE_CSS_BASIC */
 };
 
 glui32 gidispatch_count_classes()
@@ -706,6 +724,35 @@ char *gidispatch_prototype(glui32 funcnum)
         case 0x1103: /* garglk_set_reversevideo_stream */
             return "2QbIu:";
 #endif /* GLK_MODULE_GARGLKTEXT */
+
+#ifdef GLK_MODULE_CSS_BASIC
+        case 0x1110: /* css_hint_set */
+            return "5IuIuIu>+#Cn>+#Cn:";
+        case 0x1111: /* css_hint_set_num */
+            return "5IuIuIu>+#CnIs:";
+        case 0x1112: /* css_hint_clear */
+            return "4IuIuIu>+#Cn:";
+        case 0x1113: /* css_hint_selector_set — sel may be null/empty (window) */
+            return "4Iu>#Cn>+#Cn>+#Cn:";
+        case 0x1114: /* css_hint_selector_set_num */
+            return "4Iu>#Cn>+#CnIs:";
+        case 0x1115: /* css_hint_selector_clear */
+            return "3Iu>#Cn>+#Cn:";
+        case 0x1116: /* css_inline_set */
+            return "3Iu>+#Cn>+#Cn:";
+        case 0x1117: /* css_inline_set_num */
+            return "3Iu>+#CnIs:";
+        case 0x1118: /* css_inline_clear */
+            return "2Iu>+#Cn:";
+        case 0x1119: /* css_hint_clear_all_by_style */
+            return "2IuIu:";
+        case 0x111A: /* css_hint_clear_all_by_selector — sel may be null/empty */
+            return "2Iu>#Cn:";
+        case 0x111B: /* css_hint_clear_all_by_window */
+            return "1Iu:";
+        case 0x111C: /* css_hint_clear_all_inline */
+            return "0:";
+#endif /* GLK_MODULE_CSS_BASIC */
 
         default:
             return NULL;
@@ -1563,6 +1610,136 @@ void gidispatch_call(glui32 funcnum, glui32 numargs, gluniversal_t *arglist)
             garglk_set_reversevideo_stream( arglist[0].opaqueref, arglist[1].uint );
             break;
 #endif /* GLK_MODULE_GARGLKTEXT */
+
+#ifdef GLK_MODULE_CSS_BASIC
+        case 0x1110: /* css_hint_set */
+            if (arglist[3].ptrflag && arglist[6].ptrflag)
+                glk_css_hint_set(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    arglist[4].array, arglist[5].uint,
+                    arglist[7].array, arglist[8].uint);
+            else if (arglist[3].ptrflag)
+                glk_css_hint_set(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    arglist[4].array, arglist[5].uint, NULL, 0);
+            else
+                glk_css_hint_set(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    NULL, 0, NULL, 0);
+            break;
+        case 0x1111: /* css_hint_set_num */
+            if (arglist[3].ptrflag)
+                glk_css_hint_set_num(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    arglist[4].array, arglist[5].uint, arglist[6].sint);
+            else
+                glk_css_hint_set_num(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    NULL, 0, arglist[4].sint);
+            break;
+        case 0x1112: /* css_hint_clear */
+            if (arglist[3].ptrflag)
+                glk_css_hint_clear(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    arglist[4].array, arglist[5].uint);
+            else
+                glk_css_hint_clear(arglist[0].uint, arglist[1].uint, arglist[2].uint,
+                    NULL, 0);
+            break;
+        case 0x1113: /* css_hint_selector_set */
+            if (arglist[1].ptrflag) {
+                if (arglist[4].ptrflag && arglist[7].ptrflag)
+                    glk_css_hint_selector_set(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint,
+                        arglist[5].array, arglist[6].uint,
+                        arglist[8].array, arglist[9].uint);
+                else if (arglist[4].ptrflag)
+                    glk_css_hint_selector_set(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint,
+                        arglist[5].array, arglist[6].uint, NULL, 0);
+                else
+                    glk_css_hint_selector_set(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint, NULL, 0, NULL, 0);
+            } else if (arglist[2].ptrflag && arglist[5].ptrflag) {
+                glk_css_hint_selector_set(arglist[0].uint, NULL, 0,
+                    arglist[3].array, arglist[4].uint,
+                    arglist[6].array, arglist[7].uint);
+            } else if (arglist[2].ptrflag) {
+                glk_css_hint_selector_set(arglist[0].uint, NULL, 0,
+                    arglist[3].array, arglist[4].uint, NULL, 0);
+            } else {
+                glk_css_hint_selector_set(arglist[0].uint, NULL, 0, NULL, 0, NULL, 0);
+            }
+            break;
+        case 0x1114: /* css_hint_selector_set_num */
+            if (arglist[1].ptrflag) {
+                if (arglist[4].ptrflag)
+                    glk_css_hint_selector_set_num(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint,
+                        arglist[5].array, arglist[6].uint, arglist[7].sint);
+                else
+                    glk_css_hint_selector_set_num(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint, NULL, 0, arglist[5].sint);
+            } else if (arglist[2].ptrflag) {
+                glk_css_hint_selector_set_num(arglist[0].uint, NULL, 0,
+                    arglist[3].array, arglist[4].uint, arglist[5].sint);
+            } else {
+                glk_css_hint_selector_set_num(arglist[0].uint, NULL, 0, NULL, 0,
+                    arglist[3].sint);
+            }
+            break;
+        case 0x1115: /* css_hint_selector_clear */
+            if (arglist[1].ptrflag) {
+                if (arglist[4].ptrflag)
+                    glk_css_hint_selector_clear(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint,
+                        arglist[5].array, arglist[6].uint);
+                else
+                    glk_css_hint_selector_clear(arglist[0].uint,
+                        arglist[2].array, arglist[3].uint, NULL, 0);
+            } else if (arglist[2].ptrflag) {
+                glk_css_hint_selector_clear(arglist[0].uint, NULL, 0,
+                    arglist[3].array, arglist[4].uint);
+            } else {
+                glk_css_hint_selector_clear(arglist[0].uint, NULL, 0, NULL, 0);
+            }
+            break;
+        case 0x1116: /* css_inline_set */
+            if (arglist[1].ptrflag && arglist[4].ptrflag)
+                glk_css_inline_set(arglist[0].uint,
+                    arglist[2].array, arglist[3].uint,
+                    arglist[5].array, arglist[6].uint);
+            else if (arglist[1].ptrflag)
+                glk_css_inline_set(arglist[0].uint,
+                    arglist[2].array, arglist[3].uint, NULL, 0);
+            else
+                glk_css_inline_set(arglist[0].uint, NULL, 0, NULL, 0);
+            break;
+        case 0x1117: /* css_inline_set_num */
+            if (arglist[1].ptrflag)
+                glk_css_inline_set_num(arglist[0].uint,
+                    arglist[2].array, arglist[3].uint, arglist[4].sint);
+            else
+                glk_css_inline_set_num(arglist[0].uint, NULL, 0, arglist[2].sint);
+            break;
+        case 0x1118: /* css_inline_clear */
+            if (arglist[1].ptrflag)
+                glk_css_inline_clear(arglist[0].uint,
+                    arglist[2].array, arglist[3].uint);
+            else
+                glk_css_inline_clear(arglist[0].uint, NULL, 0);
+            break;
+        case 0x1119: /* css_hint_clear_all_by_style */
+            glk_css_hint_clear_all_by_style(arglist[0].uint, arglist[1].uint);
+            break;
+        case 0x111A: /* css_hint_clear_all_by_selector */
+            if (arglist[1].ptrflag)
+                glk_css_hint_clear_all_by_selector(arglist[0].uint,
+                    arglist[2].array, arglist[3].uint);
+            else
+                glk_css_hint_clear_all_by_selector(arglist[0].uint, NULL, 0);
+            break;
+        case 0x111B: /* css_hint_clear_all_by_window */
+            glk_css_hint_clear_all_by_window(arglist[0].uint);
+            break;
+        case 0x111C: /* css_hint_clear_all_inline */
+            glk_css_hint_clear_all_inline();
+            break;
+#endif /* GLK_MODULE_CSS_BASIC */
 
         default:
             /* do nothing */

--- a/garglk/cheapglk/glk.h
+++ b/garglk/cheapglk/glk.h
@@ -61,6 +61,8 @@ typedef int32_t glsi32;
 
 #define GLK_MODULE_FILEREF_GET_NAME
 
+#define GLK_MODULE_CSS_BASIC
+
 #define GLK_MODULE_GARGLKTEXT
 #define GLK_MODULE_GARGLKBLEEP
 #define GLK_MODULE_GARGLKWINSIZE
@@ -113,6 +115,7 @@ typedef struct glk_schannel_struct *schanid_t;
 #define gestalt_ResourceStream (22)
 #define gestalt_GraphicsCharInput (23)
 #define gestalt_DrawImageScale (24)
+#define gestalt_CSSBasic (0x1110)
 #define gestalt_GarglkText (0x1100)
 
 #define evtype_None (0)
@@ -500,6 +503,39 @@ extern strid_t glk_stream_open_resource(glui32 filenum, glui32 rock);
 extern strid_t glk_stream_open_resource_uni(glui32 filenum, glui32 rock);
 
 #endif /* GLK_MODULE_RESOURCE_STREAM */
+
+#ifdef GLK_MODULE_CSS_BASIC
+
+#define CSS_Span (0)
+#define CSS_Paragraph (1)
+
+extern void glk_css_hint_set(glui32 wintype, glui32 styl, glui32 span_or_par,
+    const char *prop, glui32 proplen, const char *val, glui32 vallen);
+extern void glk_css_hint_set_num(glui32 wintype, glui32 styl, glui32 span_or_par,
+    const char *prop, glui32 proplen, glsi32 val);
+extern void glk_css_hint_clear(glui32 wintype, glui32 styl, glui32 span_or_par,
+    const char *prop, glui32 proplen);
+
+extern void glk_css_hint_selector_set(glui32 wintype, const char *sel, glui32 sellen,
+    const char *prop, glui32 proplen, const char *val, glui32 vallen);
+extern void glk_css_hint_selector_set_num(glui32 wintype, const char *sel, glui32 sellen,
+    const char *prop, glui32 proplen, glsi32 val);
+extern void glk_css_hint_selector_clear(glui32 wintype, const char *sel, glui32 sellen,
+    const char *prop, glui32 proplen);
+
+extern void glk_css_inline_set(glui32 span_or_par, const char *prop, glui32 proplen,
+    const char *val, glui32 vallen);
+extern void glk_css_inline_set_num(glui32 span_or_par, const char *prop, glui32 proplen,
+    glsi32 val);
+extern void glk_css_inline_clear(glui32 span_or_par, const char *prop, glui32 proplen);
+
+extern void glk_css_hint_clear_all_by_style(glui32 wintype, glui32 styl);
+extern void glk_css_hint_clear_all_by_selector(glui32 wintype, const char *sel,
+    glui32 sellen);
+extern void glk_css_hint_clear_all_by_window(glui32 wintype);
+extern void glk_css_hint_clear_all_inline(void);
+
+#endif /* GLK_MODULE_CSS_BASIC */
 
 /* XXX non-official Glk functions that may or may not exist */
 

--- a/garglk/cssbasic.cpp
+++ b/garglk/cssbasic.cpp
@@ -29,12 +29,17 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "glk.h"
 #include "garglk.h"
 
 namespace {
+
+// Interned CSS font-family entries (ids stored on attr_t / style_t).
+std::vector<CssFontFamily> gli_css_families;
+std::unordered_map<std::string, std::uint16_t> gli_css_family_keys;
 
 // Hints are stored per window type, per style, and per level (span or
 // paragraph).
@@ -212,11 +217,37 @@ double parse_length(const std::string &value, double base)
     return number(v) * gli_zoom;
 }
 
-// Decide whether a font-family list asks for the monospace font. Only
-// the first family that Gargoyle can honor is considered; since
-// Gargoyle has exactly two font families, anything that isn't
-// recognizably monospace maps to the proportional font.
-std::optional<bool> parse_font_family(const std::string &value)
+// Intern a resolved family under a stable key so repeated CSS values
+// reuse the same id.
+std::uint16_t intern_family(const std::string &key, FontFiles files, bool monospace)
+{
+    auto it = gli_css_family_keys.find(key);
+    if (it != gli_css_family_keys.end()) {
+        return it->second;
+    }
+
+    if (gli_css_families.size() >= 0xffff) {
+        return 0;
+    }
+
+    auto id = static_cast<std::uint16_t>(gli_css_families.size());
+    gli_css_families.push_back({std::move(files), monospace});
+    gli_css_family_keys.emplace(key, id);
+    return id;
+}
+
+bool name_looks_monospace(const std::string &name)
+{
+    return name == "monospace" || name == "mono" || name == "terminal" ||
+           name == "consolas" || name == "monaco" || name == "menlo" ||
+           name.find("courier") != std::string::npos ||
+           name.find("ocr") != std::string::npos;
+}
+
+// Resolve a CSS font-family list like a browser: walk left to right and
+// take the first family that can be honored. Generics map to configured
+// mono/prop fonts or a platform sans; named families use fontlookup.
+std::optional<std::uint16_t> resolve_font_family(const std::string &value, bool &monospace)
 {
     for (const auto &family : split(value, ',')) {
         auto name = garglk::downcase(unquote(trim(family)));
@@ -224,14 +255,40 @@ std::optional<bool> parse_font_family(const std::string &value)
             continue;
         }
 
-        if (name == "monospace" || name == "mono" || name == "terminal" ||
-                name == "consolas" || name == "monaco" || name == "menlo" ||
-                name.find("courier") != std::string::npos ||
-                name.find("ocr") != std::string::npos) {
-            return true;
+        if (name == "monospace") {
+            monospace = true;
+            return intern_family("\1monospace", gli_conf_mono, true);
         }
 
-        return false;
+        if (name == "serif") {
+            monospace = false;
+            return intern_family("\1serif", gli_conf_prop, false);
+        }
+
+        if (name == "sans-serif") {
+            static const char *const sans_candidates[] = {
+                "Helvetica", "Arial", "DejaVu Sans", "sans-serif",
+            };
+            for (const char *candidate : sans_candidates) {
+                auto files = garglk::fontlookup(candidate);
+                if (files.has_value()) {
+                    monospace = false;
+                    return intern_family("\1sans-serif", *files, false);
+                }
+            }
+            monospace = false;
+            return intern_family("\1sans-serif", gli_conf_prop, false);
+        }
+
+        auto original = unquote(trim(family));
+        auto files = garglk::fontlookup(original);
+        if (!files.has_value() && original != name) {
+            files = garglk::fontlookup(name);
+        }
+        if (files.has_value()) {
+            monospace = name_looks_monospace(name);
+            return intern_family(name, *files, monospace);
+        }
     }
 
     return std::nullopt;
@@ -297,7 +354,10 @@ void reset_style_property(style_t &style, const style_t &def, const std::string 
         style.font.bold = def.font.bold;
     } else if (prop == "font-style") {
         style.font.italic = def.font.italic;
-    } else if (prop == "font-family" || prop == "monospace") {
+    } else if (prop == "font-family") {
+        style.font.monospace = def.font.monospace;
+        style.family_id = def.family_id;
+    } else if (prop == "monospace") {
         style.font.monospace = def.font.monospace;
     } else if (prop == "font-size") {
         style.size = def.size;
@@ -322,6 +382,8 @@ void apply_hint_levels(style_t &style, const style_t &def, const std::array<CssP
     // size; start from that so that reapplying the hints (which happens
     // every time one of them changes) doesn't compound them.
     style.size = def.size;
+    style.family_id = def.family_id;
+    style.font.monospace = def.font.monospace;
 
     gli_css_apply_props(unused, &style, levels[CSS_Span], true, false);
     gli_css_apply_props(unused, &style, levels[CSS_Paragraph], true, true);
@@ -413,6 +475,7 @@ bool attr_has_css(const attr_t &attr)
            attr.underline.has_value() ||
            attr.size.has_value() ||
            attr.justification.has_value() ||
+           attr.family_id.has_value() ||
            attr.margin_left.has_value() ||
            attr.margin_right.has_value() ||
            attr.text_indent.has_value() ||
@@ -461,12 +524,24 @@ void gli_css_apply_props(attr_t &attr, style_t *style, const CssProps &props,
     auto family = props.find("font-family");
     auto mono_prop = props.find("monospace");
     std::optional<bool> monospace;
+    std::optional<std::uint16_t> family_id;
     if (family != props.end()) {
-        monospace = parse_font_family(family->second);
+        bool mono = false;
+        family_id = resolve_font_family(family->second, mono);
+        if (family_id.has_value()) {
+            monospace = mono;
+        }
     }
     if (mono_prop != props.end()) {
         auto val = garglk::downcase(trim(mono_prop->second));
         monospace = parse_bool(val) || val == "monospace";
+    }
+    if (family_id.has_value()) {
+        if (target != nullptr) {
+            target->family_id = *family_id;
+        } else {
+            attr.family_id = *family_id;
+        }
     }
     if (monospace.has_value()) {
         if (target != nullptr) {
@@ -1090,3 +1165,11 @@ void glk_css_hint_clear_all_inline()
     garglk_set_zcolors(zcolor_Default, zcolor_Default);
 }
 
+const CssFontFamily *gli_css_get_family(std::uint16_t id)
+{
+    if (id >= gli_css_families.size()) {
+        return nullptr;
+    }
+
+    return &gli_css_families[id];
+}

--- a/garglk/cssbasic.cpp
+++ b/garglk/cssbasic.cpp
@@ -1,0 +1,1092 @@
+// Copyright (C) 2026 by the Gargoyle contributors.
+//
+// This file is part of Gargoyle.
+//
+// Gargoyle is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// Gargoyle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Gargoyle; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+// The basic profile of Dannii Willis' CSS Glk extension: games may
+// attach a small set of CSS declarations either to a style (a "hint",
+// which behaves much like glk_stylehint_set), via a Style_* selector,
+// or to the text about to be printed (an "inline" declaration).
+// glk_css_supports is part of the full profile and is not implemented.
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdlib>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "glk.h"
+#include "garglk.h"
+
+namespace {
+
+// Hints are stored per window type, per style, and per level (span or
+// paragraph).
+using HintTable = std::array<std::array<CssProps, 2>, style_NUMSTYLES>;
+
+HintTable gli_css_buffer_hints;
+HintTable gli_css_grid_hints;
+CssProps gli_css_buffer_window_hints;
+CssProps gli_css_grid_window_hints;
+bool gli_css_have_hints = false;
+
+std::string trim(const std::string &str)
+{
+    const auto *whitespace = " \t\r\n\f\v";
+
+    auto begin = str.find_first_not_of(whitespace);
+    if (begin == std::string::npos) {
+        return "";
+    }
+
+    auto end = str.find_last_not_of(whitespace);
+
+    return str.substr(begin, end - begin + 1);
+}
+
+std::string unquote(const std::string &str)
+{
+    if (str.size() >= 2 &&
+            ((str.front() == '"' && str.back() == '"') ||
+             (str.front() == '\'' && str.back() == '\''))) {
+        return str.substr(1, str.size() - 2);
+    }
+
+    return str;
+}
+
+std::vector<std::string> split(const std::string &str, char delim)
+{
+    std::vector<std::string> parts;
+    std::string::size_type start = 0;
+
+    while (true) {
+        auto pos = str.find(delim, start);
+        if (pos == std::string::npos) {
+            parts.push_back(str.substr(start));
+            break;
+        }
+        parts.push_back(str.substr(start, pos - start));
+        start = pos + 1;
+    }
+
+    return parts;
+}
+
+struct CssColor {
+    bool valid = false;
+    bool transparent = false;
+    Color color = Color(0, 0, 0);
+};
+
+CssColor parse_color(const std::string &value)
+{
+    static const std::map<std::string, unsigned long> named = {
+        {"black", 0x000000}, {"silver", 0xc0c0c0}, {"gray", 0x808080},
+        {"grey", 0x808080}, {"white", 0xffffff}, {"maroon", 0x800000},
+        {"red", 0xff0000}, {"purple", 0x800080}, {"fuchsia", 0xff00ff},
+        {"green", 0x008000}, {"lime", 0x00ff00}, {"olive", 0x808000},
+        {"yellow", 0xffff00}, {"navy", 0x000080}, {"blue", 0x0000ff},
+        {"teal", 0x008080}, {"aqua", 0x00ffff}, {"orange", 0xffa500},
+        {"cyan", 0x00ffff}, {"magenta", 0xff00ff}, {"pink", 0xffc0cb},
+    };
+
+    CssColor result;
+
+    auto v = garglk::downcase(trim(value));
+    if (v.empty()) {
+        return result;
+    }
+
+    if (v == "transparent") {
+        result.valid = true;
+        result.transparent = true;
+        return result;
+    }
+
+    auto named_it = named.find(v);
+    if (named_it != named.end()) {
+        auto c = named_it->second;
+        result.valid = true;
+        result.color = Color((c >> 16) & 0xff, (c >> 8) & 0xff, c & 0xff);
+        return result;
+    }
+
+    if (v[0] != '#') {
+        return result;
+    }
+
+    auto hex = v.substr(1);
+    if (hex.find_first_not_of("0123456789abcdef") != std::string::npos) {
+        return result;
+    }
+
+    unsigned long raw = std::strtoul(hex.c_str(), nullptr, 16);
+    unsigned long r, g, b, a = 255;
+
+    switch (hex.size()) {
+    case 3:
+        r = ((raw >> 8) & 0xf) * 0x11;
+        g = ((raw >> 4) & 0xf) * 0x11;
+        b = (raw & 0xf) * 0x11;
+        break;
+    case 4:
+        r = ((raw >> 12) & 0xf) * 0x11;
+        g = ((raw >> 8) & 0xf) * 0x11;
+        b = ((raw >> 4) & 0xf) * 0x11;
+        a = (raw & 0xf) * 0x11;
+        break;
+    case 6:
+        r = (raw >> 16) & 0xff;
+        g = (raw >> 8) & 0xff;
+        b = raw & 0xff;
+        break;
+    case 8:
+        r = (raw >> 24) & 0xff;
+        g = (raw >> 16) & 0xff;
+        b = (raw >> 8) & 0xff;
+        a = raw & 0xff;
+        break;
+    default:
+        return result;
+    }
+
+    result.valid = true;
+    result.transparent = a == 0;
+    result.color = Color(r, g, b);
+
+    return result;
+}
+
+// Absolute lengths (pt, px, bare numbers) are CSS logical units and must be
+// scaled by gli_zoom so they match gli_conf_propsize / gli_conf_monosize,
+// which already include zoom and the display backing scale. Relative units
+// (em, %) are computed against a base that is already in zoomed coordinates.
+// pt and px are treated identically, as in Spatterlight's CSS Basic mapper.
+double parse_length(const std::string &value, double base)
+{
+    auto v = garglk::downcase(trim(value));
+    if (v.empty()) {
+        return 0;
+    }
+
+    auto number = [](const std::string &str) {
+        try {
+            return std::stod(str);
+        } catch (const std::exception &) {
+            return 0.0;
+        }
+    };
+
+    auto ends_with = [&v](const std::string &suffix) {
+        return v.size() > suffix.size() &&
+               v.compare(v.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+
+    if (v.back() == '%') {
+        return base * (number(v.substr(0, v.size() - 1)) / 100.0);
+    }
+    if (ends_with("em")) {
+        return base * number(v.substr(0, v.size() - 2));
+    }
+    if (ends_with("pt") || ends_with("px")) {
+        return number(v.substr(0, v.size() - 2)) * gli_zoom;
+    }
+
+    return number(v) * gli_zoom;
+}
+
+// Decide whether a font-family list asks for the monospace font. Only
+// the first family that Gargoyle can honor is considered; since
+// Gargoyle has exactly two font families, anything that isn't
+// recognizably monospace maps to the proportional font.
+std::optional<bool> parse_font_family(const std::string &value)
+{
+    for (const auto &family : split(value, ',')) {
+        auto name = garglk::downcase(unquote(trim(family)));
+        if (name.empty()) {
+            continue;
+        }
+
+        if (name == "monospace" || name == "mono" || name == "terminal" ||
+                name == "consolas" || name == "monaco" || name == "menlo" ||
+                name.find("courier") != std::string::npos ||
+                name.find("ocr") != std::string::npos) {
+            return true;
+        }
+
+        return false;
+    }
+
+    return std::nullopt;
+}
+
+bool parse_bool(const std::string &value)
+{
+    return value == "1" || value == "true" || value == "yes";
+}
+
+std::optional<glui32> parse_justification(const std::string &value)
+{
+    if (value == "left") {
+        return stylehint_just_LeftFlush;
+    }
+    if (value == "right") {
+        return stylehint_just_RightFlush;
+    }
+    if (value == "center") {
+        return stylehint_just_Centered;
+    }
+    if (value == "justify") {
+        return stylehint_just_LeftRight;
+    }
+
+    return std::nullopt;
+}
+
+HintTable &hint_table(glui32 wintype)
+{
+    return wintype == wintype_TextGrid ? gli_css_grid_hints : gli_css_buffer_hints;
+}
+
+Styles &global_styles(glui32 wintype)
+{
+    return wintype == wintype_TextGrid ? gli_gstyles : gli_tstyles;
+}
+
+const Styles &default_styles(glui32 wintype)
+{
+    return wintype == wintype_TextGrid ? gli_gstyles_def : gli_tstyles_def;
+}
+
+bool valid_wintype(glui32 wintype)
+{
+    return wintype == wintype_TextGrid || wintype == wintype_TextBuffer;
+}
+
+// Restore whatever a single property had set on a style back to its
+// configured default.
+void reset_style_property(style_t &style, const style_t &def, const std::string &prop)
+{
+    if (prop == "color") {
+        style.fg = def.fg;
+    } else if (prop == "background-color") {
+        // Span and paragraph levels both use this property name; clear both
+        // so reapplying the remaining level can restore the right one.
+        style.bg = def.bg;
+        style.para_bg = def.para_bg;
+    } else if (prop == "reverse" || prop == "--glk-reverse" || prop == "-iftf-reverse-video") {
+        style.reverse = def.reverse;
+    } else if (prop == "font-weight") {
+        style.font.bold = def.font.bold;
+    } else if (prop == "font-style") {
+        style.font.italic = def.font.italic;
+    } else if (prop == "font-family" || prop == "monospace") {
+        style.font.monospace = def.font.monospace;
+    } else if (prop == "font-size") {
+        style.size = def.size;
+    } else if (prop == "text-decoration" || prop == "text-decoration-line") {
+        style.underline = def.underline;
+    } else if (prop == "text-align") {
+        style.justification = def.justification;
+    } else if (prop == "margin-left") {
+        style.margin_left = def.margin_left;
+    } else if (prop == "margin-right") {
+        style.margin_right = def.margin_right;
+    } else if (prop == "text-indent") {
+        style.text_indent = def.text_indent;
+    }
+}
+
+void apply_hint_levels(style_t &style, const style_t &def, const std::array<CssProps, 2> &levels)
+{
+    attr_t unused;
+
+    // Relative font sizes are measured against the style's configured
+    // size; start from that so that reapplying the hints (which happens
+    // every time one of them changes) doesn't compound them.
+    style.size = def.size;
+
+    gli_css_apply_props(unused, &style, levels[CSS_Span], true, false);
+    gli_css_apply_props(unused, &style, levels[CSS_Paragraph], true, true);
+}
+
+void apply_hints_to_style(glui32 wintype, glui32 styl)
+{
+    apply_hint_levels(global_styles(wintype)[styl], default_styles(wintype)[styl],
+            hint_table(wintype)[styl]);
+}
+
+void hint_set(glui32 wintype, glui32 styl, glui32 par_or_span, const std::string &prop, const std::string &val)
+{
+    if (wintype == wintype_AllTypes) {
+        hint_set(wintype_TextGrid, styl, par_or_span, prop, val);
+        hint_set(wintype_TextBuffer, styl, par_or_span, prop, val);
+        return;
+    }
+
+    if (!valid_wintype(wintype) || styl >= style_NUMSTYLES) {
+        return;
+    }
+
+    hint_table(wintype)[styl][par_or_span == CSS_Paragraph ? CSS_Paragraph : CSS_Span][prop] = val;
+    gli_css_have_hints = true;
+
+    apply_hints_to_style(wintype, styl);
+}
+
+void hint_clear(glui32 wintype, glui32 styl, glui32 par_or_span, const std::string &prop)
+{
+    if (wintype == wintype_AllTypes) {
+        hint_clear(wintype_TextGrid, styl, par_or_span, prop);
+        hint_clear(wintype_TextBuffer, styl, par_or_span, prop);
+        return;
+    }
+
+    if (!valid_wintype(wintype) || styl >= style_NUMSTYLES) {
+        return;
+    }
+
+    hint_table(wintype)[styl][par_or_span == CSS_Paragraph ? CSS_Paragraph : CSS_Span].erase(prop);
+
+    reset_style_property(global_styles(wintype)[styl], default_styles(wintype)[styl], prop);
+    apply_hints_to_style(wintype, styl);
+}
+
+void hint_clear_all(glui32 wintype, glui32 styl)
+{
+    if (wintype == wintype_AllTypes) {
+        hint_clear_all(wintype_TextGrid, styl);
+        hint_clear_all(wintype_TextBuffer, styl);
+        return;
+    }
+
+    if (!valid_wintype(wintype) || styl >= style_NUMSTYLES) {
+        return;
+    }
+
+    auto &table = hint_table(wintype)[styl];
+    style_t &style = global_styles(wintype)[styl];
+    const style_t &def = default_styles(wintype)[styl];
+
+    for (const auto &level : table) {
+        for (const auto &[prop, val] : level) {
+            reset_style_property(style, def, prop);
+        }
+    }
+
+    for (auto &level : table) {
+        level.clear();
+    }
+}
+
+std::string glk_string(const char *str, glui32 len)
+{
+    if (str == nullptr || len == 0) {
+        return "";
+    }
+
+    return {str, str + len};
+}
+
+bool attr_has_css(const attr_t &attr)
+{
+    return attr.bold.has_value() ||
+           attr.italic.has_value() ||
+           attr.monospace.has_value() ||
+           attr.underline.has_value() ||
+           attr.size.has_value() ||
+           attr.justification.has_value() ||
+           attr.margin_left.has_value() ||
+           attr.margin_right.has_value() ||
+           attr.text_indent.has_value() ||
+           attr.para_bgcolor.has_value() ||
+           attr.css_paint ||
+           attr.fg_transparent;
+}
+
+const Styles &window_styles(window_t *win)
+{
+    return win->type == wintype_TextGrid ? win->wingrid()->styles
+                                         : win->winbuffer()->styles;
+}
+
+// Inline CSS declarations affect text about to be printed in open windows.
+// Style-level hints only affect windows opened after they are set.
+void refresh_all_windows()
+{
+    for (winid_t win = glk_window_iterate(nullptr, nullptr); win != nullptr; win = glk_window_iterate(win, nullptr)) {
+        gli_css_refresh_window_attr(win);
+    }
+}
+
+}
+
+bool gli_css_active()
+{
+    return gli_css_have_hints;
+}
+
+void gli_css_apply_props(attr_t &attr, style_t *style, const CssProps &props,
+        bool is_style_level, bool is_paragraph, double base_size)
+{
+    if (props.empty()) {
+        return;
+    }
+
+    style_t *target = is_style_level ? style : nullptr;
+    if (is_style_level && target == nullptr) {
+        return;
+    }
+
+    // font-family is resolved up front, since switching between the
+    // proportional and monospace font changes the size that relative
+    // font sizes are measured against.
+    auto family = props.find("font-family");
+    auto mono_prop = props.find("monospace");
+    std::optional<bool> monospace;
+    if (family != props.end()) {
+        monospace = parse_font_family(family->second);
+    }
+    if (mono_prop != props.end()) {
+        auto val = garglk::downcase(trim(mono_prop->second));
+        monospace = parse_bool(val) || val == "monospace";
+    }
+    if (monospace.has_value()) {
+        if (target != nullptr) {
+            target->font.monospace = *monospace;
+        } else {
+            attr.monospace = *monospace;
+        }
+    }
+
+    if (!monospace.has_value()) {
+        if (target != nullptr) {
+            monospace = target->font.monospace;
+        } else if (attr.monospace.has_value()) {
+            monospace = *attr.monospace;
+        } else if (style != nullptr) {
+            monospace = style->font.monospace;
+        } else {
+            monospace = false;
+        }
+    }
+
+    if (base_size <= 0) {
+        if (style != nullptr && style->size.has_value()) {
+            base_size = *style->size;
+        } else {
+            base_size = *monospace ? gli_conf_monosize : gli_conf_propsize;
+        }
+    }
+
+    for (const auto &[prop, raw] : props) {
+        auto val = garglk::downcase(trim(raw));
+
+        if (prop == "color") {
+            auto color = parse_color(raw);
+            if (color.valid) {
+                if (target != nullptr) {
+                    // Style-level transparent has no alpha channel; leave fg alone
+                    // so the style keeps its previous foreground.
+                    if (!color.transparent) {
+                        target->fg = color.color;
+                    }
+                } else if (color.transparent) {
+                    attr.fgcolor.reset();
+                    attr.fg_transparent = true;
+                    attr.css_paint = true;
+                } else {
+                    attr.fgcolor = color.color;
+                    attr.fg_transparent = false;
+                    attr.css_paint = true;
+                }
+            }
+        } else if (prop == "background-color") {
+            auto color = parse_color(raw);
+            if (color.valid && !color.transparent) {
+                if (is_paragraph) {
+                    if (target != nullptr) {
+                        target->para_bg = color.color;
+                    } else {
+                        attr.para_bgcolor = color.color;
+                    }
+                } else if (target != nullptr) {
+                    target->bg = color.color;
+                } else {
+                    attr.bgcolor = color.color;
+                    attr.css_paint = true;
+                }
+            } else if (color.transparent) {
+                if (is_paragraph) {
+                    if (target != nullptr) {
+                        target->para_bg.reset();
+                    } else {
+                        attr.para_bgcolor.reset();
+                    }
+                } else if (target == nullptr) {
+                    attr.bgcolor.reset();
+                    attr.css_paint = true;
+                }
+            }
+        } else if (prop == "reverse" || prop == "--glk-reverse" ||
+                prop == "-iftf-reverse-video") {
+            bool reverse;
+            if (prop == "-iftf-reverse-video") {
+                reverse = (val == "reverse" || val == "1" || val == "true" || val == "yes");
+            } else {
+                reverse = parse_bool(val);
+            }
+            if (target != nullptr) {
+                target->reverse = reverse;
+            } else {
+                attr.reverse = reverse;
+            }
+        } else if (prop == "font-weight") {
+            std::optional<bool> bold;
+            if (val == "bold" || val == "bolder" || val == "700") {
+                bold = true;
+            } else if (val == "normal" || val == "lighter" || val == "400") {
+                bold = false;
+            }
+            if (bold.has_value()) {
+                if (target != nullptr) {
+                    target->font.bold = *bold;
+                } else {
+                    attr.bold = bold;
+                }
+            }
+        } else if (prop == "font-style") {
+            std::optional<bool> italic;
+            if (val == "italic" || val == "oblique") {
+                italic = true;
+            } else if (val == "normal") {
+                italic = false;
+            }
+            if (italic.has_value()) {
+                if (target != nullptr) {
+                    target->font.italic = *italic;
+                } else {
+                    attr.italic = italic;
+                }
+            }
+        } else if (prop == "text-decoration" || prop == "text-decoration-line") {
+            bool underline = val.find("underline") != std::string::npos;
+            if (underline || val == "none") {
+                if (target != nullptr) {
+                    target->underline = underline;
+                } else {
+                    attr.underline = underline;
+                }
+            }
+        } else if (prop == "font-size") {
+            double size;
+            if (val == "small" || val == "smaller") {
+                size = base_size * 0.83;
+            } else if (val == "medium") {
+                size = base_size;
+            } else if (val == "large" || val == "larger") {
+                size = base_size * 1.2;
+            } else {
+                size = parse_length(raw, base_size);
+            }
+            if (size > 0) {
+                if (target != nullptr) {
+                    target->size = size;
+                } else {
+                    attr.size = size;
+                }
+            }
+        } else if (prop == "text-align") {
+            auto just = parse_justification(val);
+            if (just.has_value()) {
+                if (target != nullptr) {
+                    target->justification = *just;
+                } else {
+                    attr.justification = just;
+                }
+            }
+        } else if (prop == "margin-left") {
+            auto length = parse_length(raw, base_size);
+            if (target != nullptr) {
+                target->margin_left = length;
+            } else {
+                attr.margin_left = static_cast<float>(length);
+            }
+        } else if (prop == "margin-right") {
+            auto length = parse_length(raw, base_size);
+            if (target != nullptr) {
+                target->margin_right = length;
+            } else {
+                attr.margin_right = static_cast<float>(length);
+            }
+        } else if (prop == "text-indent") {
+            auto length = parse_length(raw, base_size);
+            if (target != nullptr) {
+                target->text_indent = length;
+            } else {
+                attr.text_indent = static_cast<float>(length);
+            }
+        }
+    }
+}
+
+void gli_css_apply_hints_to_styles(Styles &styles, glui32 wintype)
+{
+    if (!valid_wintype(wintype) || !gli_css_have_hints) {
+        return;
+    }
+
+    const auto &table = hint_table(wintype);
+    const Styles &def = default_styles(wintype);
+
+    for (glui32 styl = 0; styl < style_NUMSTYLES; styl++) {
+        apply_hint_levels(styles[styl], def[styl], table[styl]);
+    }
+}
+
+// Style-level CSS hints are snapshotted into each window's styles at
+// creation (like stylehints). Only inline declarations affect the current
+// attributes of an already-open window.
+void gli_css_refresh_window_attr(window_t *win)
+{
+    if (win == nullptr || !valid_wintype(win->type)) {
+        return;
+    }
+
+    attr_t &attr = win->attr;
+
+    if (!gli_css_have_hints && win->css_inline.empty() && win->css_inline_para.empty() &&
+            !win->css_fgcolor.has_value() && !win->css_bgcolor.has_value() &&
+            !win->css_reverse && !attr_has_css(attr)) {
+        return;
+    }
+
+    // Undo the colors set by the previous refresh, but leave alone any
+    // set since then by garglk_set_zcolors().
+    if (win->css_fgcolor.has_value() && attr.fgcolor == win->css_fgcolor) {
+        attr.fgcolor.reset();
+    }
+    if (win->css_bgcolor.has_value() && attr.bgcolor == win->css_bgcolor) {
+        attr.bgcolor.reset();
+    }
+    if (win->css_reverse && attr.reverse) {
+        attr.reverse = false;
+    }
+    win->css_fgcolor.reset();
+    win->css_bgcolor.reset();
+    win->css_reverse = false;
+
+    attr.clear_css();
+
+    if (win->css_inline.empty() && win->css_inline_para.empty()) {
+        return;
+    }
+
+    glui32 styl = attr.style < style_NUMSTYLES ? attr.style : 0;
+
+    auto old_fgcolor = attr.fgcolor;
+    auto old_bgcolor = attr.bgcolor;
+    bool old_reverse = attr.reverse;
+
+    style_t style = window_styles(win)[styl];
+    // Span first, then paragraph (paragraph props such as text-align win).
+    gli_css_apply_props(attr, &style, win->css_inline, false, false);
+    gli_css_apply_props(attr, &style, win->css_inline_para, false, true);
+
+    if (attr.fgcolor != old_fgcolor) {
+        win->css_fgcolor = attr.fgcolor;
+    }
+    if (attr.bgcolor != old_bgcolor) {
+        win->css_bgcolor = attr.bgcolor;
+    }
+    if (attr.reverse != old_reverse) {
+        win->css_reverse = attr.reverse;
+    }
+}
+
+namespace {
+
+CssProps &window_hint_table(glui32 wintype)
+{
+    return wintype == wintype_TextGrid ? gli_css_grid_window_hints
+                                       : gli_css_buffer_window_hints;
+}
+
+void window_hint_set(glui32 wintype, const std::string &prop, const std::string &val, bool clear)
+{
+    if (wintype == wintype_AllTypes) {
+        window_hint_set(wintype_TextGrid, prop, val, clear);
+        window_hint_set(wintype_TextBuffer, prop, val, clear);
+        return;
+    }
+    if (!valid_wintype(wintype)) {
+        return;
+    }
+
+    auto &store = window_hint_table(wintype);
+    if (clear) {
+        store.erase(prop);
+    } else {
+        store[prop] = val;
+        gli_css_have_hints = true;
+    }
+}
+
+void clear_stylehints_for_style(glui32 wintype, glui32 styl)
+{
+    for (glui32 hint = 0; hint < stylehint_NUMHINTS; hint++) {
+        glk_stylehint_clear(wintype, styl, hint);
+    }
+}
+
+void clear_level_hints(glui32 wintype, glui32 styl, glui32 span_or_par)
+{
+    if (wintype == wintype_AllTypes) {
+        clear_level_hints(wintype_TextGrid, styl, span_or_par);
+        clear_level_hints(wintype_TextBuffer, styl, span_or_par);
+        return;
+    }
+    if (!valid_wintype(wintype) || styl >= style_NUMSTYLES) {
+        return;
+    }
+
+    auto &level = hint_table(wintype)[styl][span_or_par == CSS_Paragraph ? CSS_Paragraph : CSS_Span];
+    style_t &style = global_styles(wintype)[styl];
+    const style_t &def = default_styles(wintype)[styl];
+    for (const auto &[prop, val] : level) {
+        reset_style_property(style, def, prop);
+    }
+    level.clear();
+    apply_hints_to_style(wintype, styl);
+}
+
+// Map a Style_* / Style_*_para selector, or empty (window-level). Returns false
+// for unrecognized selectors.
+bool parse_selector(const std::string &sel_in, glui32 &styl, bool &is_para, bool &is_window)
+{
+    styl = 0;
+    is_para = false;
+    is_window = false;
+
+    auto sel = trim(sel_in);
+    if (sel.empty()) {
+        is_window = true;
+        return true;
+    }
+
+    if (sel.front() == '.') {
+        sel = sel.substr(1);
+    }
+
+    static const std::map<std::string, glui32> style_map = {
+        {"Style_normal", style_Normal},
+        {"Style_emphasized", style_Emphasized},
+        {"Style_preformatted", style_Preformatted},
+        {"Style_header", style_Header},
+        {"Style_subheader", style_Subheader},
+        {"Style_alert", style_Alert},
+        {"Style_note", style_Note},
+        {"Style_blockquote", style_BlockQuote},
+        {"Style_input", style_Input},
+        {"Style_user1", style_User1},
+        {"Style_user2", style_User2},
+    };
+
+    if (sel.size() > 5 && sel.compare(sel.size() - 5, 5, "_para") == 0) {
+        is_para = true;
+        sel = sel.substr(0, sel.size() - 5);
+    }
+
+    auto it = style_map.find(sel);
+    if (it == style_map.end()) {
+        return false;
+    }
+    styl = it->second;
+    return true;
+}
+
+window_t *css_current_window()
+{
+    if (!gli_conf_stylehint) {
+        return nullptr;
+    }
+
+    stream_t *str = glk_stream_get_current();
+    if (str == nullptr || !str->writable || str->type != strtype_Window || str->win == nullptr) {
+        return nullptr;
+    }
+
+    return valid_wintype(str->win->type) ? str->win : nullptr;
+}
+
+} // namespace
+
+void gli_css_apply_window_hints(window_t *win)
+{
+    if (win == nullptr || !valid_wintype(win->type)) {
+        return;
+    }
+
+    const auto &hints = (win->type == wintype_TextGrid)
+        ? gli_css_grid_window_hints : gli_css_buffer_window_hints;
+    auto it = hints.find("background-color");
+    if (it == hints.end()) {
+        return;
+    }
+    auto color = parse_color(it->second);
+    if (color.valid && !color.transparent) {
+        win->bgcolor = color.color;
+    }
+}
+
+//
+// The Glk API itself
+//
+
+void glk_css_hint_set(glui32 wintype, glui32 styl, glui32 span_or_par,
+    const char *prop, glui32 proplen, const char *val, glui32 vallen)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    auto property = garglk::downcase(trim(glk_string(prop, proplen)));
+    if (property.empty()) {
+        return;
+    }
+
+    hint_set(wintype, styl, span_or_par, property, trim(glk_string(val, vallen)));
+    refresh_all_windows();
+}
+
+void glk_css_hint_set_num(glui32 wintype, glui32 styl, glui32 span_or_par,
+    const char *prop, glui32 proplen, glsi32 val)
+{
+    auto number = std::to_string(val);
+    glk_css_hint_set(wintype, styl, span_or_par, prop, proplen,
+            number.c_str(), number.size());
+}
+
+void glk_css_hint_clear(glui32 wintype, glui32 styl, glui32 span_or_par,
+    const char *prop, glui32 proplen)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    auto property = garglk::downcase(trim(glk_string(prop, proplen)));
+    if (property.empty()) {
+        return;
+    }
+
+    hint_clear(wintype, styl, span_or_par, property);
+    refresh_all_windows();
+}
+
+void glk_css_hint_selector_set(glui32 wintype, const char *sel, glui32 sellen,
+    const char *prop, glui32 proplen, const char *val, glui32 vallen)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    auto property = garglk::downcase(trim(glk_string(prop, proplen)));
+    if (property.empty()) {
+        return;
+    }
+
+    glui32 styl = 0;
+    bool is_para = false;
+    bool is_window = false;
+    if (!parse_selector(glk_string(sel, sellen), styl, is_para, is_window)) {
+        return;
+    }
+
+    auto value = trim(glk_string(val, vallen));
+    if (is_window) {
+        window_hint_set(wintype, property, value, false);
+    } else {
+        hint_set(wintype, styl, is_para ? CSS_Paragraph : CSS_Span, property, value);
+        refresh_all_windows();
+    }
+}
+
+void glk_css_hint_selector_set_num(glui32 wintype, const char *sel, glui32 sellen,
+    const char *prop, glui32 proplen, glsi32 val)
+{
+    auto number = std::to_string(val);
+    glk_css_hint_selector_set(wintype, sel, sellen, prop, proplen,
+            number.c_str(), number.size());
+}
+
+void glk_css_hint_selector_clear(glui32 wintype, const char *sel, glui32 sellen,
+    const char *prop, glui32 proplen)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    auto property = garglk::downcase(trim(glk_string(prop, proplen)));
+    if (property.empty()) {
+        return;
+    }
+
+    glui32 styl = 0;
+    bool is_para = false;
+    bool is_window = false;
+    if (!parse_selector(glk_string(sel, sellen), styl, is_para, is_window)) {
+        return;
+    }
+
+    if (is_window) {
+        window_hint_set(wintype, property, "", true);
+    } else {
+        hint_clear(wintype, styl, is_para ? CSS_Paragraph : CSS_Span, property);
+        refresh_all_windows();
+    }
+}
+
+void glk_css_hint_clear_all_by_style(glui32 wintype, glui32 styl)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    hint_clear_all(wintype, styl);
+    clear_stylehints_for_style(wintype, styl);
+    refresh_all_windows();
+}
+
+void glk_css_hint_clear_all_by_selector(glui32 wintype, const char *sel, glui32 sellen)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    glui32 styl = 0;
+    bool is_para = false;
+    bool is_window = false;
+    if (!parse_selector(glk_string(sel, sellen), styl, is_para, is_window)) {
+        return;
+    }
+
+    if (is_window) {
+        if (wintype == wintype_AllTypes) {
+            gli_css_buffer_window_hints.clear();
+            gli_css_grid_window_hints.clear();
+        } else if (valid_wintype(wintype)) {
+            if (wintype == wintype_TextGrid) {
+                gli_css_grid_window_hints.clear();
+            } else {
+                gli_css_buffer_window_hints.clear();
+            }
+        }
+        return;
+    }
+
+    clear_level_hints(wintype, styl, is_para ? CSS_Paragraph : CSS_Span);
+    clear_stylehints_for_style(wintype, styl);
+    refresh_all_windows();
+}
+
+void glk_css_hint_clear_all_by_window(glui32 wintype)
+{
+    if (!gli_conf_stylehint) {
+        return;
+    }
+
+    auto clear_one = [](glui32 wt) {
+        for (glui32 styl = 0; styl < style_NUMSTYLES; styl++) {
+            hint_clear_all(wt, styl);
+            clear_stylehints_for_style(wt, styl);
+        }
+        if (wt == wintype_TextGrid) {
+            gli_css_grid_window_hints.clear();
+        } else {
+            gli_css_buffer_window_hints.clear();
+        }
+    };
+
+    if (wintype == wintype_AllTypes) {
+        clear_one(wintype_TextGrid);
+        clear_one(wintype_TextBuffer);
+    } else if (valid_wintype(wintype)) {
+        clear_one(wintype);
+    }
+    refresh_all_windows();
+}
+
+void glk_css_inline_set(glui32 span_or_par, const char *prop, glui32 proplen,
+    const char *val, glui32 vallen)
+{
+    auto property = garglk::downcase(trim(glk_string(prop, proplen)));
+    if (property.empty()) {
+        return;
+    }
+
+    window_t *win = css_current_window();
+    if (win == nullptr) {
+        return;
+    }
+
+    auto &store = (span_or_par == CSS_Paragraph) ? win->css_inline_para : win->css_inline;
+    store[property] = trim(glk_string(val, vallen));
+    gli_css_refresh_window_attr(win);
+}
+
+void glk_css_inline_set_num(glui32 span_or_par, const char *prop, glui32 proplen, glsi32 val)
+{
+    auto number = std::to_string(val);
+    glk_css_inline_set(span_or_par, prop, proplen, number.c_str(), number.size());
+}
+
+void glk_css_inline_clear(glui32 span_or_par, const char *prop, glui32 proplen)
+{
+    auto property = garglk::downcase(trim(glk_string(prop, proplen)));
+    if (property.empty()) {
+        return;
+    }
+
+    window_t *win = css_current_window();
+    if (win == nullptr) {
+        return;
+    }
+
+    auto &store = (span_or_par == CSS_Paragraph) ? win->css_inline_para : win->css_inline;
+    store.erase(property);
+    gli_css_refresh_window_attr(win);
+}
+
+void glk_css_hint_clear_all_inline()
+{
+    window_t *win = css_current_window();
+    if (win == nullptr) {
+        return;
+    }
+
+    win->css_inline.clear();
+    win->css_inline_para.clear();
+    gli_css_refresh_window_attr(win);
+
+    // Also clear Gargoyle text-formatting extensions (reverse / zcolors).
+    garglk_set_reversevideo(0);
+    garglk_set_zcolors(zcolor_Default, zcolor_Default);
+}
+

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -104,17 +104,21 @@ public:
         std::string m_what;
     };
 
-    Font(FontFace fontface, UniqueFace face, const std::string &fontpath);
+    Font(FontFace fontface, UniqueFace face, const std::string &fontpath, std::optional<double> size_override = std::nullopt);
 
     FontEntry getglyph(glui32 cid);
     int charkern(glui32 c0, glui32 c1);
     const UniqueFace &face() {
         return m_face;
     }
+    const std::string &path() const {
+        return m_path;
+    }
 
 private:
     UniqueFace m_face;
     bool m_monospace = false;
+    std::string m_path;
     bool m_make_bold = false;
     bool m_make_oblique = false;
     bool m_kerned = false;
@@ -134,6 +138,11 @@ static std::array<unsigned char, 1 << GAMMA_BITS> gammainv;
 
 static std::unordered_map<FontFace, Font> gfont_table;
 static std::unordered_map<FontFace, std::vector<Font>> glyph_substitution_fonts;
+
+// Fonts at sizes other than the configured default, as requested by the
+// CSS Basic extension. These are keyed by face and by size in
+// thousandths of a point.
+static std::unordered_map<std::pair<FontFace, glui32>, Font> sized_font_table;
 
 int gli_cellw = 8;
 int gli_cellh = 8;
@@ -495,9 +504,10 @@ static std::vector<Font> make_substitution_fonts(FontFace fontface)
     return fonts;
 }
 
-Font::Font(FontFace fontface, UniqueFace face, const std::string &fontpath) :
+Font::Font(FontFace fontface, UniqueFace face, const std::string &fontpath, std::optional<double> size_override) :
     m_face(std::move(face)),
-    m_monospace(fontface.monospace)
+    m_monospace(fontface.monospace),
+    m_path(fontpath)
 {
     int err = 0;
     double aspect, size;
@@ -508,6 +518,10 @@ Font::Font(FontFace fontface, UniqueFace face, const std::string &fontpath) :
     } else {
         aspect = gli_conf_propaspect;
         size = gli_conf_propsize;
+    }
+
+    if (size_override.has_value() && *size_override > 0) {
+        size = *size_override;
     }
 
     auto dot = fontpath.rfind('.');
@@ -830,9 +844,50 @@ static const std::vector<std::pair<std::vector<glui32>, glui32>> ligatures = {
     {{'f', 'l'}, UNI_LIG_FL},
 };
 
-static int gli_string_impl(int x, FontFace fontface, const glui32 *s, std::size_t n, int spw, const std::function<void(int, const std::array<Bitmap, GLI_SUBPIX> &)> &callback)
+// Convert a requested font size (in points) to the key used by
+// sized_font_table; the default size for the face maps to 0, meaning
+// the font from gfont_table is used as-is.
+static glui32 font_size_key(FontFace fontface, std::optional<double> size)
 {
-    auto &f = gfont_table.at(fontface);
+    if (!size.has_value() || *size <= 0) {
+        return 0;
+    }
+
+    double def = fontface.monospace ? gli_conf_monosize : gli_conf_propsize;
+    auto key = static_cast<glui32>(std::lround(*size * 1000));
+
+    return key == static_cast<glui32>(std::lround(def * 1000)) ? 0 : key;
+}
+
+static Font &get_font(FontFace fontface, glui32 size_key)
+{
+    auto &base = gfont_table.at(fontface);
+
+    if (size_key == 0) {
+        return base;
+    }
+
+    auto key = std::pair(fontface, size_key);
+    auto it = sized_font_table.find(key);
+    if (it == sized_font_table.end()) {
+        FT_Face face;
+        if (FT_New_Face(ftlib, base.path().c_str(), 0, &face) != 0) {
+            return base;
+        }
+
+        try {
+            it = sized_font_table.emplace(key, Font(fontface, UniqueFace(face), base.path(), size_key / 1000.0)).first;
+        } catch (const Font::LoadError &) {
+            return base;
+        }
+    }
+
+    return it->second;
+}
+
+static int gli_string_impl(int x, FontFace fontface, glui32 size_key, const glui32 *s, std::size_t n, int spw, const std::function<void(int, const std::array<Bitmap, GLI_SUBPIX> &)> &callback)
+{
+    auto &f = get_font(fontface, size_key);
     bool dolig = !FT_IS_FIXED_WIDTH(f.face());
     int prev = -1;
     glui32 c;
@@ -869,9 +924,10 @@ static int gli_string_impl(int x, FontFace fontface, const glui32 *s, std::size_
         // that glyph is unavailable, log a warning and select a
         // question mark instead. If a question mark can't be loaded,
         // abort with an error message. Lookups are cached.
-        auto glyph = [&f, &fontface](glui32 c) -> const FontEntry & {
-            static std::unordered_map<std::pair<FontFace, glui32>, FontEntry> fallback_cache;
+        auto glyph = [&f, &fontface, size_key](glui32 c) -> const FontEntry & {
+            static std::unordered_map<glui32, std::unordered_map<std::pair<FontFace, glui32>, FontEntry>> size_caches;
 
+            auto &fallback_cache = size_caches[size_key];
             auto key = std::pair(fontface, c);
 
             auto it = fallback_cache.find(key);
@@ -923,9 +979,10 @@ static int gli_string_impl(int x, FontFace fontface, const glui32 *s, std::size_
 }
 
 int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb,
-                        const glui32 *text, int len, int spacewidth)
+                        const glui32 *text, int len, int spacewidth,
+                        std::optional<double> fontsize)
 {
-    return gli_string_impl(x, face, text, len, spacewidth, [&y, &rgb](int x, const std::array<Bitmap, GLI_SUBPIX> &glyphs) {
+    return gli_string_impl(x, face, font_size_key(face, fontsize), text, len, spacewidth, [&y, &rgb](int x, const std::array<Bitmap, GLI_SUBPIX> &glyphs) {
         int px = x / GLI_SUBPIX;
         int sx = x % GLI_SUBPIX;
 
@@ -937,9 +994,10 @@ int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb,
     });
 }
 
-int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth)
+int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth,
+                         std::optional<double> fontsize)
 {
-    return gli_string_impl(0, face, text, len, spacewidth, [](int, const std::array<Bitmap, GLI_SUBPIX> &) {});
+    return gli_string_impl(0, face, font_size_key(face, fontsize), text, len, spacewidth, [](int, const std::array<Bitmap, GLI_SUBPIX> &) {});
 }
 
 void gli_draw_caret(int x, int y)

--- a/garglk/draw.cpp
+++ b/garglk/draw.cpp
@@ -144,6 +144,33 @@ static std::unordered_map<FontFace, std::vector<Font>> glyph_substitution_fonts;
 // thousandths of a point.
 static std::unordered_map<std::pair<FontFace, glui32>, Font> sized_font_table;
 
+// CSS font-family faces, keyed by family id, bold/italic, and size.
+struct CssFontKey {
+    std::uint16_t family_id = 0;
+    bool bold = false;
+    bool italic = false;
+    glui32 size_key = 0;
+
+    bool operator==(const CssFontKey &other) const {
+        return family_id == other.family_id &&
+               bold == other.bold &&
+               italic == other.italic &&
+               size_key == other.size_key;
+    }
+};
+
+struct CssFontKeyHash {
+    std::size_t operator()(const CssFontKey &key) const {
+        auto seed = hash_combine(0, std::hash<std::uint16_t>()(key.family_id));
+        seed = hash_combine(seed, std::hash<bool>()(key.bold));
+        seed = hash_combine(seed, std::hash<bool>()(key.italic));
+        seed = hash_combine(seed, std::hash<glui32>()(key.size_key));
+        return seed;
+    }
+};
+
+static std::unordered_map<CssFontKey, Font, CssFontKeyHash> css_font_table;
+
 int gli_cellw = 8;
 int gli_cellh = 8;
 
@@ -847,19 +874,33 @@ static const std::vector<std::pair<std::vector<glui32>, glui32>> ligatures = {
 // Convert a requested font size (in points) to the key used by
 // sized_font_table; the default size for the face maps to 0, meaning
 // the font from gfont_table is used as-is.
-static glui32 font_size_key(FontFace fontface, std::optional<double> size)
+static glui32 font_size_key(bool monospace, std::optional<double> size)
 {
     if (!size.has_value() || *size <= 0) {
         return 0;
     }
 
-    double def = fontface.monospace ? gli_conf_monosize : gli_conf_propsize;
+    double def = monospace ? gli_conf_monosize : gli_conf_propsize;
     auto key = static_cast<glui32>(std::lround(*size * 1000));
 
     return key == static_cast<glui32>(std::lround(def * 1000)) ? 0 : key;
 }
 
-static Font &get_font(FontFace fontface, glui32 size_key)
+static const std::optional<std::string> &family_slot(const FontFiles &files, bool bold, bool italic)
+{
+    if (bold && italic) {
+        return files.z.fontpath();
+    }
+    if (bold) {
+        return files.b.fontpath();
+    }
+    if (italic) {
+        return files.i.fontpath();
+    }
+    return files.r.fontpath();
+}
+
+static Font &get_font_default(FontFace fontface, glui32 size_key)
 {
     auto &base = gfont_table.at(fontface);
 
@@ -885,9 +926,60 @@ static Font &get_font(FontFace fontface, glui32 size_key)
     return it->second;
 }
 
-static int gli_string_impl(int x, FontFace fontface, glui32 size_key, const glui32 *s, std::size_t n, int spw, const std::function<void(int, const std::array<Bitmap, GLI_SUBPIX> &)> &callback)
+static Font &get_font(FontFace fontface, glui32 size_key, std::optional<std::uint16_t> family_id)
 {
-    auto &f = get_font(fontface, size_key);
+    if (!family_id.has_value()) {
+        return get_font_default(fontface, size_key);
+    }
+
+    const CssFontFamily *family = gli_css_get_family(*family_id);
+    if (family == nullptr) {
+        return get_font_default(fontface, size_key);
+    }
+
+    CssFontKey key{*family_id, fontface.bold, fontface.italic, size_key};
+    auto it = css_font_table.find(key);
+    if (it != css_font_table.end()) {
+        return it->second;
+    }
+
+    // Prefer the style slot, then regular within the family, then the
+    // configured FontFace table.
+    std::array<const std::optional<std::string> *, 2> paths = {
+        &family_slot(family->files, fontface.bold, fontface.italic),
+        &family->files.r.fontpath(),
+    };
+
+    FontFace loadface = fontface;
+    loadface.monospace = family->monospace;
+
+    for (const auto *path : paths) {
+        if (path == nullptr || !path->has_value()) {
+            continue;
+        }
+
+        FT_Face face;
+        if (FT_New_Face(ftlib, (*path)->c_str(), 0, &face) != 0) {
+            continue;
+        }
+
+        try {
+            std::optional<double> size_override;
+            if (size_key != 0) {
+                size_override = size_key / 1000.0;
+            }
+            it = css_font_table.emplace(key, Font(loadface, UniqueFace(face), **path, size_override)).first;
+            return it->second;
+        } catch (const Font::LoadError &) {
+        }
+    }
+
+    return get_font_default(fontface, size_key);
+}
+
+static int gli_string_impl(int x, FontFace fontface, glui32 size_key, std::optional<std::uint16_t> family_id, const glui32 *s, std::size_t n, int spw, const std::function<void(int, const std::array<Bitmap, GLI_SUBPIX> &)> &callback)
+{
+    auto &f = get_font(fontface, size_key, family_id);
     bool dolig = !FT_IS_FIXED_WIDTH(f.face());
     int prev = -1;
     glui32 c;
@@ -924,11 +1016,32 @@ static int gli_string_impl(int x, FontFace fontface, glui32 size_key, const glui
         // that glyph is unavailable, log a warning and select a
         // question mark instead. If a question mark can't be loaded,
         // abort with an error message. Lookups are cached.
-        auto glyph = [&f, &fontface, size_key](glui32 c) -> const FontEntry & {
-            static std::unordered_map<glui32, std::unordered_map<std::pair<FontFace, glui32>, FontEntry>> size_caches;
+        auto glyph = [&f, &fontface, size_key, family_id](glui32 c) -> const FontEntry & {
+            struct GlyphKey {
+                FontFace face;
+                std::uint16_t family_id;
+                glui32 cid;
+
+                bool operator==(const GlyphKey &other) const {
+                    return face == other.face &&
+                           family_id == other.family_id &&
+                           cid == other.cid;
+                }
+            };
+
+            struct GlyphKeyHash {
+                std::size_t operator()(const GlyphKey &key) const {
+                    auto seed = hash_combine(0, std::hash<FontFace>()(key.face));
+                    seed = hash_combine(seed, std::hash<std::uint16_t>()(key.family_id));
+                    seed = hash_combine(seed, std::hash<glui32>()(key.cid));
+                    return seed;
+                }
+            };
+
+            static std::unordered_map<glui32, std::unordered_map<GlyphKey, FontEntry, GlyphKeyHash>> size_caches;
 
             auto &fallback_cache = size_caches[size_key];
-            auto key = std::pair(fontface, c);
+            GlyphKey key{fontface, family_id.value_or(0xffff), c};
 
             auto it = fallback_cache.find(key);
             if (it == fallback_cache.end()) {
@@ -980,9 +1093,17 @@ static int gli_string_impl(int x, FontFace fontface, glui32 size_key, const glui
 
 int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb,
                         const glui32 *text, int len, int spacewidth,
-                        std::optional<double> fontsize)
+                        std::optional<double> fontsize,
+                        std::optional<std::uint16_t> family_id)
 {
-    return gli_string_impl(x, face, font_size_key(face, fontsize), text, len, spacewidth, [&y, &rgb](int x, const std::array<Bitmap, GLI_SUBPIX> &glyphs) {
+    bool monospace = face.monospace;
+    if (family_id.has_value()) {
+        if (const CssFontFamily *family = gli_css_get_family(*family_id)) {
+            monospace = family->monospace;
+        }
+    }
+
+    return gli_string_impl(x, face, font_size_key(monospace, fontsize), family_id, text, len, spacewidth, [&y, &rgb](int x, const std::array<Bitmap, GLI_SUBPIX> &glyphs) {
         int px = x / GLI_SUBPIX;
         int sx = x % GLI_SUBPIX;
 
@@ -995,9 +1116,17 @@ int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb,
 }
 
 int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth,
-                         std::optional<double> fontsize)
+                         std::optional<double> fontsize,
+                         std::optional<std::uint16_t> family_id)
 {
-    return gli_string_impl(0, face, font_size_key(face, fontsize), text, len, spacewidth, [](int, const std::array<Bitmap, GLI_SUBPIX> &) {});
+    bool monospace = face.monospace;
+    if (family_id.has_value()) {
+        if (const CssFontFamily *family = gli_css_get_family(*family_id)) {
+            monospace = family->monospace;
+        }
+    }
+
+    return gli_string_impl(0, face, font_size_key(monospace, fontsize), family_id, text, len, spacewidth, [](int, const std::array<Bitmap, GLI_SUBPIX> &) {});
 }
 
 void gli_draw_caret(int x, int y)

--- a/garglk/font.h
+++ b/garglk/font.h
@@ -43,51 +43,52 @@ public:
         BoldItalic
     };
 
-    explicit FontFiller(FontType type) :
-        m_type(type)
-    {
-    }
+    FontFiller() = default;
 
     void add(Style style, std::optional<std::string> path) {
         m_fonts.insert({style, std::move(path)});
     }
 
-    bool fill() {
-        const auto &regular = m_fonts[Style::Regular];
-        if (!regular.has_value()) {
-            return false;
+    // Build FontFiles from collected style paths. Bold/italic/z fall
+    // back to regular when missing so FreeType can synthesize styles.
+    std::optional<FontFiles> files() const {
+        const auto &regular = m_fonts.find(Style::Regular);
+        if (regular == m_fonts.end() || !regular->second.has_value()) {
+            return std::nullopt;
         }
 
-        FontFiles &files = m_type == FontType::Monospace ? gli_conf_mono
-                                                         : gli_conf_prop;
+        FontFiles out;
+        out.r.base = *regular->second;
+        out.b.base = *regular->second;
+        out.i.base = *regular->second;
+        out.z.base = *regular->second;
 
-        files.r.base = *regular;
-        files.b.base = *regular;
-        files.i.base = *regular;
-        files.z.base = *regular;
-
-        const auto &bold = m_fonts[Style::Bold];
-        if (bold.has_value()) {
-            files.b.base = *bold;
-            files.z.base = *bold;
+        auto style_path = [this](Style style) -> const std::optional<std::string> * {
+            auto it = m_fonts.find(style);
+            if (it == m_fonts.end() || !it->second.has_value()) {
+                return nullptr;
+            }
+            return &it->second;
         };
 
-        const auto &italic = m_fonts[Style::Italic];
-        if (italic.has_value()) {
-            files.i.base = *italic;
-            files.z.base = *italic;
+        if (const auto *bold = style_path(Style::Bold)) {
+            out.b.base = **bold;
+            out.z.base = **bold;
         }
 
-        const auto &bolditalic = m_fonts[Style::BoldItalic];
-        if (bolditalic.has_value()) {
-            files.z.base = *bolditalic;
+        if (const auto *italic = style_path(Style::Italic)) {
+            out.i.base = **italic;
+            out.z.base = **italic;
         }
 
-        return true;
+        if (const auto *bolditalic = style_path(Style::BoldItalic)) {
+            out.z.base = **bolditalic;
+        }
+
+        return out;
     }
 
 private:
-    FontType m_type;
     std::unordered_map<Style, std::optional<std::string>> m_fonts;
 };
 

--- a/garglk/fontfc.cpp
+++ b/garglk/fontfc.cpp
@@ -80,10 +80,10 @@ static std::optional<std::string> find_font_by_styles(const std::string &basefon
     return std::nullopt;
 }
 
-bool garglk::fontreplace(const std::string &font, FontType type)
+std::optional<FontFiles> garglk::fontlookup(const std::string &font)
 {
     if (cfg == nullptr || font.empty()) {
-        return false;
+        return std::nullopt;
     }
 
     // Although there are 4 "main" types of font (Regular, Italic, Bold, Bold
@@ -134,10 +134,10 @@ bool garglk::fontreplace(const std::string &font, FontType type)
     // italic variations can be created out of a regular font, so it's
     // OK if those don't exist.
     if (!sysfont.has_value()) {
-        return false;
+        return std::nullopt;
     }
 
-    FontFiller filler(type);
+    FontFiller filler;
 
     filler.add(FontFiller::Style::Regular, sysfont);
 
@@ -150,7 +150,19 @@ bool garglk::fontreplace(const std::string &font, FontType type)
     sysfont = find_font_by_styles(font, bold_italic_styles, bold_weights, italic_slants);
     filler.add(FontFiller::Style::BoldItalic, sysfont);
 
-    return filler.fill();
+    return filler.files();
+}
+
+bool garglk::fontreplace(const std::string &font, FontType type)
+{
+    auto files = fontlookup(font);
+    if (!files.has_value()) {
+        return false;
+    }
+
+    FontFiles &dest = type == FontType::Monospace ? gli_conf_mono : gli_conf_prop;
+    dest = *files;
+    return true;
 }
 
 void fontload()

--- a/garglk/fontmac.mm
+++ b/garglk/fontmac.mm
@@ -19,6 +19,7 @@
 #import <Cocoa/Cocoa.h>
 
 #include <cstdlib>
+#include <optional>
 #include <string>
 
 #include "font.h"
@@ -28,10 +29,10 @@
 static NSMutableArray *gli_registered_fonts = nil;
 static NSDistributedLock *gli_font_lock = nil;
 
-bool garglk::fontreplace(const std::string &font, FontType type)
+std::optional<FontFiles> garglk::fontlookup(const std::string &font)
 {
     if (font.empty()) {
-        return false;
+        return std::nullopt;
     }
 
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -43,7 +44,7 @@ bool garglk::fontreplace(const std::string &font, FontType type)
     NSArray *fontMatches =
         [fontFamilyDescriptor matchingFontDescriptorsWithMandatoryKeys: nil];
 
-    FontFiller filler(type);
+    FontFiller filler;
 
     for (NSFontDescriptor *sysfont in fontMatches) {
         // find path for font
@@ -56,7 +57,6 @@ bool garglk::fontreplace(const std::string &font, FontType type)
 
         if (fontPathRef && CFStringGetLength(fontPathRef) > 0) {
             NSString *fontPath = (__bridge NSString *)fontPathRef;
-            NSLog(@"fontPath: %@", fontPath);
 
             std::string file = [fontPath UTF8String];
             auto traits = [sysfont symbolicTraits];
@@ -79,7 +79,19 @@ bool garglk::fontreplace(const std::string &font, FontType type)
 
     [pool drain];
 
-    return filler.fill();
+    return filler.files();
+}
+
+bool garglk::fontreplace(const std::string &font, FontType type)
+{
+    auto files = fontlookup(font);
+    if (!files.has_value()) {
+        return false;
+    }
+
+    FontFiles &dest = type == FontType::Monospace ? gli_conf_mono : gli_conf_prop;
+    dest = *files;
+    return true;
 }
 
 void fontload()

--- a/garglk/fontwin.cpp
+++ b/garglk/fontwin.cpp
@@ -22,6 +22,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <optional>
 #include <string>
 
 #include "format.h"
@@ -129,10 +130,10 @@ static bool find_font_file(const std::string &facename, std::string &filepath)
     return find_font_file_with_key(HKEY_LOCAL_MACHINE, FONT_SUBKEY, facename, filepath);
 }
 
-bool garglk::fontreplace(const std::string &font, FontType type)
+std::optional<FontFiles> garglk::fontlookup(const std::string &font)
 {
     if (font.empty()) {
-        return false;
+        return std::nullopt;
     }
 
     LOGFONTA logfont;
@@ -143,14 +144,26 @@ bool garglk::fontreplace(const std::string &font, FontType type)
 
     hdc = GetDC(0);
 
-    FontFiller filler(type);
+    FontFiller filler;
 
     std::snprintf(logfont.lfFaceName, LF_FACESIZE, "%s", font.c_str());
     EnumFontFamiliesExA(hdc, &logfont, reinterpret_cast<FONTENUMPROCA>(font_cb), reinterpret_cast<LPARAM>(&filler), 0);
 
     ReleaseDC(0, hdc);
 
-    return filler.fill();
+    return filler.files();
+}
+
+bool garglk::fontreplace(const std::string &font, FontType type)
+{
+    auto files = fontlookup(font);
+    if (!files.has_value()) {
+        return false;
+    }
+
+    FontFiles &dest = type == FontType::Monospace ? gli_conf_mono : gli_conf_prop;
+    dest = *files;
+    return true;
 }
 
 void fontload()

--- a/garglk/fontx11.cpp
+++ b/garglk/fontx11.cpp
@@ -527,7 +527,7 @@ garglk::XFontResult garglk::fontreplace_x11(const std::string &xlfd, FontType ty
 
     const auto &regular_weight = regular.fields[XLFD_WEIGHT];
 
-    FontFiller filler(type);
+    FontFiller filler;
 
     filler.add(FontFiller::Style::Regular, regular.path);
 
@@ -550,9 +550,13 @@ garglk::XFontResult garglk::fontreplace_x11(const std::string &xlfd, FontType ty
     filler.add(FontFiller::Style::Italic, styled(regular_weight, italic));
     filler.add(FontFiller::Style::BoldItalic, styled("bold", italic));
 
-    if (!filler.fill()) {
+    auto files = filler.files();
+    if (!files.has_value()) {
         return {XFontResult::Status::Unusable, ""};
     }
+
+    FontFiles &dest = type == FontType::Monospace ? gli_conf_mono : gli_conf_prop;
+    dest = *files;
 
     // Bitmap font size comes from the XLFD, not monosize or propsize.
     if (type == FontType::Monospace) {

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -563,19 +563,37 @@ struct picture_t {
     bool scaled;
 };
 
+// A set of CSS declarations, as used by the CSS Basic extension. Keys
+// are property names, lowercased; values are the property values as
+// provided by the game, with surrounding whitespace stripped.
+using CssProps = std::map<std::string, std::string>;
+
 struct style_t {
     FontFace font;
     Color bg;
     Color fg;
     bool reverse;
     glui32 justification = stylehint_just_LeftFlush;
+    std::optional<double> size;
+    bool underline = false;
+    double margin_left = 0;
+    double margin_right = 0;
+    double text_indent = 0;
+    // CSS_Paragraph background-color: content-box fill (not glyph-run bg).
+    std::optional<Color> para_bg;
 
     bool operator==(const style_t &other) const {
         return font == other.font &&
                bg == other.bg &&
                fg == other.fg &&
                reverse == other.reverse &&
-               justification == other.justification;
+               justification == other.justification &&
+               size == other.size &&
+               underline == other.underline &&
+               margin_left == other.margin_left &&
+               margin_right == other.margin_right &&
+               text_indent == other.text_indent &&
+               para_bg == other.para_bg &&
     }
 
     bool operator!=(const style_t &other) const {
@@ -849,18 +867,65 @@ struct attr_t {
     std::optional<Color> fgcolor;
     std::optional<Color> bgcolor;
 
+    // CSS Basic overrides; when unset, the value comes from the style.
+    std::optional<bool> bold;
+    std::optional<bool> italic;
+    std::optional<bool> monospace;
+    std::optional<bool> underline;
+    std::optional<double> size;
+    std::optional<glui32> justification;
+    // Paragraph geometry: when unset, the value comes from the style snapshot.
+    std::optional<float> margin_left;
+    std::optional<float> margin_right;
+    std::optional<float> text_indent;
+    // CSS_Paragraph background-color (content-box). Distinct from bgcolor,
+    // which paints glyph runs like a span background.
+    std::optional<Color> para_bgcolor;
+    // When true, fgcolor/bgcolor came from CSS and must be painted exactly
+    // (no Z-machine rgbshift when they match). fg_transparent draws with the
+    // effective background so glyphs are invisible.
+    bool css_paint = false;
+    bool fg_transparent = false;
+
+    bool operator==(const attr_t &other) const {
+        return reverse == other.reverse &&
+               style == other.style &&
+               hyper == other.hyper &&
+               fgcolor == other.fgcolor &&
+               bgcolor == other.bgcolor &&
+               bold == other.bold &&
+               italic == other.italic &&
+               monospace == other.monospace &&
+               underline == other.underline &&
+               size == other.size &&
+               justification == other.justification &&
+               margin_left == other.margin_left &&
+               margin_right == other.margin_right &&
+               text_indent == other.text_indent &&
+               para_bgcolor == other.para_bgcolor &&
+               css_paint == other.css_paint &&
+               fg_transparent == other.fg_transparent;
+    }
+
     bool operator!=(const attr_t &other) const {
-        return reverse != other.reverse ||
-               style != other.style ||
-               fgcolor != other.fgcolor ||
-               bgcolor != other.bgcolor ||
-               hyper != other.hyper;
+        return !(*this == other);
     }
 
     void set(glui32 style_);
     void clear();
+    // Reset only the CSS Basic overrides, leaving the style, hyperlink,
+    // and zcolors alone.
+    void clear_css();
     [[nodiscard]] FontFace font(const Styles &styles) const;
     [[nodiscard]] bool reversed(const Styles &styles) const;
+    [[nodiscard]] double fontsize(const Styles &styles) const;
+    [[nodiscard]] glui32 just(const Styles &styles) const;
+    [[nodiscard]] bool underlined(const Styles &styles) const;
+    [[nodiscard]] float marginl(const Styles &styles) const;
+    [[nodiscard]] float marginr(const Styles &styles) const;
+    [[nodiscard]] float indent(const Styles &styles) const;
+    // CSS_Paragraph content-box background, if any.
+    [[nodiscard]] std::optional<Color> parabg(const Styles &styles) const;
     [[nodiscard]] Color bg(const Styles &styles) const;
     [[nodiscard]] Color fg(const Styles &styles) const;
     [[nodiscard]] glui32 hyperlink() const;
@@ -926,6 +991,15 @@ struct glk_window_struct {
     attr_t attr;
     Color bgcolor = gli_window_color;
     Color fgcolor = gli_more_color;
+
+    // CSS Basic inline declarations (span and paragraph), plus the colors
+    // most recently applied from them, so that a refresh can tell a CSS-set
+    // color apart from one set by garglk_set_zcolors().
+    CssProps css_inline;
+    CssProps css_inline_para;
+    std::optional<Color> css_fgcolor;
+    std::optional<Color> css_bgcolor;
+    bool css_reverse = false;
 
     gidispatch_rock_t disprock;
     window_t *next, *prev; // in the big linked list of windows
@@ -1209,8 +1283,8 @@ void gli_initialize_fonts();
 void gli_draw_pixel(int x, int y, const Color &rgb);
 void gli_draw_clear(const Color &rgb);
 void gli_draw_rect(int x, int y, int w, int h, const Color &rgb);
-int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb, const glui32 *text, int len, int spacewidth);
-int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth);
+int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb, const glui32 *text, int len, int spacewidth, std::optional<double> fontsize = std::nullopt);
+int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth, std::optional<double> fontsize = std::nullopt);
 void gli_draw_caret(int x, int y);
 void gli_draw_picture(const picture_t *pic, int x0, int y0, int dx0, int dy0, int dx1, int dy1);
 
@@ -1254,6 +1328,24 @@ bool win_textbuffer_draw_picture(std::shared_ptr<picture_t> pic, window_textbuff
 void win_textbuffer_flow_break(window_textbuffer_t *win);
 
 void gli_read_config(int argc, char **argv);
+
+// CSS Basic (see cssbasic.cpp)
+
+// Apply a set of CSS declarations either to a style (is_style_level) or
+// to a set of text attributes. When is_paragraph is true, background-color
+// becomes a content-box fill (para_bg) rather than a glyph-run background.
+// base_size, if non-zero, is the font size (in points) that relative font
+// sizes are computed against.
+void gli_css_apply_props(attr_t &attr, style_t *style, const CssProps &props,
+        bool is_style_level, bool is_paragraph = false, double base_size = 0);
+// Reapply the window's CSS hints and inline declarations to its current
+// text attributes.
+void gli_css_refresh_window_attr(window_t *win);
+// Bake the CSS hints for a window type into a freshly created window's
+// copy of the style table.
+void gli_css_apply_hints_to_styles(Styles &styles, glui32 wintype);
+void gli_css_apply_window_hints(window_t *win);
+bool gli_css_active();
 
 // unicode case mapping
 

--- a/garglk/garglk.h
+++ b/garglk/garglk.h
@@ -93,6 +93,17 @@ struct FontFace {
     bool italic;
 };
 
+struct FontFiles {
+    struct {
+        std::optional<std::string> base;
+        std::optional<std::string> override;
+
+        const std::optional<std::string> &fontpath() const {
+            return override.has_value() ? override : base;
+        }
+    } r, b, i, z;
+};
+
 // Taken from Boost 1.81.0.
 // Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com).
 constexpr std::size_t hash_combine(std::size_t seed, std::size_t h) noexcept {
@@ -186,6 +197,9 @@ struct XFontResult {
 
 XFontResult fontreplace_x11(const std::string &xlfd, FontType type);
 bool x11_fonts_available();
+// Resolve an installed font family to Regular/Bold/Italic/BoldItalic
+// file paths without mutating the configured mono/prop fonts.
+std::optional<FontFiles> fontlookup(const std::string &font);
 std::vector<ConfigFile> configs(const std::optional<std::string> &gamepath);
 void config_entries(const std::string &fname, bool accept_bare, const std::vector<std::string> &matches, const std::function<void(const std::string &cmd, const std::string &arg, int lineno)> &callback);
 std::string user_config();
@@ -581,6 +595,8 @@ struct style_t {
     double text_indent = 0;
     // CSS_Paragraph background-color: content-box fill (not glyph-run bg).
     std::optional<Color> para_bg;
+    // CSS font-family resolved to an interned family table entry.
+    std::optional<std::uint16_t> family_id;
 
     bool operator==(const style_t &other) const {
         return font == other.font &&
@@ -594,6 +610,7 @@ struct style_t {
                margin_right == other.margin_right &&
                text_indent == other.text_indent &&
                para_bg == other.para_bg &&
+               family_id == other.family_id;
     }
 
     bool operator!=(const style_t &other) const {
@@ -697,17 +714,6 @@ extern int gli_scroll_width;
 
 extern int gli_baseline;
 extern int gli_leading;
-
-struct FontFiles {
-    struct {
-        std::optional<std::string> base;
-        std::optional<std::string> override;
-
-        const std::optional<std::string> &fontpath() const {
-            return override.has_value() ? override : base;
-        }
-    } r, b, i, z;
-};
 
 #define DEFAULT_MONO_FONT	"Gargoyle Mono"
 #define DEFAULT_PROP_FONT	"Gargoyle Serif"
@@ -874,6 +880,7 @@ struct attr_t {
     std::optional<bool> underline;
     std::optional<double> size;
     std::optional<glui32> justification;
+    std::optional<std::uint16_t> family_id;
     // Paragraph geometry: when unset, the value comes from the style snapshot.
     std::optional<float> margin_left;
     std::optional<float> margin_right;
@@ -899,6 +906,7 @@ struct attr_t {
                underline == other.underline &&
                size == other.size &&
                justification == other.justification &&
+               family_id == other.family_id &&
                margin_left == other.margin_left &&
                margin_right == other.margin_right &&
                text_indent == other.text_indent &&
@@ -918,6 +926,7 @@ struct attr_t {
     void clear_css();
     [[nodiscard]] FontFace font(const Styles &styles) const;
     [[nodiscard]] bool reversed(const Styles &styles) const;
+    [[nodiscard]] std::optional<std::uint16_t> family(const Styles &styles) const;
     [[nodiscard]] double fontsize(const Styles &styles) const;
     [[nodiscard]] glui32 just(const Styles &styles) const;
     [[nodiscard]] bool underlined(const Styles &styles) const;
@@ -1283,8 +1292,8 @@ void gli_initialize_fonts();
 void gli_draw_pixel(int x, int y, const Color &rgb);
 void gli_draw_clear(const Color &rgb);
 void gli_draw_rect(int x, int y, int w, int h, const Color &rgb);
-int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb, const glui32 *text, int len, int spacewidth, std::optional<double> fontsize = std::nullopt);
-int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth, std::optional<double> fontsize = std::nullopt);
+int gli_draw_string_uni(int x, int y, FontFace face, const Color &rgb, const glui32 *text, int len, int spacewidth, std::optional<double> fontsize = std::nullopt, std::optional<std::uint16_t> family_id = std::nullopt);
+int gli_string_width_uni(FontFace face, const glui32 *text, int len, int spacewidth, std::optional<double> fontsize = std::nullopt, std::optional<std::uint16_t> family_id = std::nullopt);
 void gli_draw_caret(int x, int y);
 void gli_draw_picture(const picture_t *pic, int x0, int y0, int dx0, int dy0, int dx1, int dy1);
 
@@ -1346,6 +1355,15 @@ void gli_css_refresh_window_attr(window_t *win);
 void gli_css_apply_hints_to_styles(Styles &styles, glui32 wintype);
 void gli_css_apply_window_hints(window_t *win);
 bool gli_css_active();
+
+// Interned CSS font-family: file paths for r/b/i/z plus whether the
+// family should use monospace metrics (aspect, dash/space rules).
+struct CssFontFamily {
+    FontFiles files;
+    bool monospace = false;
+};
+
+const CssFontFamily *gli_css_get_family(std::uint16_t id);
 
 // unicode case mapping
 

--- a/garglk/window.cpp
+++ b/garglk/window.cpp
@@ -1628,6 +1628,7 @@ void attr_t::clear_css()
     underline.reset();
     size.reset();
     justification.reset();
+    family_id.reset();
     margin_left.reset();
     margin_right.reset();
     text_indent.reset();
@@ -1651,6 +1652,15 @@ FontFace attr_t::font(const Styles &styles) const
     }
 
     return face;
+}
+
+std::optional<std::uint16_t> attr_t::family(const Styles &styles) const
+{
+    if (family_id.has_value()) {
+        return family_id;
+    }
+
+    return styles[style].family_id;
 }
 
 double attr_t::fontsize(const Styles &styles) const

--- a/garglk/window.cpp
+++ b/garglk/window.cpp
@@ -220,9 +220,13 @@ winid_t glk_window_open(winid_t splitwin,
             break;
         case wintype_TextGrid:
             newwin->window = std::make_unique<window_textgrid_t>(newwin.get());
+            gli_css_apply_hints_to_styles(newwin->wingrid()->styles, wintype_TextGrid);
+            gli_css_apply_window_hints(newwin.get());
             break;
         case wintype_TextBuffer:
             newwin->window = std::make_unique<window_textbuffer_t>(newwin.get());
+            gli_css_apply_hints_to_styles(newwin->winbuffer()->styles, wintype_TextBuffer);
+            gli_css_apply_window_hints(newwin.get());
             break;
         case wintype_Graphics:
             newwin->window = std::make_unique<window_graphics_t>(newwin.get());
@@ -1603,6 +1607,7 @@ void attr_t::set(glui32 style_)
     bgcolor.reset();
     reverse = false;
     style = style_;
+    clear_css();
 }
 
 void attr_t::clear()
@@ -1612,11 +1617,85 @@ void attr_t::clear()
     reverse = false;
     hyper = 0;
     style = 0;
+    clear_css();
+}
+
+void attr_t::clear_css()
+{
+    bold.reset();
+    italic.reset();
+    monospace.reset();
+    underline.reset();
+    size.reset();
+    justification.reset();
+    margin_left.reset();
+    margin_right.reset();
+    text_indent.reset();
+    para_bgcolor.reset();
+    css_paint = false;
+    fg_transparent = false;
 }
 
 FontFace attr_t::font(const Styles &styles) const
 {
-    return styles[style].font;
+    FontFace face = styles[style].font;
+
+    if (bold.has_value()) {
+        face.bold = *bold;
+    }
+    if (italic.has_value()) {
+        face.italic = *italic;
+    }
+    if (monospace.has_value()) {
+        face.monospace = *monospace;
+    }
+
+    return face;
+}
+
+double attr_t::fontsize(const Styles &styles) const
+{
+    if (size.has_value()) {
+        return *size;
+    }
+    if (styles[style].size.has_value()) {
+        return *styles[style].size;
+    }
+
+    return font(styles).monospace ? gli_conf_monosize : gli_conf_propsize;
+}
+
+glui32 attr_t::just(const Styles &styles) const
+{
+    return justification.value_or(styles[style].justification);
+}
+
+bool attr_t::underlined(const Styles &styles) const
+{
+    return underline.value_or(styles[style].underline);
+}
+
+float attr_t::marginl(const Styles &styles) const
+{
+    return margin_left.value_or(static_cast<float>(styles[style].margin_left));
+}
+
+float attr_t::marginr(const Styles &styles) const
+{
+    return margin_right.value_or(static_cast<float>(styles[style].margin_right));
+}
+
+float attr_t::indent(const Styles &styles) const
+{
+    return text_indent.value_or(static_cast<float>(styles[style].text_indent));
+}
+
+std::optional<Color> attr_t::parabg(const Styles &styles) const
+{
+    if (para_bgcolor.has_value()) {
+        return para_bgcolor;
+    }
+    return styles[style].para_bg;
 }
 
 static Color zcolor_LightGrey = Color(181, 181, 181);
@@ -1659,11 +1738,21 @@ Color attr_t::bg(const Styles &styles) const
                         gli_override_bg.has_value() ? gli_override_bg :
                         std::nullopt;
 
+    auto pbg = parabg(styles);
+
     if (!revset) {
+        // With a paragraph content-box fill and no span bgcolor, glyph-run
+        // backgrounds must match the box so they do not paint over it.
+        if (pbg.has_value() && !bgcolor.has_value() && !gli_override_bg.has_value()) {
+            return *pbg;
+        }
         return zcolor_Background.value_or(styles[style].bg);
+    } else if (pbg.has_value()) {
+        // Reverse + para: content box becomes the original foreground.
+        return zcolor_Foreground.value_or(styles[style].fg);
     } else {
         if (zcolor_Foreground.has_value()) {
-            if (zcolor_Foreground == zcolor_Background) {
+            if (zcolor_Foreground == zcolor_Background && !css_paint) {
                 return rgbshift(*zcolor_Foreground);
             } else {
                 return *zcolor_Foreground;
@@ -1690,9 +1779,19 @@ Color attr_t::fg(const Styles &styles) const
                         gli_override_bg.has_value() ? gli_override_bg :
                         std::nullopt;
 
+    auto pbg = parabg(styles);
+
+    // CSS color:transparent — paint with the effective background.
+    if (fg_transparent && !revset) {
+        if (pbg.has_value()) {
+            return *pbg;
+        }
+        return zcolor_Background.value_or(styles[style].bg);
+    }
+
     if (!revset) {
         if (zcolor_Foreground.has_value()) {
-            if (zcolor_Foreground == zcolor_Background) {
+            if (zcolor_Foreground == zcolor_Background && !css_paint) {
                 return rgbshift(*zcolor_Foreground);
             } else {
                 return *zcolor_Foreground;
@@ -1704,6 +1803,10 @@ Color attr_t::fg(const Styles &styles) const
                 return styles[style].fg;
             }
         }
+    } else if (pbg.has_value()) {
+        // Reverse with CSS_Paragraph background: text takes the para color
+        // (Spatterlight swaps GlkParaBackground with the foreground).
+        return *pbg;
     } else {
         return zcolor_Background.value_or(styles[style].bg);
     }

--- a/garglk/wingrid.cpp
+++ b/garglk/wingrid.cpp
@@ -83,6 +83,7 @@ void win_textgrid_redraw(window_t *win) {
     auto draw_run = [&dwin, win](const tgline_t *ln, int start, int end, int x, int y) -> int {
         glui32 link    = ln->attrs[start].hyperlink();
         auto   font    = ln->attrs[start].font(dwin->styles);
+        auto   size    = ln->attrs[start].fontsize(dwin->styles);
         Color  fgcolor = link != 0 ? gli_link_color
                                    : ln->attrs[start].fg(dwin->styles);
         Color  bgcolor = ln->attrs[start].bg(dwin->styles);
@@ -98,10 +99,12 @@ void win_textgrid_redraw(window_t *win) {
                 gli_draw_rect(x, y + gli_baseline + 1, w, 1, gli_link_color);
             }
             gli_put_hyperlink(link, x, y, x + w, y + gli_leading);
+        } else if (ln->attrs[start].underlined(dwin->styles)) {
+            gli_draw_rect(x, y + gli_baseline + 1, w, 1, fgcolor);
         }
 
         for (int i = start; i < end; i++) {
-            gli_draw_string_uni(x * GLI_SUBPIX, y + gli_baseline, font, fgcolor, &ln->chars[i], 1, -1);
+            gli_draw_string_uni(x * GLI_SUBPIX, y + gli_baseline, font, fgcolor, &ln->chars[i], 1, -1, size);
             x += gli_cellw;
         }
 

--- a/garglk/wingrid.cpp
+++ b/garglk/wingrid.cpp
@@ -84,6 +84,7 @@ void win_textgrid_redraw(window_t *win) {
         glui32 link    = ln->attrs[start].hyperlink();
         auto   font    = ln->attrs[start].font(dwin->styles);
         auto   size    = ln->attrs[start].fontsize(dwin->styles);
+        auto   family  = ln->attrs[start].family(dwin->styles);
         Color  fgcolor = link != 0 ? gli_link_color
                                    : ln->attrs[start].fg(dwin->styles);
         Color  bgcolor = ln->attrs[start].bg(dwin->styles);
@@ -104,7 +105,7 @@ void win_textgrid_redraw(window_t *win) {
         }
 
         for (int i = start; i < end; i++) {
-            gli_draw_string_uni(x * GLI_SUBPIX, y + gli_baseline, font, fgcolor, &ln->chars[i], 1, -1, size);
+            gli_draw_string_uni(x * GLI_SUBPIX, y + gli_baseline, font, fgcolor, &ln->chars[i], 1, -1, size, family);
             x += gli_cellw;
         }
 

--- a/garglk/wintext.cpp
+++ b/garglk/wintext.cpp
@@ -344,13 +344,15 @@ static int calcwidth(window_textbuffer_t *dwin,
     for (b = startchar; b < numchars; b++) {
         if (attrs[a] != attrs[b]) {
             w += gli_string_width_uni(attrs[a].font(dwin->styles),
-                    chars + a, b - a, spw, attrs[a].fontsize(dwin->styles));
+                    chars + a, b - a, spw, attrs[a].fontsize(dwin->styles),
+                    attrs[a].family(dwin->styles));
             a = b;
         }
     }
 
     w += gli_string_width_uni(attrs[a].font(dwin->styles),
-            chars + a, b - a, spw, attrs[a].fontsize(dwin->styles));
+            chars + a, b - a, spw, attrs[a].fontsize(dwin->styles),
+            attrs[a].family(dwin->styles));
 
     return w;
 }
@@ -767,7 +769,8 @@ void win_textbuffer_redraw(window_t *win)
             if (ln.attrs[a] != ln.attrs[b]) {
                 auto font = ln.attrs[a].font(dwin->styles);
                 w = gli_string_width_uni(font, &ln.chars[a], b - a, spw,
-                        ln.attrs[a].fontsize(dwin->styles));
+                        ln.attrs[a].fontsize(dwin->styles),
+                        ln.attrs[a].family(dwin->styles));
                 draw_run_background(ln, a, x, w);
                 x += w;
                 a = b;
@@ -775,7 +778,8 @@ void win_textbuffer_redraw(window_t *win)
         }
         auto font = ln.attrs[a].font(dwin->styles);
         w = gli_string_width_uni(font, &ln.chars[a], b - a, spw,
-                ln.attrs[a].fontsize(dwin->styles));
+                ln.attrs[a].fontsize(dwin->styles),
+                ln.attrs[a].family(dwin->styles));
         draw_run_background(ln, a, x, w);
         x += w;
 
@@ -813,7 +817,8 @@ void win_textbuffer_redraw(window_t *win)
                 color = link != 0 ? gli_link_color : ln.attrs[a].fg(dwin->styles);
                 x = gli_draw_string_uni(x, y + gli_baseline,
                         font, color, &ln.chars[a], b - a, spw,
-                        ln.attrs[a].fontsize(dwin->styles));
+                        ln.attrs[a].fontsize(dwin->styles),
+                        ln.attrs[a].family(dwin->styles));
                 a = b;
             }
         }
@@ -822,7 +827,8 @@ void win_textbuffer_redraw(window_t *win)
         color = link != 0 ? gli_link_color : ln.attrs[a].fg(dwin->styles);
         gli_draw_string_uni(x, y + gli_baseline,
                 font, color, &ln.chars[a], linelen - a, spw,
-                ln.attrs[a].fontsize(dwin->styles));
+                ln.attrs[a].fontsize(dwin->styles),
+                ln.attrs[a].family(dwin->styles));
     }
 
     //

--- a/garglk/wintext.cpp
+++ b/garglk/wintext.cpp
@@ -121,7 +121,11 @@ static void reflow(window_t *win)
     int i, k, p, s;
     int x, f;
 
-    if (dwin->height < 4 || dwin->width < 20) {
+    // Skip only when there is no usable text area. Do not require height >= 4:
+    // nested proportional splits often leave short-but-wide panes (e.g. 25x3)
+    // that still need reflow after a width change, or mid-word wraps from a
+    // prior narrow layout stick forever.
+    if (dwin->width < 1 || dwin->height < 1) {
         return;
     }
 
@@ -274,10 +278,18 @@ void win_textbuffer_rearrange(window_t *win, rect_t *box)
     // changes leaves the layout stale for up to a cell's worth of pixels,
     // and win_textbuffer_redraw then truncates the overhanging characters
     // instead of wrapping them.
-    if (newwid != dwin->width || newpixwid != dwin->pixel_width) {
+    //
+    // Do not commit a new width while height < 1: reflow() cannot run yet, and
+    // updating width here would prevent a later height-only rearrange from
+    // noticing the change and reflowing.
+    bool need_reflow = (newwid != dwin->width || newpixwid != dwin->pixel_width);
+    bool did_reflow = false;
+    if (need_reflow && newhgt >= 1) {
         dwin->width = newwid;
         dwin->pixel_width = newpixwid;
         reflow(win);
+        need_reflow = false;
+        did_reflow = true;
     }
 
     if (newhgt != dwin->height) {
@@ -287,6 +299,13 @@ void win_textbuffer_rearrange(window_t *win, rect_t *box)
         }
 
         dwin->height = newhgt;
+
+        if (need_reflow && dwin->height >= 1) {
+            dwin->width = newwid;
+            dwin->pixel_width = newpixwid;
+            reflow(win);
+            did_reflow = true;
+        }
 
         // keep window within 'valid' lines
         if (dwin->scrollpos > dwin->scrollmax - dwin->height + 1) {
@@ -298,6 +317,19 @@ void win_textbuffer_rearrange(window_t *win, rect_t *box)
         touchscroll(dwin);
 
         dwin->copybuf.clear();
+    } else if (need_reflow && dwin->height >= 1) {
+        dwin->width = newwid;
+        dwin->pixel_width = newpixwid;
+        reflow(win);
+        did_reflow = true;
+    }
+
+    // After reflow, height is final. For panes that are not taking line input,
+    // keep the start of the buffer in view so titles printed first remain
+    // visible in short nested windows (csstest win_span_*).
+    if (did_reflow && !win->line_request && !win->line_request_uni
+            && dwin->height > 0 && dwin->scrollmax >= dwin->height) {
+        dwin->scrollpos = dwin->scrollmax - dwin->height + 1;
     }
 }
 
@@ -312,13 +344,13 @@ static int calcwidth(window_textbuffer_t *dwin,
     for (b = startchar; b < numchars; b++) {
         if (attrs[a] != attrs[b]) {
             w += gli_string_width_uni(attrs[a].font(dwin->styles),
-                    chars + a, b - a, spw);
+                    chars + a, b - a, spw, attrs[a].fontsize(dwin->styles));
             a = b;
         }
     }
 
     w += gli_string_width_uni(attrs[a].font(dwin->styles),
-            chars + a, b - a, spw);
+            chars + a, b - a, spw, attrs[a].fontsize(dwin->styles));
 
     return w;
 }
@@ -330,23 +362,45 @@ static int calcwidth(window_textbuffer_t *dwin,
     return calcwidth(dwin, chars.data(), attrs.data(), startchar, numchars, spw);
 }
 
+// Left and right CSS margins for a line, in subpixels.
+static void line_margins(window_textbuffer_t *dwin, const tbline_t &ln,
+    int linelen, int &left, int &right)
+{
+    left = 0;
+    right = 0;
+
+    if (linelen <= 0) {
+        return;
+    }
+
+    const attr_t &attr = ln.attrs[0];
+    float ml = attr.marginl(dwin->styles);
+    float mr = attr.marginr(dwin->styles);
+    float ti = attr.indent(dwin->styles);
+    left = (ml + ti) * GLI_SUBPIX;
+    right = mr * GLI_SUBPIX;
+}
+
 // Horizontal origin for a line's text, honoring Justification stylehints.
 static int line_text_x0(window_textbuffer_t *dwin, const tbline_t &ln,
     int linelen, int x0, int x1, int spw)
 {
-    int text_x0 = x0 + SLOP + ln.lm;
+    int marginl, marginr;
+    line_margins(dwin, ln, linelen, marginl, marginr);
+
+    int text_x0 = x0 + SLOP + ln.lm + marginl;
 
     if (linelen <= 0) {
         return text_x0;
     }
 
-    glui32 just = dwin->styles[ln.attrs[0].style].justification;
+    glui32 just = ln.attrs[0].just(dwin->styles);
     if (just != stylehint_just_Centered && just != stylehint_just_RightFlush) {
         return text_x0;
     }
 
     int textw = calcwidth(dwin, ln.chars, ln.attrs, 0, linelen, spw);
-    int avail = x1 - x0 - ln.lm - ln.rm - 2 * SLOP;
+    int avail = x1 - x0 - ln.lm - ln.rm - marginl - marginr - 2 * SLOP;
     if (textw >= avail) {
         return text_x0;
     }
@@ -528,7 +582,7 @@ void win_textbuffer_redraw(window_t *win)
 
         // count spaces and width for full (left-right) justification
         glui32 line_just = linelen > 0
-            ? dwin->styles[ln.attrs[0].style].justification
+            ? ln.attrs[0].just(dwin->styles)
             : stylehint_just_LeftFlush;
         bool full_justify = (gli_conf_justify || line_just == stylehint_just_LeftRight)
             && line_just != stylehint_just_Centered
@@ -541,8 +595,10 @@ void win_textbuffer_redraw(window_t *win)
                 }
             }
             w = calcwidth(dwin, ln.chars, ln.attrs, 0, linelen, 0);
+            int marginl, marginr;
+            line_margins(dwin, ln, linelen, marginl, marginr);
             if (nsp != 0) {
-                spw = (x1 - x0 - ln.lm - ln.rm - 2 * SLOP - w) / nsp;
+                spw = (x1 - x0 - ln.lm - ln.rm - marginl - marginr - 2 * SLOP - w) / nsp;
             } else {
                 spw = 0;
             }
@@ -629,71 +685,108 @@ void win_textbuffer_redraw(window_t *win)
         gli_put_hyperlink(0, x0 / GLI_SUBPIX, y,
                 x1 / GLI_SUBPIX, y + gli_leading);
 
+        // Content-box (CSS_Paragraph background-color): full width inside
+        // margins, independent of glyph extent — matching Spatterlight.
+        int box_x0 = x0 + SLOP + ln.lm;
+        int box_x1 = x1 - ln.rm - SLOP;
+        std::optional<Color> para_box_color;
+        if (linelen > 0) {
+            auto pbg = ln.attrs[0].parabg(dwin->styles);
+            if (pbg.has_value()) {
+                float ml = ln.attrs[0].marginl(dwin->styles);
+                float mr = ln.attrs[0].marginr(dwin->styles);
+                // Like Spatterlight: fill uses margin-left/right only (not
+                // text-indent).
+                box_x0 += static_cast<int>(ml * GLI_SUBPIX);
+                box_x1 -= static_cast<int>(mr * GLI_SUBPIX);
+                para_box_color = ln.attrs[0].bg(dwin->styles);
+            }
+        }
+        bool has_para_bg = para_box_color.has_value();
+
         // Derive widths from pixel endpoints so adjacent runs tile exactly.
         // Transparent overlays fill only reverse-video runs below.
+        Color win_bg = gli_override_bg.has_value() ? gli_window_color : win->bgcolor;
         if (!win->is_transparent()) {
-            color = gli_override_bg.has_value() ? gli_window_color : win->bgcolor;
             gli_draw_rect(x0 / GLI_SUBPIX, y,
                     (x1 - x0) / GLI_SUBPIX, gli_leading,
-                    color);
+                    win_bg);
         }
+
+        if (has_para_bg && box_x1 > box_x0) {
+            gli_draw_rect(box_x0 / GLI_SUBPIX, y,
+                    (box_x1 - box_x0) / GLI_SUBPIX, gli_leading,
+                    *para_box_color);
+        }
+
+        // Paint the background of a run of identically-styled
+        // characters, along with its hyperlink and CSS underlines.
+        // Transparent overlays fill only reverse-video runs.
+        auto draw_run_background = [dwin, win, y, has_para_bg, win_bg](const tbline_t &ln, int a, int x, int w) {
+            glui32 link = ln.attrs[a].hyperlink();
+            Color color = ln.attrs[a].bg(dwin->styles);
+            int rx0 = x / GLI_SUBPIX;
+            int rx1 = (x + w) / GLI_SUBPIX;
+
+            // Paragraph content-box already filled the line; only paint a
+            // glyph-run background when this run has an explicit span color
+            // or reverse without relying solely on the para fill.
+            bool paint_run = !has_para_bg
+                || ln.attrs[a].bgcolor.has_value()
+                || (ln.attrs[a].reversed(dwin->styles) && !ln.attrs[a].parabg(dwin->styles).has_value());
+
+            // Window-level CSS background-color already cleared the line.
+            // Do not paint opaque style.bg (often white) over it — matches
+            // Spatterlight, where the text view background shows through.
+            if (paint_run && color == win_bg && !ln.attrs[a].reversed(dwin->styles)
+                    && !ln.attrs[a].bgcolor.has_value()) {
+                paint_run = false;
+            }
+
+            if (paint_run && (!win->is_transparent() || ln.attrs[a].reversed(dwin->styles))) {
+                gli_draw_rect(rx0, y, rx1 - rx0, gli_leading, color);
+            }
+
+            if (link != 0) {
+                if (gli_underline_hyperlinks) {
+                    gli_draw_rect(rx0 + 1, y + gli_baseline + 1,
+                            rx1 - rx0 + 1, 1,
+                            gli_link_color);
+                }
+                gli_put_hyperlink(link, rx0, y, rx1, y + gli_leading);
+            } else if (ln.attrs[a].underlined(dwin->styles)) {
+                gli_draw_rect(rx0, y + gli_baseline + 1,
+                        rx1 - rx0, 1,
+                        ln.attrs[a].fg(dwin->styles));
+            }
+        };
 
         x = text_x0;
         a = first;
         for (b = first; b < linelen; b++) {
             if (ln.attrs[a] != ln.attrs[b]) {
-                link = ln.attrs[a].hyperlink();
                 auto font = ln.attrs[a].font(dwin->styles);
-                color = ln.attrs[a].bg(dwin->styles);
-                w = gli_string_width_uni(font, &ln.chars[a], b - a, spw);
-                int rx0 = x / GLI_SUBPIX;
-                int rx1 = (x + w) / GLI_SUBPIX;
-                if (!win->is_transparent() || ln.attrs[a].reversed(dwin->styles)) {
-                    gli_draw_rect(rx0, y,
-                            rx1 - rx0, gli_leading,
-                            color);
-                }
-                if (link != 0) {
-                    if (gli_underline_hyperlinks) {
-                        gli_draw_rect(rx0 + 1, y + gli_baseline + 1,
-                                rx1 - rx0 + 1, 1,
-                                gli_link_color);
-                    }
-                    gli_put_hyperlink(link, rx0, y,
-                            rx1,
-                            y + gli_leading);
-                }
+                w = gli_string_width_uni(font, &ln.chars[a], b - a, spw,
+                        ln.attrs[a].fontsize(dwin->styles));
+                draw_run_background(ln, a, x, w);
                 x += w;
                 a = b;
             }
         }
-        link = ln.attrs[a].hyperlink();
         auto font = ln.attrs[a].font(dwin->styles);
-        color = ln.attrs[a].bg(dwin->styles);
-        w = gli_string_width_uni(font, &ln.chars[a], b - a, spw);
-        int rx0 = x / GLI_SUBPIX;
-        int rx1 = (x + w) / GLI_SUBPIX;
-        if (!win->is_transparent() || ln.attrs[a].reversed(dwin->styles)) {
-            gli_draw_rect(rx0, y, rx1 - rx0,
-                    gli_leading, color);
-        }
-        if (link != 0) {
-            if (gli_underline_hyperlinks) {
-                gli_draw_rect(rx0 + 1, y + gli_baseline + 1,
-                        rx1 - rx0 + 1, 1,
-                        gli_link_color);
-            }
-            gli_put_hyperlink(link, rx0, y,
-                    rx1,
-                    y + gli_leading);
-        }
+        w = gli_string_width_uni(font, &ln.chars[a], b - a, spw,
+                ln.attrs[a].fontsize(dwin->styles));
+        draw_run_background(ln, a, x, w);
         x += w;
 
         if (!win->is_transparent()) {
-            color = gli_override_bg.has_value() ? gli_window_color : win->bgcolor;
-            gli_draw_rect(x / GLI_SUBPIX, y,
-                    x1 / GLI_SUBPIX - x / GLI_SUBPIX, gli_leading,
-                    color);
+            // Do not wipe the paragraph content-box with the window color.
+            int wipe_from = has_para_bg ? std::max(x, box_x1) : x;
+            if (wipe_from < x1) {
+                gli_draw_rect(wipe_from / GLI_SUBPIX, y,
+                        x1 / GLI_SUBPIX - wipe_from / GLI_SUBPIX, gli_leading,
+                        win_bg);
+            }
         }
 
         //
@@ -719,7 +812,8 @@ void win_textbuffer_redraw(window_t *win)
                 font = ln.attrs[a].font(dwin->styles);
                 color = link != 0 ? gli_link_color : ln.attrs[a].fg(dwin->styles);
                 x = gli_draw_string_uni(x, y + gli_baseline,
-                        font, color, &ln.chars[a], b - a, spw);
+                        font, color, &ln.chars[a], b - a, spw,
+                        ln.attrs[a].fontsize(dwin->styles));
                 a = b;
             }
         }
@@ -727,7 +821,8 @@ void win_textbuffer_redraw(window_t *win)
         font = ln.attrs[a].font(dwin->styles);
         color = link != 0 ? gli_link_color : ln.attrs[a].fg(dwin->styles);
         gli_draw_string_uni(x, y + gli_baseline,
-                font, color, &ln.chars[a], linelen - a, spw);
+                font, color, &ln.chars[a], linelen - a, spw,
+                ln.attrs[a].fontsize(dwin->styles));
     }
 
     //
@@ -1167,6 +1262,8 @@ void win_textbuffer_putchar_uni(window_t *win, glui32 ch)
 
     pw = (win->bbox.x1 - win->bbox.x0 - gli_tmarginx * 2 - scroll_width(win)) * GLI_SUBPIX;
     pw = pw - 2 * SLOP - dwin->radjw - dwin->ladjw;
+    pw -= (win->attr.marginl(dwin->styles) + win->attr.marginr(dwin->styles) +
+            win->attr.indent(dwin->styles)) * GLI_SUBPIX;
 
     Color color = gli_override_bg.has_value() ? gli_window_color : win->bgcolor;
 
@@ -1209,7 +1306,7 @@ void win_textbuffer_putchar_uni(window_t *win, glui32 ch)
     // the font file itself is actually monospace: if the font is monor,
     // monob, monoi, or monoz, then this will be true, regardless of
     // what font the user actually set as the monospace font.
-    bool monospace = gli_tstyles[win->attr.style].font.monospace;
+    bool monospace = win->attr.font(dwin->styles).monospace;
 
     if (gli_conf_dashes != 0 && !monospace) {
         if (ch == '-') {


### PR DESCRIPTION
Reimplemented based on PR https://github.com/angstsmurf/spatterlight/pull/135

https://curiousdannii.github.io/if/glk-proposals.html#css

Test with https://github.com/dfabulich/glk-css-test and with #1036 

There's also a separate commit to add support for `font-family`; it's quite a bit of code in its own right.

<img width="1259" height="1396" alt="Screenshot 2026-09-13 at 2 10 12 AM" src="https://github.com/user-attachments/assets/550229ae-746d-4d05-84da-5a248623b777" />

